### PR TITLE
Manage recently connected ports

### DIFF
--- a/application/client.plugins/projects/serial/src/lib/common/host.events.ts
+++ b/application/client.plugins/projects/serial/src/lib/common/host.events.ts
@@ -10,7 +10,10 @@ export enum EHostCommands {
     open = 'open',
     close = 'close',
     list = 'list',
-    write = 'write',
+    send = 'send',
     spyStart = 'spyStart',
-    spyStop = 'spyStop'
+    spyStop = 'spyStop',
+    write = 'write',
+    read = 'read',
+    remove = 'remove'
 }

--- a/application/client.plugins/projects/serial/src/lib/services/service.ts
+++ b/application/client.plugins/projects/serial/src/lib/services/service.ts
@@ -32,7 +32,7 @@ export class Service extends Toolkit.APluginService {
     private _onAPIReady() {
         this.api = this.getAPI();
         if (this.api === undefined) {
-            this._logger.error('API not found!');
+            this._notify('error', 'API not found', ENotificationType.error);
             return;
         }
         this._subscriptions.onSessionOpen = this.api.getSessionsEventsHub().subscribe().onSessionOpen(this._onSessionOpen.bind(this));
@@ -58,6 +58,17 @@ export class Service extends Toolkit.APluginService {
 
     private _onSessionChange(guid: string) {
         this.session = guid;
+    }
+
+    private _notify(caption: string, message: string, type: ENotificationType) {
+        this.notify(caption, message, type);
+        if (type === ENotificationType.error) {
+            this._logger.error(message);
+        } else if (type === ENotificationType.warning) {
+            this._logger.warn(message);
+        } else {
+            this._logger.info(message);
+        }
     }
 
     public getObservable(): {
@@ -88,7 +99,7 @@ export class Service extends Toolkit.APluginService {
                     this.state = response;
                     this._subjects.event.next(message);
                 }).catch((error: Error) => {
-                    this._logger.error(error);
+                    this._notify('error', error.message, ENotificationType.error);
                 });
                 return;
             }
@@ -111,7 +122,7 @@ export class Service extends Toolkit.APluginService {
                 resolve();
             }
         }).catch((error: Error) => {
-            this._logger.error(error);
+            this._notify('error', `Failed to save read load of ports: ${error.message}`, ENotificationType.error);
         });
     }
 
@@ -139,7 +150,7 @@ export class Service extends Toolkit.APluginService {
             this._openQueue[options.path] = true;
             this.emptyQueue(options.path);
         }).catch((error: Error) => {
-            this._logger.error(error);
+            this._notify('error', `Failed to connect to ${options.path}: ${error.message}`, ENotificationType.error);
         });
     }
 
@@ -152,7 +163,7 @@ export class Service extends Toolkit.APluginService {
             this._openQueue[port] = false;
             this.sessionConnected[this.session][port] = undefined;
         }).catch((error: Error) => {
-            this._logger.error(error);
+            this._notify('error', `Failed to disconnect from ${port}: ${error.message}`, ENotificationType.error);
         });
     }
 
@@ -161,7 +172,7 @@ export class Service extends Toolkit.APluginService {
             stream: this.session,
             command: EHostCommands.list,
         }, this.session).catch((error: Error) => {
-            this._logger.error(error);
+            this._notify('error', `Failed to request port list: ${error.message}`, ENotificationType.error);
         });
     }
 
@@ -171,7 +182,7 @@ export class Service extends Toolkit.APluginService {
             command: EHostCommands.spyStart,
             options: options,
         }, this.session).catch((error: Error) => {
-            this._logger.error(error);
+            this._notify('error', `Failed to start spying on ports: ${error.message}`, ENotificationType.error);
         });
     }
 
@@ -181,7 +192,7 @@ export class Service extends Toolkit.APluginService {
             command: EHostCommands.spyStop,
             options: options,
         }, this.session).catch((error: Error) => {
-            this._logger.error(error);
+            this._notify('error', `Failed to stop spying on ports: ${error.message}`, ENotificationType.error);
         });
     }
 
@@ -192,7 +203,7 @@ export class Service extends Toolkit.APluginService {
             cmd: message,
             path: port
         }, this.session).catch((error: Error) => {
-            this._logger.error(`Cannot send message due to error: ${error}`);
+            this._notify('error', `Failed to send message to port: ${error.message}`, ENotificationType.error);
         });
     }
 
@@ -202,7 +213,7 @@ export class Service extends Toolkit.APluginService {
             command: EHostCommands.write,
             options: options
         }, this.session).catch((error: Error) => {
-            this._logger.error(error);
+            this._notify('error', `Failed to write port configuration: ${error.message}`, ENotificationType.error);
         });
     }
 
@@ -211,7 +222,7 @@ export class Service extends Toolkit.APluginService {
             stream: this.session,
             command: EHostCommands.read,
         }, this.session).catch((error: Error) => {
-            this._logger.error(error);
+            this._notify('error', `Failed to read port configuration: ${error.message}`, ENotificationType.error);
         });
     }
 
@@ -221,7 +232,7 @@ export class Service extends Toolkit.APluginService {
             command: EHostCommands.remove,
             port: port
         }, this.session).catch((error: Error) => {
-            this._logger.error(error);
+            this._notify('error', `Failed to remove port configuration: ${error.message}`, ENotificationType.error);
         });
     }
 

