### PR TITLE
Add import-export options for sidebar filters

### DIFF
--- a/application/client/src/app/service/history.ts
+++ b/application/client/src/app/service/history.ts
@@ -76,7 +76,7 @@ export class Service extends Implementation {
         return this.provider.export(uuids, filename);
     }
 
-    public import(filename: string): Promise<void> {
+    public import(filename: string): Promise<string[]> {
         return this.provider.import(filename);
     }
 }

--- a/application/client/src/app/service/history/provider.ts
+++ b/application/client/src/app/service/history/provider.ts
@@ -58,7 +58,7 @@ export class Provider implements EntryConvertable {
         return bridge.entries({ file: filename }).overwrite([this.entry().to()]);
     }
 
-    public import(filename: string): Promise<void> {
+    public import(filename: string): Promise<string[]> {
         return bridge
             .entries({ file: filename })
             .get()
@@ -83,11 +83,12 @@ export class Provider implements EntryConvertable {
                     });
                     return col;
                 });
+                let uuid: string[] = this.collections.map(collection => collection.uuid);
                 this.storage.definitions.add(this.definitions);
                 this.storage.collections.add(this.collections);
                 this.collections = [];
                 this.definitions = [];
-                return undefined;
+                return uuid;
             });
     }
 

--- a/application/client/src/app/service/history/provider.ts
+++ b/application/client/src/app/service/history/provider.ts
@@ -83,7 +83,7 @@ export class Provider implements EntryConvertable {
                     });
                     return col;
                 });
-                let uuid: string[] = this.collections.map(collection => collection.uuid);
+                const uuid: string[] = this.collections.map(collection => collection.uuid);
                 this.storage.definitions.add(this.definitions);
                 this.storage.collections.add(this.collections);
                 this.collections = [];

--- a/application/client/src/app/ui/views/sidebar/search/component.ts
+++ b/application/client/src/app/ui/views/sidebar/search/component.ts
@@ -59,10 +59,10 @@ export class Filters extends ChangesDetector implements OnDestroy, AfterContentI
                 handler: () => {
                     this.log().debug(`Not implemented yet`);
                 },
-            },
+            }
         ];
         contextmenu.show({
-            items: items,
+            items: this.providers.contextMenuOptions(items),
             x: event.pageX,
             y: event.pageY,
         });

--- a/application/client/src/app/ui/views/sidebar/search/providers/providers.ts
+++ b/application/client/src/app/ui/views/sidebar/search/providers/providers.ts
@@ -489,12 +489,7 @@ export class Providers {
                 },
             });
 
