### PR TITLE
Core: Use Multiple Parse Results

### DIFF
--- a/application/apps/indexer/addons/dlt-tools/src/lib.rs
+++ b/application/apps/indexer/addons/dlt-tools/src/lib.rs
@@ -51,13 +51,15 @@ pub async fn scan_dlt_ft(
                         canceled = true;
                         break;
                     }
-                    item = tokio_stream::StreamExt::next(&mut stream) => {
-                        match item {
-                            Some((_, item)) => {
+                    items = tokio_stream::StreamExt::next(&mut stream) => {
+                        match items {
+                            Some(items) => {
+                                for (_, item) in items {
                                 if let MessageStreamItem::Item(ParseYield::MessageAndAttachment((_msg, attachment))) = item {
                                     attachments.push(attachment);
                                 } else if let MessageStreamItem::Item(ParseYield::Attachment(attachment)) = item {
                                     attachments.push(attachment);
+                                }
                                 }
                             }
                             _ => {

--- a/application/apps/indexer/addons/dlt-tools/src/lib.rs
+++ b/application/apps/indexer/addons/dlt-tools/src/lib.rs
@@ -55,11 +55,11 @@ pub async fn scan_dlt_ft(
                         match items {
                             Some(items) => {
                                 for (_, item) in items {
-                                if let MessageStreamItem::Item(ParseYield::MessageAndAttachment((_msg, attachment))) = item {
-                                    attachments.push(attachment);
-                                } else if let MessageStreamItem::Item(ParseYield::Attachment(attachment)) = item {
-                                    attachments.push(attachment);
-                                }
+                                    if let MessageStreamItem::Item(ParseYield::MessageAndAttachment((_msg, attachment))) = item {
+                                        attachments.push(attachment);
+                                    } else if let MessageStreamItem::Item(ParseYield::Attachment(attachment)) = item {
+                                        attachments.push(attachment);
+                                    }
                                 }
                             }
                             _ => {

--- a/application/apps/indexer/indexer_cli/src/interactive.rs
+++ b/application/apps/indexer/indexer_cli/src/interactive.rs
@@ -54,18 +54,28 @@ pub(crate) async fn handle_interactive_session(input: Option<PathBuf>) {
                                         println!("received shutdown through future channel");
                                         break;
                                     }
-                                    item = msg_stream.next() => {
-                                        match item {
-                                            Some((_, MessageStreamItem::Item(ParseYield::Message(msg)))) => {
-                                                println!("msg: {msg}");
+                                    items = msg_stream.next() => {
+                                        let items = match items {
+                                            Some(item) => item,
+                                            None => {
+                                                println!("no msg");
+                                                continue;
                                             }
-                                            Some((_, MessageStreamItem::Item(ParseYield::MessageAndAttachment((msg, attachment))))) => {
-                                                println!("msg: {msg}, attachment: {attachment:?}");
+                                        };
+                                        for item in items {
+
+                                            match item {
+                                                (_, MessageStreamItem::Item(ParseYield::Message(msg))) => {
+                                                    println!("msg: {msg}");
+                                                }
+                                                (_, MessageStreamItem::Item(ParseYield::MessageAndAttachment((msg, attachment)))) => {
+                                                    println!("msg: {msg}, attachment: {attachment:?}");
+                                                }
+                                                (_, MessageStreamItem::Item(ParseYield::Attachment(attachment))) => {
+                                                    println!("attachment: {attachment:?}");
+                                                }
+                                                _ => println!("no msg"),
                                             }
-                                            Some((_, MessageStreamItem::Item(ParseYield::Attachment(attachment)))) => {
-                                                println!("attachment: {attachment:?}");
-                                            }
-                                            _ => println!("no msg"),
                                         }
                                     }
                                 }

--- a/application/apps/indexer/indexer_cli/src/main.rs
+++ b/application/apps/indexer/indexer_cli/src/main.rs
@@ -1395,11 +1395,7 @@ async fn detect_messages_type(input: &Path) -> Result<bool, DltParseError> {
             let mut attachment_count = 0usize;
             let mut err_count = 0usize;
             let mut consumed = 0usize;
-            'outer: loop {
-                let items = match msg_stream.next().await {
-                    Some(items) => items,
-                    None => break,
-                };
+            'outer: while let Some(items) = msg_stream.next().await {
                 for item in items {
                     match item {
                         (_, MessageStreamItem::Item(ParseYield::Message(item))) => {
@@ -1446,11 +1442,7 @@ async fn detect_messages_type(input: &Path) -> Result<bool, DltParseError> {
                     let mut err_count = 0usize;
                     let mut consumed = 0usize;
                     let mut skipped_count = 0usize;
-                    'outer: loop {
-                        let items = match msg_stream.next().await {
-                            Some(items) => items,
-                            None => break,
-                        };
+                    'outer: while let Some(items) = msg_stream.next().await {
                         for item in items {
                             match item {
                                 (used, MessageStreamItem::Item(_)) => {
@@ -1490,11 +1482,7 @@ async fn detect_messages_type(input: &Path) -> Result<bool, DltParseError> {
                     let mut err_count = 0usize;
                     let mut consumed = 0usize;
                     let mut skipped_count = 0usize;
-                    'outer: loop {
-                        let items = match msg_stream.next().await {
-                            Some(items) => items,
-                            None => break,
-                        };
+                    'outer: while let Some(items) = msg_stream.next().await {
                         for item in items {
                             match item {
                                 (_, MessageStreamItem::Item(ParseYield::Message(item))) => {
@@ -1547,11 +1535,7 @@ async fn detect_messages_type(input: &Path) -> Result<bool, DltParseError> {
             let mut consumed = 0usize;
             let mut attachment_count = 0usize;
             use std::io::Cursor;
-            'outer: loop {
-                let items = match msg_stream.next().await {
-                    Some(items) => items,
-                    None => break,
-                };
+            'outer: while let Some(items) = msg_stream.next().await {
                 for item in items {
                     match item {
                         (_rest, MessageStreamItem::Item(ParseYield::Message(item))) => {

--- a/application/apps/indexer/parsers/src/dlt/mod.rs
+++ b/application/apps/indexer/parsers/src/dlt/mod.rs
@@ -120,8 +120,8 @@ impl<'m> Parser<FormattableMessage<'m>> for DltParser<'m> {
         &mut self,
         input: &[u8],
         timestamp: Option<u64>,
-    ) -> impl IntoIterator<Item = Result<(usize, Option<ParseYield<FormattableMessage<'m>>>), Error>>
-           + Send {
+    ) -> impl Iterator<Item = Result<(usize, Option<ParseYield<FormattableMessage<'m>>>), Error>>
+    {
         let res = match dlt_message(input, self.filter_config.as_ref(), self.with_storage_header) {
             Ok((rest, dlt_core::parse::ParsedMessage::FilteredOut(_n))) => {
                 let consumed = input.len() - rest.len();
@@ -167,8 +167,7 @@ impl Parser<RangeMessage> for DltRangeParser {
         &mut self,
         input: &[u8],
         _timestamp: Option<u64>,
-    ) -> impl IntoIterator<Item = Result<(usize, Option<ParseYield<RangeMessage>>), Error>> + Send
-    {
+    ) -> impl Iterator<Item = Result<(usize, Option<ParseYield<RangeMessage>>), Error>> {
         let (rest, consumed) = match dlt_consume_msg(input) {
             Ok((rest, consumed)) => (rest, consumed),
             Err(e) => return iter::once(Err(Error::Parse(format!("{e}")))),
@@ -192,8 +191,7 @@ impl Parser<RawMessage> for DltRawParser {
         &mut self,
         input: &[u8],
         _timestamp: Option<u64>,
-    ) -> impl IntoIterator<Item = Result<(usize, Option<ParseYield<RawMessage>>), Error>> + Send
-    {
+    ) -> impl Iterator<Item = Result<(usize, Option<ParseYield<RawMessage>>), Error>> {
         let (rest, consumed) = match dlt_consume_msg(input) {
             Ok((rest, consumed)) => (rest, consumed),
             Err(e) => return iter::once(Err(Error::Parse(format!("{e}")))),

--- a/application/apps/indexer/parsers/src/lib.rs
+++ b/application/apps/indexer/parsers/src/lib.rs
@@ -44,7 +44,7 @@ pub trait Parser<T> {
         &mut self,
         input: &[u8],
         timestamp: Option<u64>,
-    ) -> Result<(usize, Option<ParseYield<T>>), Error>;
+    ) -> Vec<Result<(usize, Option<ParseYield<T>>), Error>>;
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/application/apps/indexer/parsers/src/lib.rs
+++ b/application/apps/indexer/parsers/src/lib.rs
@@ -35,16 +35,16 @@ impl<T> From<T> for ParseYield<T> {
 /// in chipmunk
 pub trait Parser<T> {
     /// take a slice of bytes and try to apply a parser. If the parse was
-    /// successfull, this will yield  the rest of the slice along with `Some(log_message)`
+    /// successful, this will yield the consumed bytes count along with `Some(log_message)`
     ///
     /// if the slice does not have enough bytes, an `Incomplete` error is returned.
     ///
     /// in case we could parse a message but the message was filtered out, `None` is returned
-    fn parse<'a>(
+    fn parse(
         &mut self,
-        input: &'a [u8],
+        input: &[u8],
         timestamp: Option<u64>,
-    ) -> Result<(&'a [u8], Option<ParseYield<T>>), Error>;
+    ) -> Result<(usize, Option<ParseYield<T>>), Error>;
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/application/apps/indexer/parsers/src/lib.rs
+++ b/application/apps/indexer/parsers/src/lib.rs
@@ -44,7 +44,7 @@ pub trait Parser<T> {
         &mut self,
         input: &[u8],
         timestamp: Option<u64>,
-    ) -> Vec<Result<(usize, Option<ParseYield<T>>), Error>>;
+    ) -> impl IntoIterator<Item = Result<(usize, Option<ParseYield<T>>), Error>> + Send;
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/application/apps/indexer/parsers/src/lib.rs
+++ b/application/apps/indexer/parsers/src/lib.rs
@@ -44,7 +44,7 @@ pub trait Parser<T> {
         &mut self,
         input: &[u8],
         timestamp: Option<u64>,
-    ) -> impl IntoIterator<Item = Result<(usize, Option<ParseYield<T>>), Error>> + Send;
+    ) -> impl Iterator<Item = Result<(usize, Option<ParseYield<T>>), Error>>;
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/application/apps/indexer/parsers/src/someip.rs
+++ b/application/apps/indexer/parsers/src/someip.rs
@@ -53,13 +53,13 @@ impl Parser<SomeipLogMessage> for SomeipParser {
         &mut self,
         input: &[u8],
         timestamp: Option<u64>,
-    ) -> Result<(usize, Option<ParseYield<SomeipLogMessage>>), Error> {
+    ) -> Vec<Result<(usize, Option<ParseYield<SomeipLogMessage>>), Error>> {
         let time = timestamp.unwrap_or(0);
         match Message::from_slice(input) {
             Ok(Message::Sd(header, payload)) => {
                 let len = header.message_len();
                 debug!("at {} : SD Message ({} bytes)", time, len);
-                Ok((
+                vec![Ok((
                     if input.len() - len < Header::LENGTH {
                         input.len()
                     } else {
@@ -69,13 +69,13 @@ impl Parser<SomeipLogMessage> for SomeipParser {
                         sd_message_string(&header, &payload),
                         input[..len].to_vec(),
                     ))),
-                ))
+                ))]
             }
 
             Ok(Message::Rpc(header, payload)) => {
                 let len = header.message_len();
                 debug!("at {} : RPC Message ({:?} bytes)", time, len);
-                Ok((
+                vec![Ok((
                     if input.len() - len < Header::LENGTH {
                         input.len()
                     } else {
@@ -85,13 +85,13 @@ impl Parser<SomeipLogMessage> for SomeipParser {
                         rpc_message_string(&header, &payload, &self.model),
                         input[..len].to_vec(),
                     ))),
-                ))
+                ))]
             }
 
             Ok(Message::CookieClient) => {
                 let len = Header::LENGTH;
                 debug!("at {} : MCC Message", time);
-                Ok((
+                vec![Ok((
                     if input.len() - len < Header::LENGTH {
                         input.len()
                     } else {
@@ -101,13 +101,13 @@ impl Parser<SomeipLogMessage> for SomeipParser {
                         String::from("MCC"), // Magic-Cookie-Client
                         input[..len].to_vec(),
                     ))),
-                ))
+                ))]
             }
 
             Ok(Message::CookieServer) => {
                 let len = Header::LENGTH;
                 debug!("at {} : MCS Message", time);
-                Ok((
+                vec![Ok((
                     if input.len() - len < Header::LENGTH {
                         input.len()
                     } else {
@@ -117,13 +117,13 @@ impl Parser<SomeipLogMessage> for SomeipParser {
                         String::from("MCS"), // Magic-Cookie-Server
                         input[..len].to_vec(),
                     ))),
-                ))
+                ))]
             }
 
             Err(e) => {
                 let msg = e.to_string();
                 error!("at {} : {}", time, msg);
-                Err(Error::Parse(msg))
+                vec![Err(Error::Parse(msg))]
             }
         }
     }
@@ -407,7 +407,12 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser
+            .parse(input, None)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
 
         assert_eq!(consumed, input.len());
 
@@ -428,7 +433,12 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser
+            .parse(input, None)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
 
         assert_eq!(consumed, input.len());
 
@@ -449,7 +459,12 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser
+            .parse(input, None)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
 
         assert_eq!(consumed, input.len());
 
@@ -474,7 +489,12 @@ mod test {
         let model = test_model();
 
         let mut parser = SomeipParser { model: Some(model) };
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser
+            .parse(input, None)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
 
         assert_eq!(consumed, input.len());
 
@@ -498,7 +518,12 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser
+            .parse(input, None)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
 
         assert_eq!(consumed, input.len());
 
@@ -524,7 +549,12 @@ mod test {
         let model = test_model();
 
         let mut parser = SomeipParser { model: Some(model) };
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser
+            .parse(input, None)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
 
         assert_eq!(consumed, input.len());
 
@@ -550,7 +580,12 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser
+            .parse(input, None)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
 
         assert_eq!(consumed, input.len());
 
@@ -592,7 +627,12 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser
+            .parse(input, None)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
 
         assert_eq!(consumed, input.len());
 

--- a/application/apps/indexer/parsers/src/someip.rs
+++ b/application/apps/indexer/parsers/src/someip.rs
@@ -59,8 +59,7 @@ impl Parser<SomeipLogMessage> for SomeipParser {
         &mut self,
         input: &[u8],
         timestamp: Option<u64>,
-    ) -> impl IntoIterator<Item = Result<(usize, Option<ParseYield<SomeipLogMessage>>), Error>> + Send
-    {
+    ) -> impl Iterator<Item = Result<(usize, Option<ParseYield<SomeipLogMessage>>), Error>> {
         let time = timestamp.unwrap_or(0);
         match Message::from_slice(input) {
             Ok(Message::Sd(header, payload)) => {
@@ -414,12 +413,7 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser
-            .parse(input, None)
-            .into_iter()
-            .next()
-            .unwrap()
-            .unwrap();
+        let (consumed, message) = parser.parse(input, None).next().unwrap().unwrap();
 
         assert_eq!(consumed, input.len());
 
@@ -440,12 +434,7 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser
-            .parse(input, None)
-            .into_iter()
-            .next()
-            .unwrap()
-            .unwrap();
+        let (consumed, message) = parser.parse(input, None).next().unwrap().unwrap();
 
         assert_eq!(consumed, input.len());
 
@@ -466,12 +455,7 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser
-            .parse(input, None)
-            .into_iter()
-            .next()
-            .unwrap()
-            .unwrap();
+        let (consumed, message) = parser.parse(input, None).next().unwrap().unwrap();
 
         assert_eq!(consumed, input.len());
 
@@ -496,12 +480,7 @@ mod test {
         let model = test_model();
 
         let mut parser = SomeipParser { model: Some(model) };
-        let (consumed, message) = parser
-            .parse(input, None)
-            .into_iter()
-            .next()
-            .unwrap()
-            .unwrap();
+        let (consumed, message) = parser.parse(input, None).next().unwrap().unwrap();
 
         assert_eq!(consumed, input.len());
 
@@ -525,12 +504,7 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser
-            .parse(input, None)
-            .into_iter()
-            .next()
-            .unwrap()
-            .unwrap();
+        let (consumed, message) = parser.parse(input, None).next().unwrap().unwrap();
 
         assert_eq!(consumed, input.len());
 
@@ -556,12 +530,7 @@ mod test {
         let model = test_model();
 
         let mut parser = SomeipParser { model: Some(model) };
-        let (consumed, message) = parser
-            .parse(input, None)
-            .into_iter()
-            .next()
-            .unwrap()
-            .unwrap();
+        let (consumed, message) = parser.parse(input, None).next().unwrap().unwrap();
 
         assert_eq!(consumed, input.len());
 
@@ -587,12 +556,7 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser
-            .parse(input, None)
-            .into_iter()
-            .next()
-            .unwrap()
-            .unwrap();
+        let (consumed, message) = parser.parse(input, None).next().unwrap().unwrap();
 
         assert_eq!(consumed, input.len());
 
@@ -634,12 +598,7 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser
-            .parse(input, None)
-            .into_iter()
-            .next()
-            .unwrap()
-            .unwrap();
+        let (consumed, message) = parser.parse(input, None).next().unwrap().unwrap();
 
         assert_eq!(consumed, input.len());
 

--- a/application/apps/indexer/parsers/src/text.rs
+++ b/application/apps/indexer/parsers/src/text.rs
@@ -1,6 +1,6 @@
 use crate::{Error, LogMessage, ParseYield, Parser};
 use serde::Serialize;
-use std::{fmt, io::Write};
+use std::{fmt, io::Write, iter};
 
 pub struct StringTokenizer {}
 
@@ -31,11 +31,12 @@ where
         &mut self,
         input: &[u8],
         _timestamp: Option<u64>,
-    ) -> Vec<Result<(usize, Option<ParseYield<StringMessage>>), Error>> {
+    ) -> impl IntoIterator<Item = Result<(usize, Option<ParseYield<StringMessage>>), Error>> + Send
+    {
         // TODO: support non-utf8 encodings
         use memchr::memchr;
         if input.is_empty() {
-            return vec![Ok((input.len(), None))];
+            return iter::once(Ok((input.len(), None)));
         }
         let res = if let Some(msg_size) = memchr(b'\n', input) {
             let content = String::from_utf8_lossy(&input[..msg_size]);
@@ -52,7 +53,7 @@ where
             ))
         };
 
-        vec![res]
+        iter::once(res)
     }
 }
 

--- a/application/apps/indexer/parsers/src/text.rs
+++ b/application/apps/indexer/parsers/src/text.rs
@@ -27,25 +27,25 @@ impl Parser<StringMessage> for StringTokenizer
 where
     StringMessage: LogMessage,
 {
-    fn parse<'b>(
+    fn parse(
         &mut self,
-        input: &'b [u8],
+        input: &[u8],
         _timestamp: Option<u64>,
-    ) -> Result<(&'b [u8], Option<ParseYield<StringMessage>>), Error> {
+    ) -> Result<(usize, Option<ParseYield<StringMessage>>), Error> {
         // TODO: support non-utf8 encodings
         use memchr::memchr;
         if input.is_empty() {
-            return Ok((input, None));
+            return Ok((input.len(), None));
         }
         if let Some(msg_size) = memchr(b'\n', input) {
             let content = String::from_utf8_lossy(&input[..msg_size]);
             let string_msg = StringMessage {
                 content: content.to_string(),
             };
-            Ok((&input[msg_size + 1..], Some(string_msg.into())))
+            Ok((msg_size + 1, Some(string_msg.into())))
         } else {
             Ok((
-                &[],
+                input.len(),
                 Some(ParseYield::from(StringMessage {
                     content: String::new(),
                 })),
@@ -58,18 +58,23 @@ where
 fn test_string_tokenizer() {
     let mut parser = StringTokenizer {};
     let content = b"hello\nworld\n";
-    let (rest_1, first_msg) = parser.parse(content, None).unwrap();
+    let (consumed_1, first_msg) = parser.parse(content, None).unwrap();
     match first_msg {
         Some(ParseYield::Message(StringMessage { content })) if content.eq("hello") => {}
         _ => panic!("First message did not match"),
     }
+    let rest_1 = &content[consumed_1..];
     println!("rest_1 = {:?}", String::from_utf8_lossy(rest_1));
-    let (rest_2, second_msg) = parser.parse(rest_1, None).unwrap();
+    let (consumed_2, second_msg) = parser.parse(rest_1, None).unwrap();
     match second_msg {
         Some(ParseYield::Message(StringMessage { content })) if content.eq("world") => {}
         _ => panic!("Second message did not match"),
     }
-    let (rest_3, third_msg) = parser.parse(rest_2, None).unwrap();
-    println!("rest_3 = {:?}", String::from_utf8_lossy(rest_3));
+    let rest_2 = &rest_1[consumed_2..];
+    let (consumed_3, third_msg) = parser.parse(rest_2, None).unwrap();
+    println!(
+        "rest_3 = {:?}",
+        String::from_utf8_lossy(&rest_2[consumed_3..])
+    );
     assert!(third_msg.is_none());
 }

--- a/application/apps/indexer/parsers/src/text.rs
+++ b/application/apps/indexer/parsers/src/text.rs
@@ -31,8 +31,7 @@ where
         &mut self,
         input: &[u8],
         _timestamp: Option<u64>,
-    ) -> impl IntoIterator<Item = Result<(usize, Option<ParseYield<StringMessage>>), Error>> + Send
-    {
+    ) -> impl Iterator<Item = Result<(usize, Option<ParseYield<StringMessage>>), Error>> {
         // TODO: support non-utf8 encodings
         use memchr::memchr;
         if input.is_empty() {
@@ -61,35 +60,20 @@ where
 fn test_string_tokenizer() {
     let mut parser = StringTokenizer {};
     let content = b"hello\nworld\n";
-    let (consumed_1, first_msg) = parser
-        .parse(content, None)
-        .into_iter()
-        .next()
-        .unwrap()
-        .unwrap();
+    let (consumed_1, first_msg) = parser.parse(content, None).next().unwrap().unwrap();
     match first_msg {
         Some(ParseYield::Message(StringMessage { content })) if content.eq("hello") => {}
         _ => panic!("First message did not match"),
     }
     let rest_1 = &content[consumed_1..];
     println!("rest_1 = {:?}", String::from_utf8_lossy(rest_1));
-    let (consumed_2, second_msg) = parser
-        .parse(rest_1, None)
-        .into_iter()
-        .next()
-        .unwrap()
-        .unwrap();
+    let (consumed_2, second_msg) = parser.parse(rest_1, None).next().unwrap().unwrap();
     match second_msg {
         Some(ParseYield::Message(StringMessage { content })) if content.eq("world") => {}
         _ => panic!("Second message did not match"),
     }
     let rest_2 = &rest_1[consumed_2..];
-    let (consumed_3, third_msg) = parser
-        .parse(rest_2, None)
-        .into_iter()
-        .next()
-        .unwrap()
-        .unwrap();
+    let (consumed_3, third_msg) = parser.parse(rest_2, None).next().unwrap().unwrap();
     println!(
         "rest_3 = {:?}",
         String::from_utf8_lossy(&rest_2[consumed_3..])

--- a/application/apps/indexer/processor/src/export/mod.rs
+++ b/application/apps/indexer/processor/src/export/mod.rs
@@ -39,7 +39,7 @@ pub enum ExportError {
 ///
 /// # Errors
 /// In case of cancellation will return ExportError::Cancelled
-pub async fn export_raw<S, T>(
+pub async fn export_raw<S, T, IT>(
     mut s: S,
     destination_path: &Path,
     sections: &Vec<IndexSection>,
@@ -49,7 +49,8 @@ pub async fn export_raw<S, T>(
 ) -> Result<usize, ExportError>
 where
     T: LogMessage + Sized,
-    S: futures::Stream<Item = Vec<(usize, MessageStreamItem<T>)>> + Unpin,
+    S: futures::Stream<Item = IT> + Unpin,
+    IT: Iterator<Item = (usize, MessageStreamItem<T>)>,
 {
     trace!("export_raw, sections: {sections:?}");
     if !sections_valid(sections) {

--- a/application/apps/indexer/processor/src/export/mod.rs
+++ b/application/apps/indexer/processor/src/export/mod.rs
@@ -39,7 +39,7 @@ pub enum ExportError {
 ///
 /// # Errors
 /// In case of cancellation will return ExportError::Cancelled
-pub async fn export_raw<S, T, IT>(
+pub async fn export_raw<S, T, I>(
     mut s: S,
     destination_path: &Path,
     sections: &Vec<IndexSection>,
@@ -49,8 +49,8 @@ pub async fn export_raw<S, T, IT>(
 ) -> Result<usize, ExportError>
 where
     T: LogMessage + Sized,
-    S: futures::Stream<Item = IT> + Unpin,
-    IT: Iterator<Item = (usize, MessageStreamItem<T>)>,
+    S: futures::Stream<Item = I> + Unpin,
+    I: Iterator<Item = (usize, MessageStreamItem<T>)>,
 {
     trace!("export_raw, sections: {sections:?}");
     if !sections_valid(sections) {

--- a/application/apps/indexer/session/src/handlers/export_raw.rs
+++ b/application/apps/indexer/session/src/handlers/export_raw.rs
@@ -189,7 +189,7 @@ async fn export<S: ByteSource>(
     }
 }
 
-pub async fn export_runner<S, T>(
+pub async fn export_runner<S, T, IT>(
     s: S,
     dest: &Path,
     sections: &Vec<IndexSection>,
@@ -199,7 +199,8 @@ pub async fn export_runner<S, T>(
 ) -> Result<Option<usize>, NativeError>
 where
     T: LogMessage + Sized,
-    S: futures::Stream<Item = Vec<(usize, MessageStreamItem<T>)>> + Unpin,
+    S: futures::Stream<Item = IT> + Unpin,
+    IT: Iterator<Item = (usize, MessageStreamItem<T>)>,
 {
     export_raw(s, dest, sections, read_to_end, text_file, cancel)
         .await

--- a/application/apps/indexer/session/src/handlers/export_raw.rs
+++ b/application/apps/indexer/session/src/handlers/export_raw.rs
@@ -189,7 +189,7 @@ async fn export<S: ByteSource>(
     }
 }
 
-pub async fn export_runner<S, T, IT>(
+pub async fn export_runner<S, T, I>(
     s: S,
     dest: &Path,
     sections: &Vec<IndexSection>,
@@ -199,8 +199,8 @@ pub async fn export_runner<S, T, IT>(
 ) -> Result<Option<usize>, NativeError>
 where
     T: LogMessage + Sized,
-    S: futures::Stream<Item = IT> + Unpin,
-    IT: Iterator<Item = (usize, MessageStreamItem<T>)>,
+    S: futures::Stream<Item = I> + Unpin,
+    I: Iterator<Item = (usize, MessageStreamItem<T>)>,
 {
     export_raw(s, dest, sections, read_to_end, text_file, cancel)
         .await

--- a/application/apps/indexer/session/src/handlers/export_raw.rs
+++ b/application/apps/indexer/session/src/handlers/export_raw.rs
@@ -199,7 +199,7 @@ pub async fn export_runner<S, T>(
 ) -> Result<Option<usize>, NativeError>
 where
     T: LogMessage + Sized,
-    S: futures::Stream<Item = (usize, MessageStreamItem<T>)> + Unpin,
+    S: futures::Stream<Item = Vec<(usize, MessageStreamItem<T>)>> + Unpin,
 {
     export_raw(s, dest, sections, read_to_end, text_file, cancel)
         .await

--- a/application/apps/indexer/session/src/handlers/observing/mod.rs
+++ b/application/apps/indexer/session/src/handlers/observing/mod.rs
@@ -24,8 +24,8 @@ use tokio::{
 };
 use tokio_stream::StreamExt;
 
-enum Next<T: LogMessage> {
-    Items(Vec<(usize, MessageStreamItem<T>)>),
+enum Next<T: LogMessage, IT: IntoIterator<Item = (usize, MessageStreamItem<T>)>> {
+    Items(IT),
     Timeout,
     Waiting,
 }

--- a/application/apps/indexer/session/src/handlers/observing/mod.rs
+++ b/application/apps/indexer/session/src/handlers/observing/mod.rs
@@ -24,8 +24,8 @@ use tokio::{
 };
 use tokio_stream::StreamExt;
 
-enum Next<T: LogMessage, IT: IntoIterator<Item = (usize, MessageStreamItem<T>)>> {
-    Items(IT),
+enum Next<T: LogMessage, I: Iterator<Item = (usize, MessageStreamItem<T>)>> {
+    Items(I),
     Timeout,
     Waiting,
 }

--- a/application/apps/indexer/session/src/handlers/observing/mod.rs
+++ b/application/apps/indexer/session/src/handlers/observing/mod.rs
@@ -25,7 +25,7 @@ use tokio::{
 use tokio_stream::StreamExt;
 
 enum Next<T: LogMessage> {
-    Item(MessageStreamItem<T>),
+    Items(Vec<(usize, MessageStreamItem<T>)>),
     Timeout,
     Waiting,
 }
@@ -123,9 +123,9 @@ async fn run_producer<T: LogMessage, P: Parser<T>, S: ByteSource>(
     while let Some(next) = select! {
         next_from_stream = async {
             match timeout(Duration::from_millis(FLUSH_TIMEOUT_IN_MS as u64), stream.next()).await {
-                Ok(item) => {
-                    if let Some((_, item)) = item {
-                        Some(Next::Item(item))
+                Ok(items) => {
+                    if let Some(items) = items {
+                        Some(Next::Items(items))
                     } else {
                         Some(Next::Waiting)
                     }
@@ -136,41 +136,43 @@ async fn run_producer<T: LogMessage, P: Parser<T>, S: ByteSource>(
         _ = cancel.cancelled() => None,
     } {
         match next {
-            Next::Item(item) => {
-                match item {
-                    MessageStreamItem::Item(ParseYield::Message(item)) => {
-                        state
-                            .write_session_file(source_id, format!("{item}\n"))
-                            .await?;
-                    }
-                    MessageStreamItem::Item(ParseYield::MessageAndAttachment((
-                        item,
-                        attachment,
-                    ))) => {
-                        state
-                            .write_session_file(source_id, format!("{item}\n"))
-                            .await?;
-                        state.add_attachment(attachment)?;
-                    }
-                    MessageStreamItem::Item(ParseYield::Attachment(attachment)) => {
-                        state.add_attachment(attachment)?;
-                    }
-                    MessageStreamItem::Done => {
-                        trace!("observe, message stream is done");
-                        state.flush_session_file().await?;
-                        state.file_read().await?;
-                    }
-                    // MessageStreamItem::FileRead => {
-                    //     state.file_read().await?;
-                    // }
-                    MessageStreamItem::Skipped => {
-                        trace!("observe: skipped a message");
-                    }
-                    MessageStreamItem::Incomplete => {
-                        trace!("observe: incomplete message");
-                    }
-                    MessageStreamItem::Empty => {
-                        trace!("observe: empty message");
+            Next::Items(items) => {
+                for (_, item) in items {
+                    match item {
+                        MessageStreamItem::Item(ParseYield::Message(item)) => {
+                            state
+                                .write_session_file(source_id, format!("{item}\n"))
+                                .await?;
+                        }
+                        MessageStreamItem::Item(ParseYield::MessageAndAttachment((
+                            item,
+                            attachment,
+                        ))) => {
+                            state
+                                .write_session_file(source_id, format!("{item}\n"))
+                                .await?;
+                            state.add_attachment(attachment)?;
+                        }
+                        MessageStreamItem::Item(ParseYield::Attachment(attachment)) => {
+                            state.add_attachment(attachment)?;
+                        }
+                        MessageStreamItem::Done => {
+                            trace!("observe, message stream is done");
+                            state.flush_session_file().await?;
+                            state.file_read().await?;
+                        }
+                        // MessageStreamItem::FileRead => {
+                        //     state.file_read().await?;
+                        // }
+                        MessageStreamItem::Skipped => {
+                            trace!("observe: skipped a message");
+                        }
+                        MessageStreamItem::Incomplete => {
+                            trace!("observe: incomplete message");
+                        }
+                        MessageStreamItem::Empty => {
+                            trace!("observe: empty message");
+                        }
                     }
                 }
             }

--- a/application/apps/indexer/sources/src/producer.rs
+++ b/application/apps/indexer/sources/src/producer.rs
@@ -128,8 +128,7 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
                 .parser
                 .parse(self.byte_source.current_slice(), self.last_seen_ts)
             {
-                Ok((rest, Some(m))) => {
-                    let consumed = available - rest.len();
+                Ok((consumed, Some(m))) => {
                     let total_used_bytes = consumed + skipped_bytes;
                     debug!(
                         "Extracted a valid message, consumed {} bytes (total used {} bytes)",
@@ -138,8 +137,7 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
                     self.byte_source.consume(consumed);
                     return Some((total_used_bytes, MessageStreamItem::Item(m)));
                 }
-                Ok((rest, None)) => {
-                    let consumed = available - rest.len();
+                Ok((consumed, None)) => {
                     self.byte_source.consume(consumed);
                     trace!("None, consumed {} bytes", consumed);
                     let total_used_bytes = consumed + skipped_bytes;

--- a/application/apps/indexer/sources/src/producer.rs
+++ b/application/apps/indexer/sources/src/producer.rs
@@ -133,7 +133,6 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
             let parse_results: Vec<_> = self
                 .parser
                 .parse(self.byte_source.current_slice(), self.last_seen_ts)
-                .into_iter()
                 .collect();
 
             let res_len = parse_results.len();

--- a/application/apps/indexer/sources/src/producer.rs
+++ b/application/apps/indexer/sources/src/producer.rs
@@ -213,16 +213,14 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
                         }
                     }
                 }
-                if call_parse {
-                    //TODO AAZ: This is needed while the implementation only
-                    assert!(results.is_empty());
-                } else {
-                    if results.is_empty() {
-                        return None;
-                    } else {
-                        return Some(results);
-                    }
-                }
+            }
+            if call_parse {
+                //TODO AAZ: This is needed while the implementation only
+                assert!(results.is_empty());
+            } else if results.is_empty() {
+                return None;
+            } else {
+                return Some(results);
             }
         }
 

--- a/application/apps/indexer/sources/src/producer.rs
+++ b/application/apps/indexer/sources/src/producer.rs
@@ -128,9 +128,11 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
                 self.done = true;
                 return Some(vec![(0, MessageStreamItem::Done)]);
             }
-            let parse_results = self
+            let parse_results: Vec<_> = self
                 .parser
-                .parse(self.byte_source.current_slice(), self.last_seen_ts);
+                .parse(self.byte_source.current_slice(), self.last_seen_ts)
+                .into_iter()
+                .collect();
 
             let res_len = parse_results.len();
 

--- a/application/apps/indexer/sources/src/producer.rs
+++ b/application/apps/indexer/sources/src/producer.rs
@@ -54,12 +54,10 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
     }
     /// create a stream of pairs that contain the count of all consumed bytes and the
     /// MessageStreamItem
-    pub fn as_stream(&mut self) -> impl Stream<Item = (usize, MessageStreamItem<T>)> + '_ {
+    pub fn as_stream(&mut self) -> impl Stream<Item = Vec<(usize, MessageStreamItem<T>)>> + '_ {
         stream! {
             while let Some(items) = self.read_next_segment().await {
-                for item in items {
-                    yield item;
-                }
+                yield items;
             }
         }
     }

--- a/application/apps/indexer/sources/src/producer.rs
+++ b/application/apps/indexer/sources/src/producer.rs
@@ -34,6 +34,7 @@ where
     total_skipped: usize,
     done: bool,
     rx_sde: Option<SdeReceiver>,
+    start: std::time::Instant,
 }
 
 impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
@@ -50,6 +51,7 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
             total_skipped: 0,
             done: false,
             rx_sde,
+            start: std::time::Instant::now(),
         }
     }
     /// create a stream of pairs that contain the count of all consumed bytes and the
@@ -69,6 +71,10 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
     ) -> Option<impl Iterator<Item = (usize, MessageStreamItem<T>)>> {
         if self.done {
             debug!("done...no next segment");
+            println!(
+                "\x1b[93mmessage producer took : {:?}\x1b[0m",
+                self.start.elapsed()
+            );
             return None;
         }
         self.index += 1;
@@ -209,6 +215,10 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
                             } else {
                                 let unused = skipped_bytes + available;
                                 self.done = true;
+                                println!(
+                                    "\x1b[93mmessage producer took : {:?}. But ended with parse error\x1b[0m",
+                                    self.start.elapsed()
+                                );
                                 return Some(vec![(unused, MessageStreamItem::Done)].into_iter());
                             }
                         }

--- a/application/apps/indexer/sources/src/producer.rs
+++ b/application/apps/indexer/sources/src/producer.rs
@@ -214,14 +214,14 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
                     }
                 }
                 if call_parse {
+                    //TODO AAZ: This is needed while the implementation only
                     assert!(results.is_empty());
-                    continue;
-                }
-
-                if results.is_empty() {
-                    return None;
                 } else {
-                    return Some(results);
+                    if results.is_empty() {
+                        return None;
+                    } else {
+                        return Some(results);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR is a work of progress and currently blocked by #2045 

As preparation for the plugins system, we need to change the parser trait signature and the producer stream to return multiple parse results at once instead of returning them one by one. 
The idea behind that to let the parsers plugins parse all the available bytes and return all the results to the host at once.

The changes include:
- `Parser::parse()` returns `impl IntoIter<Item = ParseResult> + Send` to avoid affect the performance of current parsers, because we can use `iter::once()` with them, which help the compiler to do more optimization since it knows at compile time that the results are one item only.
- Producer Stream returns a vector of results because there is one possible implementation for it and it's using vectors to store the results.

#### Road Map:
- [x] Change `Parser::parse()` and `Producer::as_stream()` signatures to return multiple results ate once.
- [ ] Make sure all parsers stop on the first potential error they encounter.
- [ ] Cover all edge cases with unit-tests after #2045 is merged
- [ ] Apply benchmarks on the this PR to make sure there is no performance loss  