--- a/application/client.plugins/projects/serial/src/lib/services/service.ts
+++ b/application/client.plugins/projects/serial/src/lib/services/service.ts
@@ -10,7 +10,6 @@ export class Service extends Toolkit.APluginService {
     public state:  {[port: string]: IPortState} = {};
     public savedSession: {[session: string]: IPortSession} = {};
     public sessionConnected: {[session: string]: {[port: string]: IPortState}} = {};
-    public recentPorts: string[] = [];
 
     private api: Toolkit.IAPI | undefined;
     private session: string;
@@ -128,7 +127,7 @@ export class Service extends Toolkit.APluginService {
             command: EHostCommands.open,
             options: options,
         }, this.session).then(() => {
-            this.recentPorts.push(options.path);
+            this.writeConfig(options);
             if (this.sessionConnected[this.session] === undefined) {
                 this.sessionConnected[this.session] = {};
             }
@@ -187,11 +186,40 @@ export class Service extends Toolkit.APluginService {
     public sendMessage(message: string, port: string): Promise<any> {
         return this.api.getIPC().requestToHost({
             stream: this.session,
-            command: EHostCommands.write,
+            command: EHostCommands.send,
             cmd: message,
             path: port
         }, this.session).catch((error: Error) => {
             this._logger.error(`Cannot send message due to error: ${error}`);
+        });
+    }
+
+    public writeConfig(options: IOptions): Promise<void> {
+        return this.api.getIPC().requestToHost({
+            stream: this.session,
+            command: EHostCommands.write,
+            options: options
+        }, this.session).catch((error: Error) => {
+            this._logger.error(error);
+        });
+    }
+
+    public readConfig(): Promise<any> {
+        return this.api.getIPC().requestToHost({
+            stream: this.session,
+            command: EHostCommands.read,
+        }, this.session).catch((error: Error) => {
+            this._logger.error(error);
+        });
+    }
+
+    public removeConfig(port: string): Promise<void> {
+        return this.api.getIPC().requestToHost({
+            stream: this.session,
+            command: EHostCommands.remove,
+            port: port
+        }, this.session).catch((error: Error) => {
+            this._logger.error(error);
         });
     }
 

--- a/application/client.plugins/projects/serial/src/lib/services/service.ts
+++ b/application/client.plugins/projects/serial/src/lib/services/service.ts
@@ -1,5 +1,5 @@
 import * as Toolkit from 'chipmunk.client.toolkit';
-import { ENotificationType } from 'chipmunk.client.toolkit';
+import { IPopup, ENotificationType } from 'chipmunk.client.toolkit';
 import { EHostCommands, EHostEvents } from '../common/host.events';
 import { IOptions } from '../common/interface.options';
 import { Observable, Subject } from 'rxjs';
@@ -19,6 +19,7 @@ export class Service extends Toolkit.APluginService {
     private _logger: Toolkit.Logger = new Toolkit.Logger(`Plugin: serial: inj_output_bot:`);
     private _openQueue: {[port: string]: boolean} = {};
     private _messageQueue: {[port: string]: string[]} = {};
+    private _popupGuid: string;
     private _subjects = {
         event: new Subject<any>(),
     };
@@ -233,9 +234,14 @@ export class Service extends Toolkit.APluginService {
         });
     }
 
-    public closePopup(popup: string) {
-        this.api.removePopup(popup);
+    public removePopup() {
+        this.api.removePopup(this._popupGuid);
     }
+
+    public addPopup(popup: IPopup) {
+        this._popupGuid = this.api.addPopup(popup);
+    }
+
     public notify(caption: string, message: string, type: ENotificationType) {
         this.api.addNotification({
             caption: caption,

--- a/application/client.plugins/projects/serial/src/lib/services/service.ts
+++ b/application/client.plugins/projects/serial/src/lib/services/service.ts
@@ -112,7 +112,7 @@ export class Service extends Toolkit.APluginService {
             if (Object.keys(this.sessionConnected).length > 0) {
                 Object.keys(this.sessionConnected).forEach(session => {
                     Object.keys(this.sessionConnected[session]).forEach(port => {
-                        if (ports[port]) {
+                        if (ports[port] && this.sessionConnected[session][port]) {
                             this.sessionConnected[session][port].ioState.read += ports[port].ioState.read;
                         }
                     });

--- a/application/client.plugins/projects/serial/src/lib/services/service.ts
+++ b/application/client.plugins/projects/serial/src/lib/services/service.ts
@@ -150,7 +150,7 @@ export class Service extends Toolkit.APluginService {
             path: port,
         }, this.session).then(() => {
             this._openQueue[port] = false;
-            this.sessionConnected[this.session][port] = undefined;
+            delete this.sessionConnected[this.session][port];
         }).catch((error: Error) => {
             this.notify('error', `Failed to disconnect from ${port}: ${error.message}`, ENotificationType.error);
         });

--- a/application/client.plugins/projects/serial/src/lib/services/service.ts
+++ b/application/client.plugins/projects/serial/src/lib/services/service.ts
@@ -1,4 +1,5 @@
 import * as Toolkit from 'chipmunk.client.toolkit';
+import { ENotificationType } from 'chipmunk.client.toolkit';
 import { EHostCommands, EHostEvents } from '../common/host.events';
 import { IOptions } from '../common/interface.options';
 import { Observable, Subject } from 'rxjs';
@@ -234,6 +235,15 @@ export class Service extends Toolkit.APluginService {
 
     public closePopup(popup: string) {
         this.api.removePopup(popup);
+    }
+    public notify(caption: string, message: string, type: ENotificationType) {
+        this.api.addNotification({
+            caption: caption,
+            message: message,
+            options: {
+                type: type
+            }
+        });
     }
 }
 

--- a/application/client.plugins/projects/serial/src/lib/services/service.ts
+++ b/application/client.plugins/projects/serial/src/lib/services/service.ts
@@ -187,12 +187,17 @@ export class Service extends Toolkit.APluginService {
     }
 
     public stopSpy(options: IOptions[]): Promise<any> {
-        return this.api.getIPC().requestToHost({
-            stream: this.session,
-            command: EHostCommands.spyStop,
-            options: options,
-        }, this.session).catch((error: Error) => {
-            this._notify('error', `Failed to stop spying on ports: ${error.message}`, ENotificationType.error);
+        if (options.length > 0) {
+            return this.api.getIPC().requestToHost({
+                stream: this.session,
+                command: EHostCommands.spyStop,
+                options: options,
+            }, this.session).catch((error: Error) => {
+                this._notify('error', `Failed to stop spying on ports: ${error.message}`, ENotificationType.error);
+            });
+        }
+        return new Promise((resolve) => {
+            resolve();
         });
     }
 

--- a/application/client.plugins/projects/serial/src/lib/services/service.ts
+++ b/application/client.plugins/projects/serial/src/lib/services/service.ts
@@ -32,7 +32,7 @@ export class Service extends Toolkit.APluginService {
     private _onAPIReady() {
         this.api = this.getAPI();
         if (this.api === undefined) {
-            this._notify('error', 'API not found', ENotificationType.error);
+            this.notify('error', 'API not found', ENotificationType.error);
             return;
         }
         this._subscriptions.onSessionOpen = this.api.getSessionsEventsHub().subscribe().onSessionOpen(this._onSessionOpen.bind(this));
@@ -58,17 +58,6 @@ export class Service extends Toolkit.APluginService {
 
     private _onSessionChange(guid: string) {
         this.session = guid;
-    }
-
-    private _notify(caption: string, message: string, type: ENotificationType) {
-        this.notify(caption, message, type);
-        if (type === ENotificationType.error) {
-            this._logger.error(message);
-        } else if (type === ENotificationType.warning) {
-            this._logger.warn(message);
-        } else {
-            this._logger.info(message);
-        }
     }
 
     public getObservable(): {
@@ -99,7 +88,7 @@ export class Service extends Toolkit.APluginService {
                     this.state = response;
                     this._subjects.event.next(message);
                 }).catch((error: Error) => {
-                    this._notify('error', error.message, ENotificationType.error);
+                    throw(error);
                 });
                 return;
             }
@@ -122,7 +111,7 @@ export class Service extends Toolkit.APluginService {
                 resolve();
             }
         }).catch((error: Error) => {
-            this._notify('error', `Failed to save read load of ports: ${error.message}`, ENotificationType.error);
+            throw(error);
         });
     }
 
@@ -150,7 +139,7 @@ export class Service extends Toolkit.APluginService {
             this._openQueue[options.path] = true;
             this.emptyQueue(options.path);
         }).catch((error: Error) => {
-            this._notify('error', `Failed to connect to ${options.path}: ${error.message}`, ENotificationType.error);
+            throw(error);
         });
     }
 
@@ -163,7 +152,7 @@ export class Service extends Toolkit.APluginService {
             this._openQueue[port] = false;
             this.sessionConnected[this.session][port] = undefined;
         }).catch((error: Error) => {
-            this._notify('error', `Failed to disconnect from ${port}: ${error.message}`, ENotificationType.error);
+            throw(error);
         });
     }
 
@@ -172,7 +161,7 @@ export class Service extends Toolkit.APluginService {
             stream: this.session,
             command: EHostCommands.list,
         }, this.session).catch((error: Error) => {
-            this._notify('error', `Failed to request port list: ${error.message}`, ENotificationType.error);
+            throw(error);
         });
     }
 
@@ -182,7 +171,7 @@ export class Service extends Toolkit.APluginService {
             command: EHostCommands.spyStart,
             options: options,
         }, this.session).catch((error: Error) => {
-            this._notify('error', `Failed to start spying on ports: ${error.message}`, ENotificationType.error);
+            throw(error);
         });
     }
 
@@ -193,7 +182,7 @@ export class Service extends Toolkit.APluginService {
                 command: EHostCommands.spyStop,
                 options: options,
             }, this.session).catch((error: Error) => {
-                this._notify('error', `Failed to stop spying on ports: ${error.message}`, ENotificationType.error);
+                throw(error);
             });
         }
         return new Promise((resolve) => {
@@ -208,7 +197,7 @@ export class Service extends Toolkit.APluginService {
             cmd: message,
             path: port
         }, this.session).catch((error: Error) => {
-            this._notify('error', `Failed to send message to port: ${error.message}`, ENotificationType.error);
+            throw(error);
         });
     }
 
@@ -218,7 +207,7 @@ export class Service extends Toolkit.APluginService {
             command: EHostCommands.write,
             options: options
         }, this.session).catch((error: Error) => {
-            this._notify('error', `Failed to write port configuration: ${error.message}`, ENotificationType.error);
+            throw(error);
         });
     }
 
