### PR TITLE
Remove async_trait crate and use native method

### DIFF
--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -160,17 +160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.39",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,7 +2093,6 @@ name = "sources"
 version = "0.1.0"
 dependencies = [
  "async-stream",
- "async-trait",
  "buf_redux 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "env_logger",

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 async-stream = "0.3"
-async-trait = "0.1"
 buf_redux = "0.8"
 bytes = "1.3"
 etherparse = "0.13"

--- a/application/apps/indexer/sources/src/binary/pcap/legacy.rs
+++ b/application/apps/indexer/sources/src/binary/pcap/legacy.rs
@@ -2,7 +2,6 @@ use crate::{
     binary::pcap::debug_block, ByteSource, Error as SourceError, ReloadInfo, SourceFilter,
     TransportProtocol,
 };
-use async_trait::async_trait;
 use buf_redux::Buffer;
 use log::{debug, error, trace};
 use pcap_parser::{traits::PcapReaderIterator, LegacyPcapReader, PcapBlockOwned, PcapError};
@@ -27,7 +26,6 @@ impl<R: Read> PcapLegacyByteSource<R> {
     }
 }
 
-#[async_trait]
 impl<R: Read + Send + Sync> ByteSource for PcapLegacyByteSource<R> {
     async fn reload(
         &mut self,

--- a/application/apps/indexer/sources/src/binary/pcap/ng.rs
+++ b/application/apps/indexer/sources/src/binary/pcap/ng.rs
@@ -2,7 +2,6 @@ use crate::{
     binary::pcap::debug_block, ByteSource, Error as SourceError, ReloadInfo, SourceFilter,
     TransportProtocol,
 };
-use async_trait::async_trait;
 use buf_redux::Buffer;
 use log::{debug, error, trace};
 use pcap_parser::{traits::PcapReaderIterator, PcapBlockOwned, PcapError, PcapNGReader};
@@ -27,7 +26,6 @@ impl<R: Read> PcapngByteSource<R> {
     }
 }
 
-#[async_trait]
 impl<R: Read + Send + Sync> ByteSource for PcapngByteSource<R> {
     async fn reload(
         &mut self,

--- a/application/apps/indexer/sources/src/binary/raw.rs
+++ b/application/apps/indexer/sources/src/binary/raw.rs
@@ -2,7 +2,6 @@ use crate::{
     ByteSource, Error as SourceError, ReloadInfo, SourceFilter, DEFAULT_MIN_BUFFER_SPACE,
     DEFAULT_READER_CAPACITY,
 };
-use async_trait::async_trait;
 use buf_redux::{policy::MinBuffered, BufReader as ReduxReader};
 use std::io::{BufRead, Read, Seek};
 
@@ -34,7 +33,6 @@ where
     }
 }
 
-#[async_trait]
 impl<R: Read + Send + Sync + Seek> ByteSource for BinaryByteSource<R> {
     async fn reload(
         &mut self,

--- a/application/apps/indexer/sources/src/command/process.rs
+++ b/application/apps/indexer/sources/src/command/process.rs
@@ -1,5 +1,4 @@
 use crate::{sde, ByteSource, Error as SourceError, ReloadInfo, SourceFilter};
-use async_trait::async_trait;
 use buf_redux::Buffer;
 use futures;
 use regex::{Captures, Regex};
@@ -155,7 +154,6 @@ impl ProcessSource {
     }
 }
 
-#[async_trait]
 impl ByteSource for ProcessSource {
     async fn reload(
         &mut self,

--- a/application/apps/indexer/sources/src/lib.rs
+++ b/application/apps/indexer/sources/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(unused_crate_dependencies)]
-use async_trait::async_trait;
 use thiserror::Error;
 
 #[macro_use]
@@ -84,7 +83,6 @@ pub(crate) const DEFAULT_MIN_BUFFER_SPACE: usize = 10 * 1024;
 /// want to extract the data part from certain frames, the `relaod` method will load only the relevant
 /// data into an internal buffer.
 /// This data can then be accessed via the `current_slice` method.
-#[async_trait]
 pub trait ByteSource: Send + Sync {
     /// Indicate that we have consumed a certain amount of data from our internal
     /// buffer and that this part can be discarded

--- a/application/apps/indexer/sources/src/serial/serialport.rs
+++ b/application/apps/indexer/sources/src/serial/serialport.rs
@@ -1,7 +1,6 @@
 use crate::{
     factory::SerialTransportConfig, sde, ByteSource, Error as SourceError, ReloadInfo, SourceFilter,
 };
-use async_trait::async_trait;
 use buf_redux::Buffer;
 use bytes::{BufMut, BytesMut};
 use futures::{
@@ -129,7 +128,6 @@ impl SerialSource {
     }
 }
 
-#[async_trait]
 impl ByteSource for SerialSource {
     async fn reload(
         &mut self,

--- a/application/apps/indexer/sources/src/socket/tcp.rs
+++ b/application/apps/indexer/sources/src/socket/tcp.rs
@@ -1,5 +1,4 @@
 use crate::{ByteSource, Error as SourceError, ReloadInfo, SourceFilter};
-use async_trait::async_trait;
 use buf_redux::Buffer;
 use tokio::net::{TcpStream, ToSocketAddrs};
 
@@ -21,7 +20,6 @@ impl TcpSource {
     }
 }
 
-#[async_trait]
 impl ByteSource for TcpSource {
     async fn reload(
         &mut self,

--- a/application/apps/indexer/sources/src/socket/udp.rs
+++ b/application/apps/indexer/sources/src/socket/udp.rs
@@ -1,5 +1,4 @@
 use crate::{ByteSource, Error as SourceError, ReloadInfo, SourceFilter};
-use async_trait::async_trait;
 use buf_redux::Buffer;
 use indexer_base::config::MulticastInfo;
 use log::trace;
@@ -75,7 +74,6 @@ impl UdpSource {
     }
 }
 
-#[async_trait]
 impl ByteSource for UdpSource {
     async fn reload(
         &mut self,

--- a/application/apps/rustcore/rs-bindings/Cargo.lock
+++ b/application/apps/rustcore/rs-bindings/Cargo.lock
@@ -2485,7 +2485,6 @@ name = "sources"
 version = "0.1.0"
 dependencies = [
  "async-stream",
- "async-trait",
  "buf_redux 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "etherparse",


### PR DESCRIPTION
From Rust1.75 onwards async support was added so we do not need async-trait crate anymore. Removed this crate in this PR and used native async support.

Resolves: #1972 