### PR TITLE
Build CLI: Activate distribution on test release

### DIFF
--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -111,23 +111,22 @@ jobs:
           release-tag: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # No need for this while testing.
-  # invoke_package_distribution:
-  #   name: Invoke chipmunk package creation and distribution for different package managers
-  #   needs: build_release
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout chipmunk-distribution
-  #       uses: actions/checkout@v2
-  #       with:
-  #         repository: esrlabs/chipmunk-distribution
-  #         path: './chipmunk-distribution'
-  #         token: ${{secrets.PUSH_TOKEN}}
-  #     - name: Push tag
-  #       working-directory: ./chipmunk-distribution
-  #       run: |
-  #         git config user.name "esrlabs"
-  #         git config user.email "esrlabs@gmail.com"
-  #         git remote set-url origin "https://esrlabs:${{secrets.PUSH_TOKEN}}@github.com/esrlabs/chipmunk-distribution"
-  #         git tag ${{ github.ref_name }}
-  #         git push origin ${{ github.ref_name }}
+  invoke_package_distribution:
+    name: Invoke chipmunk package creation and distribution for different package managers
+    needs: build_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout chipmunk-distribution
+        uses: actions/checkout@v2
+        with:
+          repository: esrlabs/chipmunk-distribution
+          path: './chipmunk-distribution'
+          token: ${{secrets.PUSH_TOKEN}}
+      - name: Push tag
+        working-directory: ./chipmunk-distribution
+        run: |
+          git config user.name "esrlabs"
+          git config user.email "esrlabs@gmail.com"
+          git remote set-url origin "https://esrlabs:${{secrets.PUSH_TOKEN}}@github.com/esrlabs/chipmunk-distribution"
+          git tag ${{ github.ref_name }}
+          git push origin ${{ github.ref_name }}


### PR DESCRIPTION
This PR activates the commented-out distribution part of the release.

Now that we've tested the release on our machines successfully, we need to test if it works with the distributions before we replace the current Ruby release with the new Build CLI tool one 