@@ -227,7 +216,7 @@ export class Service extends Toolkit.APluginService {
             stream: this.session,
             command: EHostCommands.read,
         }, this.session).catch((error: Error) => {
-            this._notify('error', `Failed to read port configuration: ${error.message}`, ENotificationType.error);
+            throw(error);
         });
     }
 
@@ -237,7 +226,7 @@ export class Service extends Toolkit.APluginService {
             command: EHostCommands.remove,
             port: port
         }, this.session).catch((error: Error) => {
-            this._notify('error', `Failed to remove port configuration: ${error.message}`, ENotificationType.error);
+            throw(error);
         });
     }
 
@@ -266,6 +255,13 @@ export class Service extends Toolkit.APluginService {
                 type: type
             }
         });
+        if (type === ENotificationType.error) {
+            this._logger.error(message);
+        } else if (type === ENotificationType.warning) {
+            this._logger.warn(message);
+        } else {
+            this._logger.info(message);
+        }
     }
 }
 

--- a/application/client.plugins/projects/serial/src/lib/views/dialog/components.ts
+++ b/application/client.plugins/projects/serial/src/lib/views/dialog/components.ts
@@ -7,6 +7,7 @@ import { SidebarVerticalPortOptionsWriteComponent } from '../sidebar.vertical/po
 import { Subscription, Subject, Observable } from 'rxjs';
 import Service from '../../services/service';
 import * as Toolkit from 'chipmunk.client.toolkit';
