### PR TITLE
Rework processes-plugin

### DIFF
--- a/application/client.plugins/projects/processes/src/lib/views/sidebar.vertical/component.ts
+++ b/application/client.plugins/projects/processes/src/lib/views/sidebar.vertical/component.ts
@@ -98,6 +98,7 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
             stream: this.session,
             command: EHostCommands.command,
             cmd: this._ng_cmd,
+            shell: this._ng_settings.shell,
         }, this.session).catch((error: Error) => {
             console.error(error);
         });

--- a/application/sandbox/processes/process/package.json
+++ b/application/sandbox/processes/process/package.json
@@ -10,6 +10,9 @@
     "test:unit": "./node_modules/.bin/jasmine-ts"
   },
   "author": "Dmitry Astafyev (dmitry.astafyev@esrlabs.com)",
+  "contributors": [
+    "Andreas Knipl (andreas.knipl@esrlabs.com)"
+  ],
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^10.12.21",

--- a/application/sandbox/processes/process/src/process.env.ts
+++ b/application/sandbox/processes/process/src/process.env.ts
@@ -67,6 +67,43 @@ export function getOSEnvVars(): Promise<TEnvVars> {
     });
 }
 
+export function defaultShell(): Promise<string> {
+    return new Promise((resolve) => {
+        let shellPath: string | undefined = '';
+        let command: string = '';
+
+        switch (OS.platform()) {
+            case EPlatforms.aix:
+            case EPlatforms.android:
+            case EPlatforms.darwin:
+            case EPlatforms.freebsd:
+            case EPlatforms.linux:
+            case EPlatforms.openbsd:
+            case EPlatforms.sunos:
+                shellPath = process.env.SHELL;
+                command = 'echo $SHELL';
+                break;
+            case EPlatforms.win32:
+                shellPath = process.env.COMSPEC;
+                command = 'ECHO %COMSPEC%';
+                break;
+        }
+
+        if (shellPath) {
+            return resolve(shellPath);
+        }
+
+        // process didn't resolve shell, so we query it manually
+        shell(command).then((stdout: string) => {
+            resolve(stdout.trim());
+        }).catch((error: Error) => {
+            // COMSPEC should always be available on windows.
+            // Therefore: we will try to use /bin/sh as error-mitigation
+            resolve("/bin/sh");
+        });
+    });
+}
+
 export function shells(): Promise<string[]> {
     return new Promise((resolve) => {
         let command: string = '';

--- a/application/sandbox/processes/process/src/process.env.ts
+++ b/application/sandbox/processes/process/src/process.env.ts
@@ -32,23 +32,12 @@ export type TEnvVars = { [key: string]: string };
 
 export function getOSEnvVars(): Promise<TEnvVars> {
     return new Promise((resolve) => {
-        let command: string = '';
-        switch (OS.platform()) {
-            case EPlatforms.aix:
-            case EPlatforms.android:
-            case EPlatforms.darwin:
-            case EPlatforms.freebsd:
-            case EPlatforms.linux:
-            case EPlatforms.openbsd:
-            case EPlatforms.sunos:
-                command = 'printenv';
-                break;
-            case EPlatforms.win32:
-                // TODO: Find solution for win
-                command = 'printenv';
-                break;
+        if (OS.platform() !== EPlatforms.darwin) {
+            return resolve(Object.assign({}, process.env) as TEnvVars);
         }
-        shell(command).then((stdout: string) => {
+
+        // GUI-Apps don't inherit all environment-variables on darwin
+        shell('printenv').then((stdout: string) => {
             const pairs: TEnvVars = {};
             stdout.split(/[\n\r]/gi).forEach((row: string) => {
                 const pair: string[] = row.split('=');

--- a/application/sandbox/processes/process/src/process.env.ts
+++ b/application/sandbox/processes/process/src/process.env.ts
@@ -125,3 +125,7 @@ export function shells(): Promise<string[]> {
 export function getExecutedModulePath(): string {
     return Path.normalize(`${Path.dirname(require.main === void 0 ? __dirname : require.main.filename)}`);
 }
+
+export function getHomePath(): string {
+    return Path.normalize(`${OS.homedir()}`);
+}

--- a/application/sandbox/processes/process/src/service.streams.ts
+++ b/application/sandbox/processes/process/src/service.streams.ts
@@ -107,10 +107,10 @@ class StreamsService extends EventEmitter {
         }
         EnvModule.getOSEnvVars().then((env: EnvModule.TEnvVars) => {
             //Apply default terminal color scheme
-            this._createStream(streamId, EnvModule.getExecutedModulePath(), this._getInitialOSEnv(env));
+            this._createStream(streamId, EnvModule.getHomePath(), this._getInitialOSEnv(env));
         }).catch((error: Error) => {
-            this._logger.warn(`Fail to get OS env vars  for stream ${streamId} due error: ${error.message}. Will be used default node values.`);
-            this._createStream(streamId, EnvModule.getExecutedModulePath(), this._getInitialOSEnv(Object.assign({}, process.env) as EnvModule.TEnvVars));
+            this._logger.warn(`Failed to get OS env vars for stream ${streamId} due to error: ${error.message}. Default node-values will be used .`);
+            this._createStream(streamId, EnvModule.getHomePath(), this._getInitialOSEnv(Object.assign({}, process.env) as EnvModule.TEnvVars));
         });
     }
 

--- a/application/sandbox/processes/process/src/service.streams.ts
+++ b/application/sandbox/processes/process/src/service.streams.ts
@@ -129,17 +129,21 @@ class StreamsService extends EventEmitter {
     }
 
     private _createStream(streamId: string, cwd: string, env: EnvModule.TEnvVars) {
-        this._streams.set(streamId, {
-            fork: undefined,
-            streamId: streamId,
-            settings: {
-                cwd: cwd,
-                shell: true,
-                env: env
-            }
+        EnvModule.defaultShell().then((userShell: string) => {
+            this._streams.set(streamId, {
+                fork: undefined,
+                streamId: streamId,
+                settings: {
+                    cwd: cwd,
+                    shell: userShell,
+                    env: env
+                }
+            });
+            this.emit(this.Events.onStreamOpened, streamId);
+            this._logger.env(`Stream "${streamId}" is bound with cwd "${cwd}".`)
+        }).catch((gettingShellErr: Error) => {
+            this._logger.env(`Failed to create stream "${streamId}" due to error: ${gettingShellErr.message}.`)
         });
-        this.emit(this.Events.onStreamOpened, streamId);
-        this._logger.env(`Stream "${streamId}" is bound with cwd "${cwd}".`)
     }
 }
 


### PR DESCRIPTION
The processes-plugin will now first search for the default shell to execute and then correctly detect the environment-variables for the current user.
The home-directory will now be used as starting position.