### PR TITLE
#822 Multiple files dialog

### DIFF
--- a/application/client.core/src/app/environment/components/dialogs/multiplefiles/template.html
+++ b/application/client.core/src/app/environment/components/dialogs/multiplefiles/template.html
@@ -1,5 +1,5 @@
-<ul>
-    <li *ngFor="let file of files">
+<ul (contextmenu)="_ng_onContexMenu($event)">
+    <li *ngFor="let file of fileList.getFiles()">
         <mat-checkbox (change)="_ng_onChange($event, file)" [checked]="file.checked" [disabled]="file.disabled"></mat-checkbox>
         {{file.name}} ({{(file.size / 1024 / 1024).toFixed(2)}} Mb)
     </li>

--- a/application/client.core/src/app/environment/services/service.file.opener.ts
+++ b/application/client.core/src/app/environment/services/service.file.opener.ts
@@ -25,8 +25,8 @@ export enum EActionType {
 
 
 export interface IFileOpenerService {
-    merge: (files: IPCMessages.IFile[]) => void;
-    concat: (files: IPCMessages.IFile[]) => void;
+    merge: (files: IPCMessages.IFile[] | FilesList) => void;
+    concat: (files: IPCMessages.IFile[] | FilesList) => void;
 }
 
 const CReopenContextMenuItemId = 'reopen_file_item';
@@ -105,7 +105,6 @@ export class FileOpenerService implements IService, IFileOpenerService {
                                 factory: DialogsMultipleFilesActionComponent,
                                 inputs: {
                                     fileList: fileList,
-                                    files: fileList.getFiles().slice()
                                 }
                             },
                             buttons: [
@@ -149,19 +148,19 @@ export class FileOpenerService implements IService, IFileOpenerService {
         });
     }
 
-    public merge(list: FilesList | IPCMessages.IFile[]) {
-        list = list instanceof Array ? list : this._filterChecked(list.getFiles());
-        if (list.length <= 0) {
+    public merge(list: IPCMessages.IFile[] | FilesList) {
+        const checked = list instanceof Array ? this._filterChecked(list) : this._filterChecked(list.getFiles());
+        if (checked.length <= 0) {
             return;
         }
-        this._open(list, EActionType.merging);
+        this._open(checked, EActionType.merging);
     }
-    public concat(list: FilesList | IPCMessages.IFile[]) {
-        list = list instanceof Array ? list : this._filterChecked(list.getFiles());
-        if (list.length <= 0) {
+    public concat(list: FilesList) {
+        const checked = list instanceof Array ? this._filterChecked(list) : this._filterChecked(list.getFiles());
+        if (checked.length <= 0) {
             return;
         }
-        this._open(list, EActionType.concat);
+        this._open(checked, EActionType.concat);
     }
 
     private _open(files: IPCMessages.IFile[], action: EActionType) {

--- a/application/client.core/src/app/environment/services/service.file.opener.ts
+++ b/application/client.core/src/app/environment/services/service.file.opener.ts
@@ -150,10 +150,18 @@ export class FileOpenerService implements IService, IFileOpenerService {
     }
 
     public merge(list: FilesList | IPCMessages.IFile[]) {
-        this._open(list instanceof Array ? list : this._filterChecked(list.getFiles()), EActionType.merging);
+        list = list instanceof Array ? list : this._filterChecked(list.getFiles());
+        if (list.length <= 0) {
+            return;
+        }
+        this._open(list, EActionType.merging);
     }
     public concat(list: FilesList | IPCMessages.IFile[]) {
-        this._open(list instanceof Array ? list : this._filterChecked(list.getFiles()), EActionType.concat);
+        list = list instanceof Array ? list : this._filterChecked(list.getFiles());
+        if (list.length <= 0) {
+            return;
+        }
+        this._open(list, EActionType.concat);
     }
 
     private _open(files: IPCMessages.IFile[], action: EActionType) {


### PR DESCRIPTION
New feature:
- When drag&dropping multiple files into Chipmunk the user can right-click to call context menu
- In the context menu, the user can "select all", "deselect all" or "reverse select all" files

Fix:
- When no file is checked in the popup window, clicking "merge" or "concat" will just close the popup window