+import { ENotificationType } from 'chipmunk.client.toolkit';
 
 interface IConnected {
     port: IPortInfo;
@@ -86,12 +87,23 @@ export class SidebarVerticalPortDialogComponent implements OnInit, OnDestroy, Af
             });
             this._forceUpdate();
         }).catch((error: Error) => {
-            this._logger.error(`Failed to load port list due to error: ${error.message}`);
+            this._notify('Error', `Failed to load port list due to error: ${error.message}`, ENotificationType.error);
         });
     }
 
     public onTick(): { tick: Observable<boolean> } {
         return { tick: this._subjects.tick.asObservable() };
+    }
+
+    private _notify(caption: string, message: string, type: ENotificationType) {
+        Service.notify(caption, message, type);
+        if (type === ENotificationType.error) {
+            this._logger.error(message);
+        } else if (type === ENotificationType.warning) {
+            this._logger.warn(message);
+        } else {
+            this._logger.info(message);
+        }
     }
 
     private _next() {
@@ -160,7 +172,7 @@ export class SidebarVerticalPortDialogComponent implements OnInit, OnDestroy, Af
         Service.removeConfig(port).then(() => {
             this._refreshPortList();
         }).catch((error: Error) => {
-            this._logger.error(`Failed to remove all recent ports due to error: ${error.message}`);
+            this._notify('Error', `Failed to remove all recent ports due to error: ${error.message}`, ENotificationType.error);
         });
     }
 }

--- a/application/client.plugins/projects/serial/src/lib/views/dialog/components.ts
+++ b/application/client.plugins/projects/serial/src/lib/views/dialog/components.ts
@@ -29,7 +29,7 @@ export class SidebarVerticalPortDialogComponent implements OnInit, OnDestroy, Af
     @Input() public _requestPortList: () => Promise<IPortInfo[]>;
     @Input() public _getSelected: (IPortInfo) => void;
     @Input() public _getOptionsCom: (SidebarVerticalPortOptionsWriteComponent) => void;
-    @Input() public _options: IOptions[];
+    @Input() public _options: () => IOptions[];
     @Input() public _ng_canBeConnected: () => boolean;
     @Input() public _ng_connected: IConnected[];
     @Input() public _ng_onOptions: () => void;
@@ -70,7 +70,7 @@ export class SidebarVerticalPortDialogComponent implements OnInit, OnDestroy, Af
 
     ngOnDestroy() {
         clearTimeout(this._interval);
-        Service.stopSpy(this._options);
+        Service.stopSpy(this._options());
         Object.keys(this._subscriptions).forEach((key: string) => {
             this._subscriptions[key].unsubscribe();
         });

--- a/application/client.plugins/projects/serial/src/lib/views/dialog/components.ts
+++ b/application/client.plugins/projects/serial/src/lib/views/dialog/components.ts
@@ -88,23 +88,12 @@ export class SidebarVerticalPortDialogComponent implements OnInit, OnDestroy, Af
             });
             this._forceUpdate();
         }).catch((error: Error) => {
-            this._notify('Error', `Failed to load port list due to error: ${error.message}`, ENotificationType.error);
+            Service.notify('Error', `Failed to load port list due to error: ${error.message}`, ENotificationType.error);
         });
     }
 
     public onTick(): { tick: Observable<boolean> } {
         return { tick: this._subjects.tick.asObservable() };
-    }
-
-    private _notify(caption: string, message: string, type: ENotificationType) {
-        Service.notify(caption, message, type);
-        if (type === ENotificationType.error) {
-            this._logger.error(message);
-        } else if (type === ENotificationType.warning) {
-            this._logger.warn(message);
-        } else {
-            this._logger.info(message);
-        }
     }
 
     private _next() {
@@ -179,7 +168,7 @@ export class SidebarVerticalPortDialogComponent implements OnInit, OnDestroy, Af
         Service.removeConfig(port).then(() => {
             this._refreshPortList();
         }).catch((error: Error) => {
-            this._notify('Error', `Failed to remove all recent ports due to error: ${error.message}`, ENotificationType.error);
+            Service.notify('Error', `Failed to remove all recent ports due to error: ${error.message}`, ENotificationType.error);
         });
     }
 }

--- a/application/client.plugins/projects/serial/src/lib/views/dialog/components.ts
+++ b/application/client.plugins/projects/serial/src/lib/views/dialog/components.ts
@@ -29,7 +29,8 @@ export class SidebarVerticalPortDialogComponent implements OnInit, OnDestroy, Af
     @Input() public _requestPortList: () => Promise<IPortInfo[]>;
     @Input() public _getSelected: (IPortInfo) => void;
     @Input() public _getOptionsCom: (SidebarVerticalPortOptionsWriteComponent) => void;
