### PR TITLE
Group shared dependencies with 'workspace.dependencies' 

### DIFF
--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -14,6 +14,28 @@ members = [
     "sources",
 ]
 
+[workspace.dependencies]
+log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+lazy_static = "1.4"
+tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1"
+dlt-core = "0.14"
+crossbeam-channel = "0.5"
+futures = "0.3"
+tokio-util = "0.7"
+buf_redux = "0.8"
+regex = "1"
+grep-regex = "0.1"
+rand = "0.8"
+dirs = "5.0"
+uuid = "1.3"
+grep-searcher = "0.1"
+tempfile = "3.10.0"
+env_logger = "0.10"
+
 # only uncomment when profiling
 # [profile.release]
 # debug = true

--- a/application/apps/indexer/addons/dlt-tools/Cargo.toml
+++ b/application/apps/indexer/addons/dlt-tools/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dlt-core = "0.14"
-futures = "0.3"
+dlt-core.workspace = true
+futures.workspace = true
 indexer_base = { path = "../../indexer_base" }
-log = "0.4.17"
+log.workspace = true
 parsers = { path = "../../parsers" }
 sources = { path = "../../sources" }
-tokio = { version = "1.17", features = ["full"] }
-tokio-util = { version = "0.7", features = ["codec", "net"] }
-tokio-stream = "0.1.5"
+tokio = { workspace = true , features = ["full"] }
+tokio-util = { workspace = true, features = ["codec", "net"] }
+tokio-stream.workspace = true
 
 [dev-dependencies]

--- a/application/apps/indexer/addons/text_grep/Cargo.toml
+++ b/application/apps/indexer/addons/text_grep/Cargo.toml
@@ -10,11 +10,11 @@ path = "src/lib.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-tokio = { version = "1", features = ["full"] }
-buf_redux = "0.8.4"
-tokio-util = "0.7.10"
-tempfile = "3.10.0"
-grep-searcher = "0.1.13"
-grep-regex = "0.1.12"
-thiserror = "1.0.57"
-regex = "1.10.3"
+tokio = { workspace = true, features = ["full"] }
+buf_redux.workspace = true
+tokio-util.workspace = true
+tempfile.workspace = true
+grep-searcher.workspace = true
+grep-regex.workspace = true
+thiserror.workspace = true
+regex.workspace = true

--- a/application/apps/indexer/indexer_base/Cargo.toml
+++ b/application/apps/indexer/indexer_base/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Oliver Mueller <oliver.mueller@esrlabs.com>"]
 edition = "2021"
 
 [dependencies]
-log = "0.4"
-serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0"
+log.workspace = true
+serde = { workspace = true , features = ["derive"] }
+thiserror.workspace = true
 
 [dev-dependencies]

--- a/application/apps/indexer/indexer_cli/Cargo.toml
+++ b/application/apps/indexer/indexer_cli/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 chrono = "0.4"
-dirs = "5.0"
-dlt-core = "0.14"
-env_logger = "0.10"
-futures = "0.3"
+dirs.workspace = true
+dlt-core.workspace = true
+env_logger.workspace = true
+futures.workspace = true
 indexer_base = { path = "../indexer_base" }
 indicatif = "0.17"
-lazy_static = "1.4"
-log = "0.4"
+lazy_static.workspace = true
+log.workspace = true
 dlt-tools = { path = "../addons/dlt-tools" }
 parsers = { path = "../parsers" }
 processor = { path = "../processor" }
@@ -22,8 +22,8 @@ session = { path = "../session" }
 structopt = "0.3"
 rustyline = "11.0"
 sources = { path = "../sources" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tokio = { version = "1.24", features = ["full"] }
-tokio-util = { version = "0.7", features = ["codec", "net"] }
-uuid = "1.3"
+serde = { workspace = true , features = ["derive"] }
+serde_json.workspace = true
+tokio = { workspace = true , features = ["full"] }
+tokio-util = { workspace = true, features = ["codec", "net"] }
+uuid.workspace = true

--- a/application/apps/indexer/merging/Cargo.toml
+++ b/application/apps/indexer/merging/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Oliver Mueller <oliver.mueller@esrlabs.com>"]
 edition = "2021"
 
 [dependencies]
-log = "0.4"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-thiserror = "1.0"
+log.workspace = true
+serde = { workspace = true , features = ["derive"] }
+serde_json.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]

--- a/application/apps/indexer/parsers/Cargo.toml
+++ b/application/apps/indexer/parsers/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2021"
 byteorder = "1.4"
 chrono = "0.4"
 chrono-tz = "0.8"
-dlt-core = "0.14"
+dlt-core.workspace = true
 humantime = "2.1"
-lazy_static = "1.4"
-log = "0.4.17"
+lazy_static.workspace = true
+log.workspace = true
 memchr = "2.4"
-serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0"
-rand = "0.8.5"
+serde = { workspace = true , features = ["derive"] }
+thiserror.workspace = true
+rand.workspace = true
 # someip-messages = { path = "../../../../../someip"}
 someip-messages = { git = "https://github.com/esrlabs/someip" }
 # someip-payload = { path = "../../../../../someip-payload" }

--- a/application/apps/indexer/processor/Cargo.toml
+++ b/application/apps/indexer/processor/Cargo.toml
@@ -8,26 +8,26 @@ edition = "2021"
 bincode = "1.3"
 buf_redux = { git = "https://github.com/DmitryAstafyev/buf_redux.git" }
 bytecount = "0.6"
-futures = "0.3"
-grep-regex = "0.1.8"
-grep-searcher = "0.1.7"
+futures.workspace = true
+grep-regex.workspace = true
+grep-searcher.workspace = true
 indexer_base = { path = "../indexer_base" }
 itertools = "0.10.0"
-lazy_static = "1.4"
-log = "0.4"
+lazy_static.workspace = true
+log.workspace = true
 parsers = { path = "../parsers" }
-regex = "1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-thiserror = "1.0"
-tokio-util = "0.7"
-uuid = { version = "1.3", features = ["serde", "v4"] }
+regex.workspace = true
+serde = { workspace = true , features = ["derive"] }
+serde_json.workspace = true
+thiserror.workspace = true
+tokio-util.workspace = true
+uuid = { workspace = true , features = ["serde", "v4"] }
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }
 pretty_assertions = "1.3"
-rand = "0.8"
-tempfile = "3.3"
+rand.workspace = true
+tempfile.workspace = true
 
 [[bench]]
 name = "map_benchmarks"

--- a/application/apps/indexer/session/Cargo.toml
+++ b/application/apps/indexer/session/Cargo.toml
@@ -6,30 +6,30 @@ edition = "2021"
 
 [dependencies]
 blake3 = "1.3"
-crossbeam-channel = "0.5"
-dirs = "5.0"
-dlt-core = "0.14"
+crossbeam-channel.workspace = true
+dirs.workspace = true
+dlt-core.workspace = true
 envvars = "0.1"
 file-tools = { path = "../addons/file-tools" }
-futures = "0.3"
+futures.workspace = true
 indexer_base = { path = "../indexer_base" }
-lazy_static = "1.4"
-log = "0.4"
+lazy_static.workspace = true
+log.workspace = true
 merging = { path = "../merging" }
 mime_guess = "2.0.4"
 parsers = { path = "../parsers" }
 processor = { path = "../processor" }
 rustc-hash = "1.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true , features = ["derive"] }
+serde_json.workspace = true
 serialport = "4.2.2"
 sources = { path = "../sources" }
-thiserror = "1.0"
-tokio = { version = "1.24", features = ["full"] }
-tokio-stream = "0.1"
-tokio-util = "0.7"
-uuid = { version = "1.3", features = ["serde", "v4"] }
+thiserror.workspace = true
+tokio = { workspace = true , features = ["full"] }
+tokio-stream.workspace = true
+tokio-util.workspace = true
+uuid = { workspace = true , features = ["serde", "v4"] }
 walkdir = "2.3"
 
 [dev-dependencies]
-lazy_static = "1.4"
+lazy_static.workspace = true

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -7,24 +7,24 @@ edition = "2021"
 [dependencies]
 async-stream = "0.3"
 async-trait = "0.1"
-buf_redux = "0.8"
+buf_redux.workspace = true
 bytes = "1.3"
 etherparse = "0.13"
-futures = "0.3"
+futures.workspace = true
 indexer_base = { path = "../indexer_base" }
-log = "0.4"
+log.workspace = true
 parsers = { path = "../parsers" }
 pcap-parser = "0.14"
-thiserror = "1.0"
-tokio = { version = "1.24", features = ["full"] }
+thiserror.workspace = true
+tokio.workspace = true
 tokio-serial = "5.4"
-tokio-stream = "0.1"
-tokio-util = { version = "0.7", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-uuid = { version = "1.3", features = ["serde", "v4"] }
-regex = "1.7"
-lazy_static = "1.4"
+tokio-stream.workspace = true
+tokio-util = { workspace = true , features = ["full"] }
+serde = { workspace = true, features = ["derive"] }
+uuid = { workspace = true , features = ["serde", "v4"] }
+regex.workspace = true
+lazy_static.workspace = true
 shellexpand = "3.0.0"
 
 [dev-dependencies]
-env_logger = "0.10"
+env_logger.workspace = true


### PR DESCRIPTION
Cargo provides the feature [workspace.dependencies](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table) to manage shared dependencies among all libraries sharing the same workspace.

Using this feature I've gathered all shared dependencies with the same major version in `Cargo.toml` file in the `indexer` directory and replaced the specified version for dependencies in all its child-libs.

This refactoring shouldn't change the current dependencies tree because there is no changes in any of `Cargo.lock` files