### PR TITLE
Build CLI: More Fixes & Improvements

### DIFF
--- a/application/apps/indexer/processor/src/text_source.rs
+++ b/application/apps/indexer/processor/src/text_source.rs
@@ -258,7 +258,7 @@ impl TextFileSource {
         file_part: &FilePart,
     ) -> Result<Vec<String>, GrabError> {
         Ok(String::from_utf8_lossy(read_buf)
-            .split(|c| c == '\n')
+            .lines()
             .take(file_part.total_lines - file_part.lines_to_drop)
             .skip(file_part.lines_to_skip)
             .map(|s| s.to_string())

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,0 +1,53 @@
+# 0.2.1
+
+## Fixes:
+
+* Disable skip checks for building Chipmunk while creating releases.
+* Fix potential freezes if graceful shutdown fails, by forcing the app to close after a timeout of 4 seconds.
+
+## Changes:
+
+* Deactivate reinstalling TypeScript in production mode after building for local builds, keeping it for creating releases only.
+* Remove `--production` from `Reset-Checksum` sub-command, resetting the scores for both environments since only one can exist at a time.
+
+# 0.2.0
+
+## Fixes:
+
+* Fix dependencies between Rust core and binding targets.
+* Remove false positives in the checksum records when builds run between development and production simultaneously.
+  This has been achieved by resetting the checksums for one environment once the other is built.
+* Fix copying files between `App` and `Client` targets.
+* Add missing copy command for `json.packages` after building the `App` target.
+
+## Changes:
+
+* Logs can no longer be printed to a file using CLI arguments. This can be easily achieved by piping the command output to a file from the shell directly.
+
+## Features:
+
+* Provide release sub-commands to build Chipmunk, bundle, and compress it for use within the GitHub CD pipeline.
+* Provide four UI modes:
+  - **Bars (default):** Displays TUI progress-bars, providing logs at the end for failed jobs only.
+  - **Report:** Displays TUI progress-bars and provides the full logs once all jobs are done.
+  - **Print:** Hides TUI progress-bars, printing the logs of each job once it's done without waiting for other jobs.
+  - **Immediate:** Hides TUI progress-bars, printing each log immediately when produced.
+* Add `fail-fast` flag to stop running jobs once one of them fails, enabled by default for the run command.
+* Implement graceful shutdown to close the spawned jobs gracefully on fail-fast or when `Ctrl-C` is called.
+* Add ANSI terminal colors to log reports.
+* Provide documentation for all modules, generated with the command `cargo doc`.
+
+# 0.1.0
+
+## Features:
+
+* Sub-commands for build, clean, lint, test, and run for Chipmunk's multiple parts.
+* Resolving dependencies upfront and running tasks concurrently when possible.
+* Displays the current progress via TUI progress bars.
+* Provide the option to print logs after all jobs finish, with the option to write these logs to a file as well.
+* Track changes in source code files by saving their checksum scores to skip jobs where no change has been detected.
+* Provide CLI sub-commands to reset the checksum scores to bypass skipping the targets.
+* Provide CLI sub-commands to print the dependencies in `print-dot` format for `Graphviz`.
+* Provide CLI sub-command to generate shell completion for a variety of shells.
+* Check build environment and provide information about it.
+* Provide integration tests in a Python script, which can be used in CI checks for PRs related to this tool.

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cargo-chipmunk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chipmunk"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Ammar Abou Zor <ammar.abou.zor@accenture.com>"]
 edition = "2021"
 description = "CLI Tool for chipmunk application development"

--- a/cli/README.md
+++ b/cli/README.md
@@ -118,6 +118,9 @@ cargo chipmunk shell-completion bash > chipmunk-completion.bash
 ```
 Next, copy the chipmunk-completion.bash file to your bash completion directory (typically  ~/.bash_completion.d/ or /etc/bash_completion.d/).
 
+## Changelogs:
+
+Changelogs can be found [here](CHANGELOG.md)
 
 ## Contributing
 

--- a/cli/integration_tests/release.py
+++ b/cli/integration_tests/release.py
@@ -1,0 +1,45 @@
+"""
+Provides methods to test the Release command in Chipmunk Build CLI Tool.
+"""
+
+from utls import get_root, run_command, print_green_bold, print_blue_bold
+
+
+RELEASE_COMMAND = [
+    "cargo",
+    "run",
+    "-r",
+    "--",
+    "chipmunk",
+    "release",
+]
+
+
+def run_release_command():
+    """Runs release command for Chipmunk. This command will fail if building Chipmunk in release mode fails too."""
+
+    print_blue_bold("Running Release Command...")
+
+    run_command(RELEASE_COMMAND)
+
+    print("Checking if release directory is not empty...")
+
+    release_dir = get_root().joinpath("application/holder/release")
+
+    if not release_dir.exists() or not release_dir.is_dir():
+        raise AssertionError(
+            f"Release Path doesn't exist after release. Path: {release_dir}"
+        )
+
+    if not any(release_dir.iterdir()):
+        raise AssertionError(
+            f"Release Path exists after release but it's empty. Path: {release_dir}"
+        )
+
+    print("Checking release directory Succeeded")
+
+    print_green_bold("*** Check for Release Command Succeeded ***")
+
+
+if __name__ == "__main__":
+    run_release_command()

--- a/cli/integration_tests/run_all.py
+++ b/cli/integration_tests/run_all.py
@@ -12,6 +12,7 @@ from lint import run_lint_command
 from print_dot import run_print_dot_commands
 from shell_compl import run_shell_completion_commands
 from test_cmd import run_test_command
+from release import run_release_command
 
 
 def run_all():
@@ -55,6 +56,14 @@ def run_all():
         run_test_command()
     except Exception:
         print_err("Test")
+        raise
+    print_separator()
+
+    ### Release ###
+    try:
+        run_release_command()
+    except Exception:
+        print_err("Release")
         raise
     print_separator()
 

--- a/cli/src/cli_args.rs
+++ b/cli/src/cli_args.rs
@@ -137,11 +137,7 @@ pub enum Command {
     /// Resets the checksums records what is used to check if there were any code changes for
     /// each target.
     #[clap(visible_alias = "reset")]
-    ResetChecksum {
-        /// Reset release records
-        #[arg(short, long, default_value_t = false)]
-        production: bool,
-    },
+    ResetChecksum,
     /// Generate shell completion for the commands of this tool in the given shell,
     /// printing them to stdout.
     #[clap(visible_alias = "compl")]

--- a/cli/src/job_type.rs
+++ b/cli/src/job_type.rs
@@ -65,8 +65,9 @@ impl JobType {
         }
     }
 
-    /// Returns if the job type is part of the build process (install, build, or after build)
-    pub fn is_part_of_build(&self) -> bool {
+    /// Returns if the job type can be skipped as it is part of the build process
+    /// (install, build, or after build)
+    pub fn can_be_skipped(&self) -> bool {
         match self {
             JobType::Install { .. } | JobType::Build { .. } | JobType::AfterBuild { .. } => true,
             JobType::Clean | JobType::Lint | JobType::Test { .. } | JobType::Run { .. } => false,

--- a/cli/src/jobs_runner/jobs_state.rs
+++ b/cli/src/jobs_runner/jobs_state.rs
@@ -22,21 +22,23 @@ pub struct JobsState {
     cancellation_token: CancellationToken,
     task_tracker: TaskTracker,
     fail_fast: bool,
+    is_app_release: bool,
 }
 
 impl JobsState {
-    fn new(fail_fast: bool) -> Self {
+    fn new(fail_fast: bool, is_app_release: bool) -> Self {
         Self {
             cancellation_token: CancellationToken::new(),
             task_tracker: TaskTracker::new(),
             fail_fast,
+            is_app_release,
         }
     }
 
     /// Provides a reference for [`JobsState`] struct, initializing it with default values
     /// if not initializing before.
     pub fn get() -> &'static JobsState {
-        JOBS_STATE.get_or_init(|| JobsState::new(false))
+        JOBS_STATE.get_or_init(|| JobsState::new(false, false))
     }
 
     /// Initialize jobs state struct setting the fail fast option
@@ -44,9 +46,9 @@ impl JobsState {
     /// # Panics
     /// This function panics if [`JobsState`] already have been initialized or retrieved
     /// before the function call
-    pub fn init(fail_fast: bool) {
+    pub fn init(fail_fast: bool, is_app_release: bool) {
         JOBS_STATE
-            .set(JobsState::new(fail_fast))
+            .set(JobsState::new(fail_fast, is_app_release))
             .expect("Jobs state can't be initialized twice");
     }
 
@@ -79,5 +81,10 @@ impl JobsState {
     /// contain a value before.
     pub fn fail_fast(&self) -> bool {
         self.fail_fast
+    }
+
+    /// Gets if the jobs are running to build and bundles a release of Chipmunk.
+    pub fn is_app_release(&self) -> bool {
+        self.is_app_release
     }
 }

--- a/cli/src/jobs_runner/jobs_state.rs
+++ b/cli/src/jobs_runner/jobs_state.rs
@@ -13,7 +13,7 @@ pub const TIMEOUT_DURATION: Duration = Duration::from_secs(2);
 
 /// Duration to wait after starting the shutdown process, to force the program to exit if it's
 /// still active after the given has passed.
-pub const FORCE_EXIT_DURATION: Duration = Duration::from_secs(2);
+pub const FORCE_EXIT_DURATION: Duration = Duration::from_secs(3);
 
 /// [`JobsState`] singleton
 static JOBS_STATE: OnceLock<JobsState> = OnceLock::new();
@@ -26,7 +26,7 @@ pub struct JobsState {
     cancellation_token: CancellationToken,
     task_tracker: TaskTracker,
     fail_fast: bool,
-    is_app_release: bool,
+    is_release_build: bool,
 }
 
 impl JobsState {
@@ -35,7 +35,7 @@ impl JobsState {
             cancellation_token: CancellationToken::new(),
             task_tracker: TaskTracker::new(),
             fail_fast,
-            is_app_release,
+            is_release_build: is_app_release,
         }
     }
 
@@ -82,8 +82,8 @@ impl JobsState {
             .await
             .is_err()
         {
-            // If task_tracker fails to close here, then it could a dead-lock or another undefined
-            // behavior while closing the running commands.
+            // If task_tracker fails to close here, then it could be a dead-lock or another
+            // undefined behavior while closing the running commands.
             // In this case we wait on other OS thread for couple seconds then force everything
             // to shutdown.
             std::thread::spawn(|| {
@@ -111,8 +111,8 @@ impl JobsState {
         self.fail_fast
     }
 
-    /// Gets if the jobs are running to build and bundles a release of Chipmunk.
-    pub fn is_app_release(&self) -> bool {
-        self.is_app_release
+    /// Determines whether jobs are currently running to build and bundle a release of Chipmunk.
+    pub fn is_release_build(&self) -> bool {
+        self.is_release_build
     }
 }

--- a/cli/src/jobs_runner/mod.rs
+++ b/cli/src/jobs_runner/mod.rs
@@ -167,7 +167,7 @@ fn spawn_jobs(
             continue;
         }
 
-        let skip = if job_def.job_type.is_part_of_build() && !jobs_state.is_app_release() {
+        let skip = if job_def.job_type.can_be_skipped() && !jobs_state.is_release_build() {
             // Skip if any prequel job of this target has failed
             if failed_jobs.contains(&job_def.target) {
                 true

--- a/cli/src/jobs_runner/mod.rs
+++ b/cli/src/jobs_runner/mod.rs
@@ -167,7 +167,7 @@ fn spawn_jobs(
             continue;
         }
 
-        let skip = if job_def.job_type.is_part_of_build() {
+        let skip = if job_def.job_type.is_part_of_build() && !jobs_state.is_app_release() {
             // Skip if any prequel job of this target has failed
             if failed_jobs.contains(&job_def.target) {
                 true

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -99,7 +99,7 @@ async fn main_process(command: Command) -> Result<(), Error> {
             fail_fast,
             ui_mode,
         } => {
-            JobsState::init(fail_fast);
+            JobsState::init(fail_fast, false);
             init_tracker(ui_mode);
             resolve_dev_tools()?;
             let targets = get_targets_or_all(target);
@@ -112,7 +112,7 @@ async fn main_process(command: Command) -> Result<(), Error> {
             fail_fast,
             ui_mode,
         } => {
-            JobsState::init(fail_fast);
+            JobsState::init(fail_fast, false);
             init_tracker(ui_mode);
             resolve_dev_tools()?;
             let targets = get_targets_or_all(target);
@@ -120,7 +120,7 @@ async fn main_process(command: Command) -> Result<(), Error> {
             (JobType::Build { production }, results)
         }
         Command::Clean { target, ui_mode } => {
-            JobsState::init(false);
+            JobsState::init(false, false);
             init_tracker(ui_mode);
             resolve_dev_tools()?;
             let targets = get_targets_or_all(target);
@@ -133,7 +133,7 @@ async fn main_process(command: Command) -> Result<(), Error> {
             fail_fast,
             ui_mode,
         } => {
-            JobsState::init(fail_fast);
+            JobsState::init(fail_fast, false);
             init_tracker(ui_mode);
             resolve_dev_tools()?;
             let targets = get_targets_or_all(target);
@@ -144,7 +144,7 @@ async fn main_process(command: Command) -> Result<(), Error> {
             production,
             no_fail_fast,
         } => {
-            JobsState::init(!no_fail_fast);
+            JobsState::init(!no_fail_fast, false);
             init_tracker(Default::default());
             resolve_dev_tools()?;
             let results = jobs_runner::run(&[Target::App], JobType::Build { production }).await?;
@@ -173,7 +173,7 @@ async fn main_process(command: Command) -> Result<(), Error> {
             fail_fast,
             development,
         } => {
-            JobsState::init(fail_fast);
+            JobsState::init(fail_fast, true);
             let ui_mode = if verbose {
                 UiMode::PrintImmediately
             } else {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -150,16 +150,10 @@ async fn main_process(command: Command) -> Result<(), Error> {
             let results = jobs_runner::run(&[Target::App], JobType::Build { production }).await?;
             (JobType::Run { production }, results)
         }
-        Command::ResetChecksum { production } => {
-            ChecksumRecords::remove_records_file(production)?;
-            println!(
-                "Checksum-Records for {} has been reset",
-                if production {
-                    "production"
-                } else {
-                    "development"
-                }
-            );
+        Command::ResetChecksum => {
+            ChecksumRecords::remove_records_file(false)?;
+            ChecksumRecords::remove_records_file(true)?;
+            println!("Checksum-Records for development and production has been reset",);
 
             return Ok(());
         }

--- a/cli/src/target/mod.rs
+++ b/cli/src/target/mod.rs
@@ -522,7 +522,8 @@ impl Target {
         // That's not an issue, if npm-package is published in npmjs; but we are coping packages manually in a right destination
         // and before copy it, we have to reinstall it to get rid of dev-dependencies.
         let reinstall_res =
-            if JobsState::get().is_app_release() && prod && matches!(self.kind(), TargetKind::Ts) {
+            if JobsState::get().is_release_build() && prod && matches!(self.kind(), TargetKind::Ts)
+            {
                 let node_path = self.cwd().join("node_modules");
                 let remove_log = format!("removing directory {}", node_path.display());
 


### PR DESCRIPTION
## Roadmap:
- [x] Reinstall TS packages in production mode only when the tool is creating a release, deactivating this step for the developer local production runs.
- [x] Never skip any job on release jobs.
- [x] Remove `--production` flag from `reset-checksums` command and reset checksum for both development and production since only one of them can be available at a time.
- [x] Provide integration python test for release command
- [x] Provide an extra safety action for graceful shutdown which will kill the app after 5 seconds from calling the method regardless on the current app state
- [x] Create change log file, providing the changes on each version 

This PR resolves a clippy warning by using `lines()` instead of `split()` with pattern