-    @Input() public _options: () => IOptions[];
+    @Input() public _getPortOptions: () => IOptions[];
+    @Input() public _setPortOptions: (options: IOptions[]) => void;
     @Input() public _ng_canBeConnected: () => boolean;
     @Input() public _ng_connected: IConnected[];
     @Input() public _ng_onOptions: () => void;
@@ -70,7 +71,7 @@ export class SidebarVerticalPortDialogComponent implements OnInit, OnDestroy, Af
 
     ngOnDestroy() {
         clearTimeout(this._interval);
-        Service.stopSpy(this._options());
+        this._stopSpy();
         Object.keys(this._subscriptions).forEach((key: string) => {
             this._subscriptions[key].unsubscribe();
         });
@@ -127,6 +128,12 @@ export class SidebarVerticalPortDialogComponent implements OnInit, OnDestroy, Af
             return;
         }
         this._cdRef.detectChanges();
+    }
+
+    private _stopSpy() {
+        Service.stopSpy(this._getPortOptions()).then(() => {
+            this._setPortOptions([]);
+        });
     }
 
     private _getOptions(): IOptions {

--- a/application/client.plugins/projects/serial/src/lib/views/dialog/port.available/components.ts
+++ b/application/client.plugins/projects/serial/src/lib/views/dialog/port.available/components.ts
@@ -76,6 +76,7 @@ export class DialogAvailablePortComponent implements OnDestroy, AfterViewInit {
         this._spark = [];
         if (this._chart) {
             this._chart.destroy();
+            this._chart = undefined;
         }
         Object.keys(this._subscriptions).forEach((key: string) => {
             this._subscriptions[key].unsubscribe();
@@ -175,6 +176,9 @@ export class DialogAvailablePortComponent implements OnDestroy, AfterViewInit {
     }
 
     private _update() {
+        if (this._destroyed) {
+            return;
+        }
         if (this._chart) {
             this._spark.shift();
             this._spark.push(this._read);

--- a/application/client.plugins/projects/serial/src/lib/views/dialog/port.available/components.ts
+++ b/application/client.plugins/projects/serial/src/lib/views/dialog/port.available/components.ts
@@ -20,6 +20,11 @@ interface Irgb {
     opacity: number;
 }
 
+const COptions = {
+    STEP: 50,
+    ANIMATION: 5000,
+};
+
 @Component({
     selector: 'lib-dia-port-available-com',
     templateUrl: './template.html',
@@ -38,11 +43,9 @@ export class DialogAvailablePortComponent implements OnDestroy, AfterViewInit {
     private _subscriptions: { [key: string]: Subscription } = {};
     private _canvas: ElementRef;
     private _ctx: any;
-    private _step = 50;
-    private _animation = 5000;
     private _read: number;
     private _chart: Chart;
-    private _spark = Array<number>(this._step + 1);
+    private _spark = Array<number>(COptions.STEP + 1);
     private _destroyed: boolean = false;
 
     constructor(private _cdRef: ChangeDetectorRef) {
@@ -131,7 +134,7 @@ export class DialogAvailablePortComponent implements OnDestroy, AfterViewInit {
         this._chart = new Chart(this._ctx, {
             type: 'line',
             data: {
-                labels: new Array(this._step).fill(''),
+                labels: new Array(COptions.STEP).fill(''),
                 datasets: [{
                     data: this._spark,
                     borderColor: this._colorize(),
@@ -141,7 +144,7 @@ export class DialogAvailablePortComponent implements OnDestroy, AfterViewInit {
             },
             options: {
                 animation: {
-                    duration: this._animation,
+                    duration: COptions.ANIMATION,
                 },
                 tooltips: false,
                 scales: {

--- a/application/client.plugins/projects/serial/src/lib/views/dialog/port.available/styles.less
+++ b/application/client.plugins/projects/serial/src/lib/views/dialog/port.available/styles.less
@@ -3,7 +3,7 @@
     display: block;
     width: 100%;
     & div.container {
-        display: flex
+        display: flex;
     }
     & div.portInfo {
         width: 120px;

--- a/application/client.plugins/projects/serial/src/lib/views/dialog/template.html
+++ b/application/client.plugins/projects/serial/src/lib/views/dialog/template.html
@@ -3,6 +3,7 @@
     <table class="ports">
         <tr [attr.class]="'port ' + (_ng_isPortSelected(port) ? 'selected' : '')" *ngFor="let port of _ng_ports" (click)="_ng_onPortSelect(port)" (dblclick)="_ng_onConnect(port)">
             <td><lib-dia-port-available-com [port]="port" [connected]="_ng_connected" [spyState]="_ng_spyState" [ticker]="onTick()"></lib-dia-port-available-com></td>            
+            <td *ngIf="_ng_recent"><span class="close-button fas fa-times" (click)="_ng_onRemovePort(port.path)"></span></td>
         </tr>
     </table>
     <div *ngIf="_ng_options">
@@ -11,5 +12,8 @@
     <div class="controlls" *ngIf="_ng_canBeConnected()">
         <span class="small-button" (click)="_ng_onOptions()">Options</span>
         <span class="small-button" (click)="_ng_onConnect()">Connect</span>
+    </div>
+    <div class="controlls" *ngIf="_ng_recent">
+        <span class="small-button" (click)="_ng_onRemovePort('*')">Remove all</span>
     </div>
 </div>

--- a/application/client.plugins/projects/serial/src/lib/views/dialog/titlebar/template.html
+++ b/application/client.plugins/projects/serial/src/lib/views/dialog/titlebar/template.html
@@ -1,2 +1,2 @@
 <span class="small-icon-button fas fa-plus" (click)="_ng_addPort(false)"></span>
-<span [attr.class]="'small-icon-button fas fa-ellipsis-h show-dialog'" (click)="_ng_addPort(true)"></span>
+<!-- <span [attr.class]="'small-icon-button fas fa-ellipsis-h show-dialog'" (click)="_ng_addPort(true)"></span> -->

--- a/application/client.plugins/projects/serial/src/lib/views/sidebar.vertical/component.ts
+++ b/application/client.plugins/projects/serial/src/lib/views/sidebar.vertical/component.ts
@@ -402,7 +402,7 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
                     return CPORTS[port.path];
                 }));
             }).catch((error: Error) => {
-                throw(error);
+                Service.notify('Error', error.message, ENotificationType.error);
             });
         });
     }
@@ -439,7 +439,7 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
                                     this._filterPorts(response.ports).then((ports: IPortInfo[]) => {
                                         return resolve(ports);
                                     }).catch((error: Error) => {
-                                        throw(error);
+                                        Service.notify('Error', error.message, ENotificationType.error);
                                     });
                                 } else {
                                     return resolve(response.ports);

--- a/application/client.plugins/projects/serial/src/lib/views/sidebar.vertical/component.ts
+++ b/application/client.plugins/projects/serial/src/lib/views/sidebar.vertical/component.ts
@@ -9,6 +9,7 @@ import { SidebarVerticalPortDialogComponent } from '../dialog/components';
 import { Subscription } from 'rxjs';
 import * as Toolkit from 'chipmunk.client.toolkit';
 import Service from '../../services/service';
+import { ENotificationType } from 'chipmunk.client.toolkit';
 
 interface IState {
     _ng_ports: IPortInfo[];
@@ -162,7 +163,8 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
             this._ng_selected = undefined;
             this._forceUpdate();
         }).catch((error: Error) => {
-            this._logger.error(this._error(`Fail to connect to port "${options.path}" due error: ${error.message}`));
+            this._notify('Error',
+                this._error(`Fail to connect to port "${options.path}" due error: ${error.message}`), ENotificationType.error);
         });
     }
 
@@ -189,7 +191,7 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
             this._ng_busy = false;
             this._forceUpdate();
         }).catch((error: Error) => {
-            this._logger.error(this._error(`Fail to close port "${port.path}" due error: ${error.message}`));
+            this._notify('Error', this._error(`Fail to close port "${port.path}" due error: ${error.message}`), ENotificationType.error);
         });
     }
 
@@ -254,7 +256,7 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
             this._saveState();
             this._forceUpdate();
         }).catch((error: Error) => {
-            this._logger.error(`Fail to get ports list due error: ${error.message}`);
+            this._notify('Error', `Fail to get ports list due error: ${error.message}`, ENotificationType.error);
         });
     }
 
@@ -293,6 +295,17 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
             return;
         }
         this._cdRef.detectChanges();
+    }
+
+    private _notify(caption: string, message: string, type: ENotificationType) {
+        Service.notify(caption, message, type);
+        if (type === ENotificationType.error) {
+            this._logger.error(message);
+        } else if (type === ENotificationType.warning) {
+            this._logger.warn(message);
+        } else {
+            this._logger.info(message);
+        }
     }
 
     public _ng_sendMessage( message: string, event?: KeyboardEvent ) {
@@ -450,7 +463,8 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
                                     this._filterPorts(response.ports).then((ports: IPortInfo[]) => {
                                         return resolve(ports);
                                     }).catch((error: Error) => {
-                                        this._logger.error(`Failed to load recenty used ports due to error: ${error.message}`);
+                                        this._notify('Error',
+                                            `Failed to load recenty used ports due to error: ${error.message}`, ENotificationType.error);
                                     });
                                 } else {
                                     return resolve(response.ports);
@@ -474,7 +488,8 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
                 }
             });
         }).catch((error: Error) => {
-            this._logger.error(`Fail to get ports list due error: ${error.message}`);
+
+            this._notify('Error', `Fail to get ports list due error: ${error.message}`, ENotificationType.error);
         });
     }
 }

