### PR TITLE
Allow nested parsers on MessageProducer level

### DIFF
--- a/application/apps/indexer/addons/dlt-tools/src/lib.rs
+++ b/application/apps/indexer/addons/dlt-tools/src/lib.rs
@@ -37,7 +37,7 @@ pub async fn scan_dlt_ft(
             let reader = BufReader::new(&input);
             let source = BinaryByteSource::new(reader);
             let parser = DltParser::new(filter.map(|f| f.into()), None, None, with_storage_header);
-            let mut producer = MessageProducer::new(parser, source, None);
+            let mut producer = MessageProducer::new(parser, source, Vec::new(), None);
             let stream = producer.as_stream();
             pin_mut!(stream);
 

--- a/application/apps/indexer/indexer_cli/src/interactive.rs
+++ b/application/apps/indexer/indexer_cli/src/interactive.rs
@@ -45,7 +45,7 @@ pub(crate) async fn handle_interactive_session(input: Option<PathBuf>) {
                             static RECEIVER: &str = "127.0.0.1:5000";
                             let udp_source = UdpSource::new(RECEIVER, vec![]).await.unwrap();
                             let dlt_parser = DltParser::new(None, None, None, false);
-                            let mut dlt_msg_producer = MessageProducer::new(dlt_parser, udp_source, None);
+                            let mut dlt_msg_producer = MessageProducer::new(dlt_parser, udp_source, Vec::new(), None);
                             let msg_stream = dlt_msg_producer.as_stream();
                             pin_mut!(msg_stream);
                             loop {

--- a/application/apps/indexer/indexer_cli/src/main.rs
+++ b/application/apps/indexer/indexer_cli/src/main.rs
@@ -806,7 +806,7 @@ pub async fn main() -> Result<()> {
             let dlt_parser = DltParser::new(None, None, None, true);
             let reader = BufReader::new(&in_file);
             let source = BinaryByteSource::new(reader);
-            let mut dlt_msg_producer = MessageProducer::new(dlt_parser, source, None);
+            let mut dlt_msg_producer = MessageProducer::new(dlt_parser, source, Vec::new(), None);
             let cancel = CancellationToken::new();
             export_raw(
                 Box::pin(dlt_msg_producer.as_stream()),
@@ -1371,7 +1371,7 @@ async fn count_dlt_messages(input: &Path) -> Result<u64, DltParseError> {
 
         let source = BinaryByteSource::new(second_reader);
 
-        let mut dlt_msg_producer = MessageProducer::new(dlt_parser, source, None);
+        let mut dlt_msg_producer = MessageProducer::new(dlt_parser, source, Vec::new(), None);
         let msg_stream = dlt_msg_producer.as_stream();
         Ok(msg_stream.count().await as u64)
     } else {
@@ -1388,7 +1388,7 @@ async fn detect_messages_type(input: &Path) -> Result<bool, DltParseError> {
             let buf_reader = BufReader::new(fs::File::open(input)?);
             let source = BinaryByteSource::new(buf_reader);
             let dlt_parser = DltRangeParser::new();
-            let mut dlt_msg_producer = MessageProducer::new(dlt_parser, source, None);
+            let mut dlt_msg_producer = MessageProducer::new(dlt_parser, source, Vec::new(), None);
             let msg_stream = dlt_msg_producer.as_stream();
             pin_mut!(msg_stream);
             let mut item_count = 0usize;
@@ -1434,7 +1434,8 @@ async fn detect_messages_type(input: &Path) -> Result<bool, DltParseError> {
             let some_parser = SomeipParser::new();
             match PcapngByteSource::new(fs::File::open(input)?) {
                 Ok(source) => {
-                    let mut some_msg_producer = MessageProducer::new(some_parser, source, None);
+                    let mut some_msg_producer =
+                        MessageProducer::new(some_parser, source, Vec::new(), None);
                     let msg_stream = some_msg_producer.as_stream();
                     pin_mut!(msg_stream);
                     let mut item_count = 0usize;
@@ -1473,7 +1474,8 @@ async fn detect_messages_type(input: &Path) -> Result<bool, DltParseError> {
             // let buf_reader = BufReader::new(fs::File::open(&input)?);
             match PcapngByteSource::new(fs::File::open(input)?) {
                 Ok(source) => {
-                    let mut dlt_msg_producer = MessageProducer::new(dlt_parser, source, None);
+                    let mut dlt_msg_producer =
+                        MessageProducer::new(dlt_parser, source, Vec::new(), None);
                     let msg_stream = dlt_msg_producer.as_stream();
                     pin_mut!(msg_stream);
                     let mut item_count = 0usize;
@@ -1525,7 +1527,7 @@ async fn detect_messages_type(input: &Path) -> Result<bool, DltParseError> {
             let txt_parser = StringTokenizer {};
             let buf_reader = BufReader::new(fs::File::open(input)?);
             let source = BinaryByteSource::new(buf_reader);
-            let mut txt_msg_producer = MessageProducer::new(txt_parser, source, None);
+            let mut txt_msg_producer = MessageProducer::new(txt_parser, source, Vec::new(), None);
             let msg_stream = txt_msg_producer.as_stream();
             pin_mut!(msg_stream);
             let mut item_count = 0usize;

--- a/application/apps/indexer/parsers/src/lib.rs
+++ b/application/apps/indexer/parsers/src/lib.rs
@@ -8,6 +8,15 @@ use thiserror::Error;
 
 extern crate log;
 
+#[derive(Debug)]
+pub enum ParserKind {
+    SomeIp(someip::SomeipParser),
+}
+
+pub enum ParserAlias {
+    SomeIp,
+}
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Parse error: {0}")]
@@ -44,6 +53,7 @@ pub trait Parser<T> {
         &mut self,
         input: &'a [u8],
         timestamp: Option<u64>,
+        nested: impl FnMut(&'a [u8], ParserAlias) -> Option<String>,
     ) -> Result<(&'a [u8], Option<ParseYield<T>>), Error>;
 }
 

--- a/application/apps/indexer/parsers/src/someip.rs
+++ b/application/apps/indexer/parsers/src/someip.rs
@@ -1,4 +1,4 @@
-use crate::{Error, LogMessage, ParseYield, Parser};
+use crate::{Error, LogMessage, ParseYield, Parser, ParserAlias};
 use std::{borrow::Cow, fmt, fmt::Display, io::Write, path::PathBuf};
 
 use someip_messages::*;
@@ -12,6 +12,7 @@ use log::{debug, error};
 use serde::Serialize;
 
 /// A parser for SOME/IP log messages.
+#[derive(Debug)]
 pub struct SomeipParser {
     model: Option<FibexModel>,
 }
@@ -53,6 +54,7 @@ impl Parser<SomeipLogMessage> for SomeipParser {
         &mut self,
         input: &'a [u8],
         timestamp: Option<u64>,
+        _nested: impl FnMut(&'a [u8], ParserAlias) -> Option<String>,
     ) -> Result<(&'a [u8], Option<ParseYield<SomeipLogMessage>>), Error> {
         let time = timestamp.unwrap_or(0);
         match Message::from_slice(input) {
@@ -407,7 +409,11 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (output, message) = parser.parse(input, None).unwrap();
+        let (output, message) = parser
+            .parse(input, None, |_: &[u8], _: ParserAlias| -> Option<String> {
+                None
+            })
+            .unwrap();
 
         assert!(output.is_empty());
 
@@ -428,7 +434,11 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (output, message) = parser.parse(input, None).unwrap();
+        let (output, message) = parser
+            .parse(input, None, |_: &[u8], _: ParserAlias| -> Option<String> {
+                None
+            })
+            .unwrap();
 
         assert!(output.is_empty());
 
@@ -449,7 +459,11 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (output, message) = parser.parse(input, None).unwrap();
+        let (output, message) = parser
+            .parse(input, None, |_: &[u8], _: ParserAlias| -> Option<String> {
+                None
+            })
+            .unwrap();
 
         assert!(output.is_empty());
 
@@ -474,7 +488,11 @@ mod test {
         let model = test_model();
 
         let mut parser = SomeipParser { model: Some(model) };
-        let (output, message) = parser.parse(input, None).unwrap();
+        let (output, message) = parser
+            .parse(input, None, |_: &[u8], _: ParserAlias| -> Option<String> {
+                None
+            })
+            .unwrap();
 
         assert!(output.is_empty());
 
@@ -498,7 +516,11 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (output, message) = parser.parse(input, None).unwrap();
+        let (output, message) = parser
+            .parse(input, None, |_: &[u8], _: ParserAlias| -> Option<String> {
+                None
+            })
+            .unwrap();
 
         assert!(output.is_empty());
 
@@ -524,7 +546,11 @@ mod test {
         let model = test_model();
 
         let mut parser = SomeipParser { model: Some(model) };
-        let (output, message) = parser.parse(input, None).unwrap();
+        let (output, message) = parser
+            .parse(input, None, |_: &[u8], _: ParserAlias| -> Option<String> {
+                None
+            })
+            .unwrap();
 
         assert!(output.is_empty());
 
@@ -550,7 +576,11 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (output, message) = parser.parse(input, None).unwrap();
+        let (output, message) = parser
+            .parse(input, None, |_: &[u8], _: ParserAlias| -> Option<String> {
+                None
+            })
+            .unwrap();
 
         assert!(output.is_empty());
 
@@ -592,7 +622,11 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (output, message) = parser.parse(input, None).unwrap();
+        let (output, message) = parser
+            .parse(input, None, |_: &[u8], _: ParserAlias| -> Option<String> {
+                None
+            })
+            .unwrap();
 
         assert!(output.is_empty());
 

--- a/application/apps/indexer/processor/src/text_source.rs
+++ b/application/apps/indexer/processor/src/text_source.rs
@@ -258,7 +258,7 @@ impl TextFileSource {
         file_part: &FilePart,
     ) -> Result<Vec<String>, GrabError> {
         Ok(String::from_utf8_lossy(read_buf)
-            .split(|c| c == '\n')
+            .split('\n')
             .take(file_part.total_lines - file_part.lines_to_drop)
             .skip(file_part.lines_to_skip)
             .map(|s| s.to_string())

--- a/application/apps/indexer/session/src/handlers/export_raw.rs
+++ b/application/apps/indexer/session/src/handlers/export_raw.rs
@@ -144,7 +144,7 @@ async fn export<S: ByteSource>(
             } else {
                 SomeipParser::new()
             };
-            let mut producer = MessageProducer::new(parser, source, None);
+            let mut producer = MessageProducer::new(parser, source, Vec::new(), None);
             export_runner(
                 Box::pin(producer.as_stream()),
                 dest,
@@ -163,7 +163,7 @@ async fn export<S: ByteSource>(
                 fmt_options.as_ref(),
                 settings.with_storage_header,
             );
-            let mut producer = MessageProducer::new(parser, source, None);
+            let mut producer = MessageProducer::new(parser, source, Vec::new(), None);
             export_runner(
                 Box::pin(producer.as_stream()),
                 dest,
@@ -175,7 +175,7 @@ async fn export<S: ByteSource>(
             .await
         }
         ParserType::Text => {
-            let mut producer = MessageProducer::new(StringTokenizer {}, source, None);
+            let mut producer = MessageProducer::new(StringTokenizer {}, source, Vec::new(), None);
             export_runner(
                 Box::pin(producer.as_stream()),
                 dest,


### PR DESCRIPTION
This PR isn't for to be merged. It's a suggestion in the scope of work on #2073 

## Solution limitations:
- only parsers without lifetime can be included as nested parsers (for example DLT parser cannot be nested)

Recreated from #2074 