-        event.items.push({ /* Delimiter */}, {
-            caption: 'Export All to File',
-            handler: () => console.log('Exporting to the file'),
-        });
-
-        event.items.push({ caption: 'Import from File', handler: () => console.log('Importing from file') });
+        this.contextMenuOptions(event.items);
 
         this._providers.forEach((provider: Provider<any>) => {
             const custom: IMenuItem[] = provider.getContextMenuItems(
@@ -518,23 +513,23 @@ export class Providers {
             this.logger.error('History session is not defined');
             return items
         }
-        items.push({});
+        items.push({ /* Delimiter */ });
         const store = this.session.search.store();
         const showExport: boolean = (store.filters().get().length + store.charts().get().length + store.disabled().get().length) !== 0;
         showExport && items.push(
         {
             caption: 'Export All to File',
-            handler: () => this.exportFilters(historySession),
+            handler: () => this._exportFilters(historySession),
         });
         items.push(
         {
             caption: 'Import from File',
-            handler: () => this.importFilterFile(historySession),
+            handler: () => this._importFilterFile(historySession),
         });
         return items;
     }
 
-    private exportFilters = (historySession: HistorySession) => {
+    private _exportFilters = (historySession: HistorySession) => {
         bridge.files().select.save()
         .then((filename: string | undefined) => {
             if (filename === undefined)
@@ -544,7 +539,7 @@ export class Providers {
         .catch(error => this.logger.error(error.message));
     }
 
-    private importFilterFile = (historySession: HistorySession) => {
+    private _importFilterFile = (historySession: HistorySession) => {
         bridge.files().select.text()
         .then(file => {
             if (file.length !== 1) {

--- a/application/client/src/app/ui/views/sidebar/search/providers/providers.ts
+++ b/application/client/src/app/ui/views/sidebar/search/providers/providers.ts
@@ -485,6 +485,14 @@ export class Providers {
                     });
                 },
             });
+
+        event.items.push({ /* Delimiter */}, {
+            caption: 'Export All to File',
+            handler: () => console.log('Exporting to the file'),
+        });
+
+        event.items.push({ caption: 'Import from File', handler: () => console.log('Importing from file') });
+
         this._providers.forEach((provider: Provider<any>) => {
             const custom: IMenuItem[] = provider.getContextMenuItems(
                 event.entity,
@@ -498,6 +506,21 @@ export class Providers {
             }
         });
         this.subjects.get().context.emit(event);
+    }
+
+    public contextMenuOptions(items: IMenuItem[]): IMenuItem[] {
+        items.push({});
+        items.push(
+        {
+            caption: 'Export All to File',
+            handler: () => console.log('Exporting from providers'),
+        });
+        items.push(
+        {
+            caption: 'Import from File',
+            handler: () => console.log('Importing'),
+        });
+        return items;
     }
 
     private _onDoubleclickEvent(event: IDoubleclickEvent) {

--- a/application/client/src/app/ui/views/sidebar/search/providers/providers.ts
+++ b/application/client/src/app/ui/views/sidebar/search/providers/providers.ts
@@ -558,9 +558,9 @@ export class Providers {
                             historySession.apply(collection);
                         }
                     })
-                    .catch(error => this._logAndNotifyError(error));
+                    .catch(error => this.logAndNotifyError(error));
                 })
-                .catch(error => this._logAndNotifyError(error))
+                .catch(error => this.logAndNotifyError(error))
             },
             export: (): void => {
                 bridge.files().select.save()
@@ -568,14 +568,14 @@ export class Providers {
                     if (filename === undefined)
                         return;
                     history.export([historySession.collections.uuid], filename)
-                    .catch(error => this._logAndNotifyError(error))
+                    .catch(error => this.logAndNotifyError(error))
                 })
-                .catch(error => this._logAndNotifyError(error))
+                .catch(error => this.logAndNotifyError(error))
             }
         };
     }
 
-    private _logAndNotifyError(error: any): void {
+    protected logAndNotifyError(error: any): void {
         this.logger.error(error.message);
         notifications.notify(
             new Notification({

--- a/application/client/src/app/ui/views/sidebar/search/providers/providers.ts
+++ b/application/client/src/app/ui/views/sidebar/search/providers/providers.ts
@@ -518,7 +518,9 @@ export class Providers {
             return items
         }
         items.push({});
-        items.push(
+        let store = this.session.search.store();
+        let showExport: boolean = (store.filters().get().length + store.charts().get().length + store.disabled().get().length) !== 0;
+        showExport && items.push(
         {
             caption: 'Export All to File',
             handler: () => {

--- a/application/client/src/app/ui/views/sidebar/search/providers/providers.ts
+++ b/application/client/src/app/ui/views/sidebar/search/providers/providers.ts
@@ -518,8 +518,8 @@ export class Providers {
             return items
         }
         items.push({});
-        let store = this.session.search.store();
-        let showExport: boolean = (store.filters().get().length + store.charts().get().length + store.disabled().get().length) !== 0;
+        const store = this.session.search.store();
+        const showExport: boolean = (store.filters().get().length + store.charts().get().length + store.disabled().get().length) !== 0;
         showExport && items.push(
         {
             caption: 'Export All to File',


### PR DESCRIPTION
Add ability to import and export all filters, Charts from sidebar. At the moment user can still export all filters from history in toolbar but to enhance the accessibility this PR add same feature in sidebar.

Fixes: #1833