--- a/application/client.plugins/projects/serial/src/lib/views/sidebar.vertical/component.ts
+++ b/application/client.plugins/projects/serial/src/lib/views/sidebar.vertical/component.ts
@@ -41,9 +41,7 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
     @ViewChild('msgInput', {static: false}) _inputCom: InputStandardComponent;
     @ViewChild('selectPort', {static: false}) _selectCom: DDListStandardComponent;
 
-    @Input() public api: Toolkit.IAPI;
     @Input() public session: string;
-    @Input() public sessions: Toolkit.ControllerSessionsEvents;
 
     private _subscriptions: { [key: string]: Subscription } = {};
     private _logger: Toolkit.Logger = new Toolkit.Logger(`Plugin: serial: inj_output_bot:`);
@@ -421,10 +419,6 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
         });
     }
 
-    private _closePopup(popup: string) {
-        Service.closePopup(popup);
-    }
-
     private _filterPorts(ports: IPortInfo[]): Promise<IPortInfo[]> {
         return new Promise((resolve, reject) => {
             const CPORTS = {};
@@ -442,14 +436,14 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
     public _ng_connectDialog(recent: boolean) {
         Service.requestPorts().then((response) => {
             this._startSpy();
-            const popupGuid: string = this.api.addPopup({
+            Service.addPopup({
                 caption: 'Choose port to connect:',
                 component: {
                     factory: SidebarVerticalPortDialogComponent,
                     inputs: {
                         _onConnect: (() => {
                             this._stopSpy().then(() => this._ng_onConnect());
-                            this._closePopup(popupGuid);
+                            Service.removePopup();
                         }),
                         _ng_canBeConnected: this._ng_canBeConnected,
                         _ng_connected: this._ng_connected,
@@ -479,7 +473,7 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
                     {
                         caption: 'Cancel',
                         handler: () => {
-                            this._closePopup(popupGuid);
+                            Service.removePopup();
                         }
                     }
                 ],
@@ -488,7 +482,6 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
                 }
             });
         }).catch((error: Error) => {
-
             this._notify('Error', `Fail to get ports list due error: ${error.message}`, ENotificationType.error);
         });
     }

--- a/application/client.plugins/projects/serial/src/lib/views/sidebar.vertical/component.ts
+++ b/application/client.plugins/projects/serial/src/lib/views/sidebar.vertical/component.ts
@@ -470,7 +470,7 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
                     }
                 ],
                 options: {
-                    width: 26
+                    width: recent ? 26 : 24
                 }
             });
         }).catch((error: Error) => {

--- a/application/client.plugins/projects/serial/src/lib/views/sidebar.vertical/component.ts
+++ b/application/client.plugins/projects/serial/src/lib/views/sidebar.vertical/component.ts
@@ -161,7 +161,7 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
             this._ng_selected = undefined;
             this._forceUpdate();
         }).catch((error: Error) => {
-            this._notify('Error',
+            Service.notify('Error',
                 this._error(`Fail to connect to port "${options.path}" due error: ${error.message}`), ENotificationType.error);
         });
     }
