### PR TITLE
Use new notarytool command-line utility

### DIFF
--- a/application/holder/hooks/afterSign.js
+++ b/application/holder/hooks/afterSign.js
@@ -1,8 +1,8 @@
 require('dotenv').config();
-const { notarize } = require('@electron/notarize');
+const {notarize} = require('@electron/notarize');
 
 exports.default = async function notarizing(context) {
-    const { electronPlatformName, appOutDir } = context;
+    const {electronPlatformName, appOutDir} = context;
     if (electronPlatformName !== 'darwin') {
         return;
     }
@@ -23,5 +23,6 @@ exports.default = async function notarizing(context) {
         appPath: `${appOutDir}/${appName}.app`,
         appleId: process.env.APPLEID,
         appleIdPassword: process.env.APPLEIDPASS,
+        tool: 'notarytool',
     });
 };


### PR DESCRIPTION
Neccessary since Apple will deprecate the old way
(to notarize your macOS software with Apple)