### PR TITLE
Sessions: Cancel other tasks on operation errors

### DIFF
--- a/application/apps/precompiled/updater/src/env/args.rs
+++ b/application/apps/precompiled/updater/src/env/args.rs
@@ -20,7 +20,10 @@ pub struct Arguments {
     pub app_name: String,
     pub location: PathBuf,
     pub compressed: PathBuf,
+    // `pid` and `ppid` aren't used yet but they can be used to check shutdown status by parent process.
+    #[allow(dead_code)]
     pub pid: Option<usize>,
+    #[allow(dead_code)]
     pub ppid: Option<usize>,
 }
 


### PR DESCRIPTION
This PR makes sure that cancel call will be invoked on the cancellation token instance if running producer returns with an operation error to avoid having the app stuck in `join!()` calls since some tasks like `tail::track()` won't return until cancel is called.

For Example the current Implementation won't show any error message in `indexer_cli` tool if `run_source()` call returns an error because it will be waiting for `tail::track()` to finish, which won't finish in that case until the user closes the session manually, and then at that point the error message will be printed.