@@ -189,7 +189,7 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
             this._ng_busy = false;
             this._forceUpdate();
         }).catch((error: Error) => {
-            this._notify('Error', this._error(`Fail to close port "${port.path}" due error: ${error.message}`), ENotificationType.error);
+            Service.notify('Error', this._error(`Fail to close port "${port.path}" due error: ${error.message}`), ENotificationType.error);
         });
     }
 
@@ -254,7 +254,7 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
             this._saveState();
             this._forceUpdate();
         }).catch((error: Error) => {
-            this._notify('Error', `Fail to get ports list due error: ${error.message}`, ENotificationType.error);
+            Service.notify('Error', `Fail to get ports list due error: ${error.message}`, ENotificationType.error);
         });
     }
 
@@ -295,20 +295,9 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
         this._cdRef.detectChanges();
     }
 
-    private _notify(caption: string, message: string, type: ENotificationType) {
-        Service.notify(caption, message, type);
-        if (type === ENotificationType.error) {
-            this._logger.error(message);
-        } else if (type === ENotificationType.warning) {
-            this._logger.warn(message);
-        } else {
-            this._logger.info(message);
-        }
-    }
-
     public _ng_sendMessage( message: string, event?: KeyboardEvent ) {
         Service.sendMessage(message, this._chosenPort).catch((error: Error) => {
-            this._notify('Error', error.message, ENotificationType.error);
+            Service.notify('Error', error.message, ENotificationType.error);
         });
         this._inputCom.setValue('');
     }
@@ -400,12 +389,12 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
     private _startSpy() {
         this._createOptions();
         Service.startSpy(this._portOptions).catch((error: Error) => {
-            this._notify('Error', error.message, ENotificationType.error);
+            Service.notify('Error', error.message, ENotificationType.error);
         });
     }
 
     private _filterPorts(ports: IPortInfo[]): Promise<IPortInfo[]> {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve) => {
             const CPORTS = {};
             Service.readConfig().then((response: {[key: string]: any}) => {
                 Object.assign(CPORTS, response.settings);
@@ -413,7 +402,7 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
                     return CPORTS[port.path];
                 }));
             }).catch((error: Error) => {
-                reject(error);
+                throw(error);
             });
         });
     }
@@ -432,7 +421,7 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
                                 this._ng_onConnect();
                                 Service.removePopup();
                             }).catch((error: Error) => {
-                                this._notify('Error', error.message, ENotificationType.error);
+                                Service.notify('Error', error.message, ENotificationType.error);
                             });
                         }),
                         _ng_canBeConnected: this._ng_canBeConnected,
@@ -450,8 +439,7 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
                                     this._filterPorts(response.ports).then((ports: IPortInfo[]) => {
                                         return resolve(ports);
                                     }).catch((error: Error) => {
-                                        this._notify('Error',
-                                            `Failed to load recenty used ports due to error: ${error.message}`, ENotificationType.error);
+                                        throw(error);
                                     });
                                 } else {
                                     return resolve(response.ports);
@@ -475,7 +463,7 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
                 }
             });
         }).catch((error: Error) => {
-            this._notify('Error', `Fail to get ports list due error: ${error.message}`, ENotificationType.error);
+            Service.notify('Error', `Fail to get ports list due error: ${error.message}`, ENotificationType.error);
         });
     }
 }

--- a/application/client.plugins/projects/serial/src/lib/views/sidebar.vertical/component.ts
+++ b/application/client.plugins/projects/serial/src/lib/views/sidebar.vertical/component.ts
@@ -397,27 +397,10 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
         });
     }
 
