### PR TITLE
Fix attaching files after concat (close #1866)

### DIFF
--- a/application/apps/indexer/session/src/handlers/observe.rs
+++ b/application/apps/indexer/session/src/handlers/observe.rs
@@ -27,7 +27,7 @@ pub async fn start_observing(
         ObserveOrigin::File(uuid, file_origin, filename) => {
             let (is_text, session_file_origin) = (
                 matches!(options.parser, ParserType::Text),
-                state.get_session_file_stage().await?,
+                state.get_session_file_origin().await?,
             );
             match session_file_origin {
                 Some(origin) if origin.is_linked() => Err(NativeError {

--- a/application/apps/indexer/session/src/handlers/observe.rs
+++ b/application/apps/indexer/session/src/handlers/observe.rs
@@ -2,7 +2,7 @@ use crate::{
     events::{NativeError, NativeErrorKind},
     handlers::observing,
     operations::{OperationAPI, OperationResult},
-    state::SessionStateAPI,
+    state::{SessionFileStage, SessionStateAPI},
 };
 use indexer_base::progress::Severity;
 use log::error;
@@ -25,15 +25,41 @@ pub async fn start_observing(
     }
     match &options.origin {
         ObserveOrigin::File(uuid, file_origin, filename) => {
-            observing::file::observe_file(
-                operation_api,
-                state,
-                uuid,
-                file_origin,
-                filename,
-                &options.parser,
-            )
-            .await
+            let (is_text, session_file_stage) = (
+                matches!(options.parser, ParserType::Text),
+                state.get_session_file_stage().await?,
+            );
+            match session_file_stage {
+                SessionFileStage::Linked => Err(NativeError {
+                    severity: Severity::ERROR,
+                    kind: NativeErrorKind::Configuration,
+                    message: Some(String::from(
+                        "Cannot observe file, because session is linked to other text file",
+                    )),
+                }),
+                SessionFileStage::NotLinked if is_text => {
+                    // Session file was created and some files/streams were opened already. We should check for text files
+                    // to prevent attempt to link session with text file. Using concat instead
+                    observing::concat::concat_files(
+                        operation_api,
+                        state,
+                        &[(uuid.clone(), file_origin.clone(), filename.clone())],
+                        &options.parser,
+                    )
+                    .await
+                }
+                SessionFileStage::NotLinked | SessionFileStage::NotCreated => {
+                    observing::file::observe_file(
+                        operation_api,
+                        state,
+                        uuid,
+                        file_origin,
+                        filename,
+                        &options.parser,
+                    )
+                    .await
+                }
+            }
         }
         ObserveOrigin::Concat(files) => {
             if files.is_empty() {

--- a/application/apps/indexer/session/src/state/api.rs
+++ b/application/apps/indexer/session/src/state/api.rs
@@ -1,8 +1,12 @@
 use crate::{
     events::NativeError,
     state::{
-        indexes::controller::Mode as IndexesMode, observed::Observed, session_file::{GrabbedElement, SessionFileStage},
-        source_ids::SourceDefinition, values::ValuesError, AttachmentInfo,
+        indexes::controller::Mode as IndexesMode,
+        observed::Observed,
+        session_file::{GrabbedElement, SessionFileOrigin},
+        source_ids::SourceDefinition,
+        values::ValuesError,
+        AttachmentInfo,
     },
     tracker::OperationTrackerAPI,
 };
@@ -28,7 +32,7 @@ pub enum Api {
     GetSessionFile(oneshot::Sender<Result<PathBuf, NativeError>>),
     WriteSessionFile((u8, String, oneshot::Sender<Result<(), NativeError>>)),
     FlushSessionFile(oneshot::Sender<Result<(), NativeError>>),
-    GetSessionFileStage(oneshot::Sender<Result<SessionFileStage, NativeError>>),
+    GetSessionFileOrigin(oneshot::Sender<Result<Option<SessionFileOrigin>, NativeError>>),
     UpdateSession((u8, oneshot::Sender<Result<bool, NativeError>>)),
     AddSource((String, oneshot::Sender<u8>)),
     GetSource((String, oneshot::Sender<Option<u8>>)),
@@ -156,7 +160,7 @@ impl Display for Api {
                 Self::GetSessionFile(_) => "GetSessionFile",
                 Self::WriteSessionFile(_) => "WriteSessionFile",
                 Self::FlushSessionFile(_) => "FlushSessionFile",
-                Self::GetSessionFileStage(_) => "GetSessionFileStage",
+                Self::GetSessionFileOrigin(_) => "GetSessionFileOrigin",
                 Self::UpdateSession(_) => "UpdateSession",
                 Self::AddSource(_) => "AddSource",
                 Self::GetSource(_) => "GetSource",
@@ -375,9 +379,9 @@ impl SessionStateAPI {
         self.exec_operation(Api::FlushSessionFile(tx), rx).await?
     }
 
-    pub async fn get_session_file_stage(&self) -> Result<SessionFileStage, NativeError> {
+    pub async fn get_session_file_stage(&self) -> Result<Option<SessionFileOrigin>, NativeError> {
         let (tx, rx) = oneshot::channel();
-        self.exec_operation(Api::GetSessionFileStage(tx), rx)
+        self.exec_operation(Api::GetSessionFileOrigin(tx), rx)
             .await?
     }
 

--- a/application/apps/indexer/session/src/state/api.rs
+++ b/application/apps/indexer/session/src/state/api.rs
@@ -379,7 +379,7 @@ impl SessionStateAPI {
         self.exec_operation(Api::FlushSessionFile(tx), rx).await?
     }
 
-    pub async fn get_session_file_stage(&self) -> Result<Option<SessionFileOrigin>, NativeError> {
+    pub async fn get_session_file_origin(&self) -> Result<Option<SessionFileOrigin>, NativeError> {
         let (tx, rx) = oneshot::channel();
         self.exec_operation(Api::GetSessionFileOrigin(tx), rx)
             .await?

--- a/application/apps/indexer/session/src/state/api.rs
+++ b/application/apps/indexer/session/src/state/api.rs
@@ -1,7 +1,7 @@
 use crate::{
     events::NativeError,
     state::{
-        indexes::controller::Mode as IndexesMode, observed::Observed, session_file::GrabbedElement,
+        indexes::controller::Mode as IndexesMode, observed::Observed, session_file::{GrabbedElement, SessionFileStage},
         source_ids::SourceDefinition, values::ValuesError, AttachmentInfo,
     },
     tracker::OperationTrackerAPI,
@@ -28,6 +28,7 @@ pub enum Api {
     GetSessionFile(oneshot::Sender<Result<PathBuf, NativeError>>),
     WriteSessionFile((u8, String, oneshot::Sender<Result<(), NativeError>>)),
     FlushSessionFile(oneshot::Sender<Result<(), NativeError>>),
+    GetSessionFileStage(oneshot::Sender<Result<SessionFileStage, NativeError>>),
     UpdateSession((u8, oneshot::Sender<Result<bool, NativeError>>)),
     AddSource((String, oneshot::Sender<u8>)),
     GetSource((String, oneshot::Sender<Option<u8>>)),
@@ -155,6 +156,7 @@ impl Display for Api {
                 Self::GetSessionFile(_) => "GetSessionFile",
                 Self::WriteSessionFile(_) => "WriteSessionFile",
                 Self::FlushSessionFile(_) => "FlushSessionFile",
+                Self::GetSessionFileStage(_) => "GetSessionFileStage",
                 Self::UpdateSession(_) => "UpdateSession",
                 Self::AddSource(_) => "AddSource",
                 Self::GetSource(_) => "GetSource",
@@ -371,6 +373,12 @@ impl SessionStateAPI {
     pub async fn flush_session_file(&self) -> Result<(), NativeError> {
         let (tx, rx) = oneshot::channel();
         self.exec_operation(Api::FlushSessionFile(tx), rx).await?
+    }
+
+    pub async fn get_session_file_stage(&self) -> Result<SessionFileStage, NativeError> {
+        let (tx, rx) = oneshot::channel();
+        self.exec_operation(Api::GetSessionFileStage(tx), rx)
+            .await?
     }
 
     pub async fn update_session(&self, source_id: u8) -> Result<bool, NativeError> {

--- a/application/apps/indexer/session/src/state/mod.rs
+++ b/application/apps/indexer/session/src/state/mod.rs
@@ -37,7 +37,7 @@ pub use indexes::{
 };
 use observed::Observed;
 use searchers::{SearcherState, Searchers};
-pub use session_file::{GrabbedElement, SessionFile, SessionFileStage, SessionFileState};
+pub use session_file::{GrabbedElement, SessionFile, SessionFileOrigin, SessionFileState};
 pub use source_ids::SourceDefinition;
 pub use values::Values;
 
@@ -408,11 +408,11 @@ pub async fn run(
                     NativeError::channel("Failed to respond to Api::FlushSessionFile")
                 })?;
             }
-            Api::GetSessionFileStage(tx_response) => {
+            Api::GetSessionFileOrigin(tx_response) => {
                 tx_response
-                    .send(Ok(state.session_file.stage.clone()))
+                    .send(Ok(state.session_file.filename.clone()))
                     .map_err(|_| {
-                        NativeError::channel("Failed to respond to Api::GetSessionFileStage")
+                        NativeError::channel("Failed to respond to Api::GetSessionFileOrigin")
                     })?;
             }
             Api::UpdateSession((source_id, tx_response)) => {

--- a/application/apps/indexer/session/src/state/mod.rs
+++ b/application/apps/indexer/session/src/state/mod.rs
@@ -37,7 +37,7 @@ pub use indexes::{
 };
 use observed::Observed;
 use searchers::{SearcherState, Searchers};
-pub use session_file::{GrabbedElement, SessionFile, SessionFileState};
+pub use session_file::{GrabbedElement, SessionFile, SessionFileStage, SessionFileState};
 pub use source_ids::SourceDefinition;
 pub use values::Values;
 
@@ -405,8 +405,15 @@ pub async fn run(
                     )
                     .await;
                 tx_response.send(res).map_err(|_| {
-                    NativeError::channel("Failed to respond to Api::WriteSessionFile")
+                    NativeError::channel("Failed to respond to Api::FlushSessionFile")
                 })?;
+            }
+            Api::GetSessionFileStage(tx_response) => {
+                tx_response
+                    .send(Ok(state.session_file.stage.clone()))
+                    .map_err(|_| {
+                        NativeError::channel("Failed to respond to Api::GetSessionFileStage")
+                    })?;
             }
             Api::UpdateSession((source_id, tx_response)) => {
                 let res = state

--- a/application/apps/indexer/session/src/state/session_file.rs
+++ b/application/apps/indexer/session/src/state/session_file.rs
@@ -60,8 +60,6 @@ pub struct SessionFile {
     pub writer: Option<BufWriter<File>>,
     pub last_message_timestamp: Instant,
     pub sources: SourceIDs,
-    /// true - if session file is a single text file, which user opens; false - *.session file, which was created
-    /// to collect decoded content or if concat
     pub stage: SessionFileStage,
 }
 

--- a/application/client/src/app/service/session/dependencies/observing/implementations/files.ts
+++ b/application/client/src/app/service/session/dependencies/observing/implementations/files.ts
@@ -120,7 +120,10 @@ export class Provider extends Base {
         if (active !== undefined) {
             return new Error(`Cannot attach new source while file is tailing`);
         }
-        const single = this._sources.find((s) => {
+        if (this._sources.length !== 1) {
+            return undefined;
+        }
+        const singleTextFile = this._sources.find((s) => {
             const file = s.observe.origin.as<$.Origin.File.Configuration>(
                 $.Origin.File.Configuration,
             );
@@ -132,7 +135,7 @@ export class Provider extends Base {
             }
             return false;
         });
-        if (single !== undefined) {
+        if (singleTextFile !== undefined) {
             return new Error(
                 `Single file has been opened. In this case you cannot attach new source(s).`,
             );

--- a/application/client/src/app/ui/tabs/multiplefiles/styles.less
+++ b/application/client/src/app/ui/tabs/multiplefiles/styles.less
@@ -22,7 +22,7 @@
   & button {
       position: relative;
       display: inline-block;
-      margin: 6px 0 6px 6px;
+      margin: 6px 0 6px 6px!important;
   }
   & div.left {
       position: absolute;

--- a/application/client/src/app/ui/views/sidebar/attachments/template.html
+++ b/application/client/src/app/ui/views/sidebar/attachments/template.html
@@ -4,7 +4,7 @@
     <span class="filler"></span>
     <span class="small-icon-button codicon codicon-checklist" *ngIf="attachments.length > 0" [matMenuTriggerFor]="menu"></span>
 </div>
-<p class="info" *ngIf="filtered.attachments">No attachments has been received</p>
+<p class="info" *ngIf="filtered.attachments.length === 0">No attachments has been received</p>
 <mat-expansion-panel *ngIf="filtered.attachments.length > 0" [hideToggle]="true" [expanded]="true" class="list">
     <mat-expansion-panel-header>
         <mat-panel-title>Received Attachments</mat-panel-title>


### PR DESCRIPTION
- Allows attaching to same session text & binary files after concat operation was done
- Fires error on attempt to attach a file to session with linked session file