-    private _removeOptions(): Promise<void> {
-        return new Promise(resolve => {
-            this._portOptions = [];
-            resolve();
-        });
-    }
-
     private _startSpy() {
         this._createOptions();
         Service.startSpy(this._portOptions).catch((error: Error) => {
             this._notify('Error', error.message, ENotificationType.error);
-        });
-    }
-
-    private _stopSpy(): Promise<any> {
-        return new Promise((resolve, reject) => {
-            Service.stopSpy(this._portOptions).then(
-                resolve
-            ).catch((error: Error) => {
-                reject(error);
-            });
         });
     }
 
@@ -444,11 +427,10 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
                     factory: SidebarVerticalPortDialogComponent,
                     inputs: {
                         _onConnect: (() => {
-                            this._stopSpy().then(() => {
-                                this._removeOptions().then(() => {
-                                    this._ng_onConnect();
-                                    Service.removePopup();
-                                });
+                            Service.stopSpy(this._portOptions).then(() => {
+                                this._portOptions = [];
+                                this._ng_onConnect();
+                                Service.removePopup();
                             }).catch((error: Error) => {
                                 this._notify('Error', error.message, ENotificationType.error);
                             });
@@ -457,7 +439,10 @@ export class SidebarVerticalComponent implements AfterViewInit, OnDestroy {
                         _ng_connected: this._ng_connected,
                         _ng_onOptions: this._ng_onOptions,
                         _ng_onPortSelect: this._ng_onPortSelect,
-                        _options: () => this._portOptions,
+                        _getPortOptions: () => this._portOptions,
+                        _setPortOptions: (options: IOptions[]) => {
+                            this._portOptions = options;
+                        },
                         _ng_recent: recent,
                         _requestPortList: (): Promise<IPortInfo[]> =>  {
                             return new Promise((resolve) => {

--- a/application/sandbox/serial/process/package.json
+++ b/application/sandbox/serial/process/package.json
@@ -20,7 +20,7 @@
     "typescript": "^3.1.3"
   },
   "dependencies": {
-    "chipmunk.plugin.ipc": "0.0.33",
+    "chipmunk.plugin.ipc": "latest",
     "serialport": "8.0.5"
   }
 }

--- a/application/sandbox/serial/process/src/consts/commands.ts
+++ b/application/sandbox/serial/process/src/consts/commands.ts
@@ -2,7 +2,10 @@ export enum ECommands {
     open = 'open',
     close = 'close',
     list = 'list',
-    write = 'write',
+    send = 'send',
     spyStart = 'spyStart',
-    spyStop = 'spyStop'
+    spyStop = 'spyStop',
+    write = 'write',
+    read = 'read',
+    remove = 'remove'
 }

--- a/application/sandbox/serial/process/src/services/service.sessions.ts
+++ b/application/sandbox/serial/process/src/services/service.sessions.ts
@@ -135,27 +135,26 @@ class ServiceSessions {
                             command: message.data.command
                         }
                     }));
-                });
-                
+                });                
             case ECommands.spyStop:
-                    return this._income_onSpyStop(message).then(() => {
-                        response(new IPCMessages.PluginInternalMessage({
-                            data: {
-                                status: 'done'
-                            },
-                            token: message.token,
-                            stream: message.stream
-                        }));
-                    }).catch((error: Error) => {
-                        response(new IPCMessages.PluginError({
-                            message: error.message,
-                            stream: message.stream,
-                            token: message.token,
-                            data: {
-                                command: message.data.command
-                            }
-                        }));
-                    });
+                return this._income_onSpyStop(message).then(() => {
+                    response(new IPCMessages.PluginInternalMessage({
+                        data: {
+                            status: 'done'
+                        },
+                        token: message.token,
+                        stream: message.stream
+                    }));
+                }).catch((error: Error) => {
+                    response(new IPCMessages.PluginError({
+                        message: error.message,
+                        stream: message.stream,
+                        token: message.token,
+                        data: {
+                            command: message.data.command
+                        }
+                    }));
+                });
             default:
                 this._logger.warn(`Unknown commad: ${message.data.command}`);
         }
@@ -269,7 +268,7 @@ class ServiceSessions {
                 return reject(new Error(this._logger.warn(`No target stream ID provided`)));
             }
             if (message === undefined) {
-                return reject(new Error(this._logger.error(`Fail to send message, because it's undefined`)))
+                return reject(new Error(this._logger.error(`Fail to start spying, because message is undefined`)))
             }
             let controller: ControllerSession | undefined = this._sessions.get(streamId);
             if (controller === undefined) {
@@ -297,7 +296,7 @@ class ServiceSessions {
                 return reject(new Error(this._logger.warn(`No target stream ID provided`)));
             }
             if (message === undefined) {
-                return reject(new Error(this._logger.error(`Fail to send message, because it's undefined`)))
+                return reject(new Error(this._logger.error(`Fail to stop spying, because message is undefined`)));
             }
             let controller: ControllerSession | undefined = this._sessions.get(streamId);
             if (controller === undefined) {

--- a/application/sandbox/serial/process/src/services/service.sessions.ts
+++ b/application/sandbox/serial/process/src/services/service.sessions.ts
@@ -436,7 +436,9 @@ class ServiceSessions {
                     return;
                 }
                 if (message.data.port === '*') {
-                    settings['ports'] = {};
+                    Object.keys(settings['ports']).forEach((port: string) => {
+                        delete settings['ports'][port];
+                    });
                 } else {
                     delete settings['ports'][message.data.port];
                 }


### PR DESCRIPTION
Popup window show recently connected ports (via config file saved on user PC)
- directly connect to port
- remove individual port
- remove all ports

Notification on error/warning (serial plugin)
- show error as notfication and log it