### PR TITLE
Allow nested parsers on MessageProducer level (v4) 

### DIFF
--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -650,9 +650,8 @@ dependencies = [
 
 [[package]]
 name = "dlt-core"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6fd69a328826e883613fbbcf468a33a53df1198c3e39bae7ad079c449431bfd"
+version = "0.16.0"
+source = "git+https://github.com/kruss/dlt-core.git?branch=dlt_network_traces#525f591862437ca15c56639143f205a956d01b6a"
 dependencies = [
  "buf_redux 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder",
@@ -1686,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.22.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
+checksum = "11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea"
 dependencies = [
  "memchr",
 ]
@@ -2085,12 +2084,12 @@ dependencies = [
 
 [[package]]
 name = "someip-payload"
-version = "0.1.1"
-source = "git+https://github.com/esrlabs/someip-payload#9a58a561a3d284e37a25ea2dc52188c70694682d"
+version = "0.1.3"
+source = "git+https://github.com/kruss/someip-payload.git?branch=robustness#ccd100907b38f60d9e1ac657250111b2e0a69518"
 dependencies = [
  "byteorder",
  "log",
- "quick-xml 0.22.0",
+ "quick-xml 0.23.1",
  "regex",
  "thiserror",
  "ux",

--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -22,7 +22,9 @@ thiserror = "1.0"
 lazy_static = "1.4"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
-dlt-core = "0.14"
+# dlt-core = "0.14"
+# TODO https://github.com/esrlabs/dlt-core/pull/24
+dlt-core = { git = "https://github.com/kruss/dlt-core.git", branch = "dlt_network_traces" }
 crossbeam-channel = "0.5"
 futures = "0.3"
 tokio-util = "0.7"

--- a/application/apps/indexer/parsers/Cargo.toml
+++ b/application/apps/indexer/parsers/Cargo.toml
@@ -18,7 +18,9 @@ rand.workspace = true
 # someip-messages = { path = "../../../../../someip"}
 someip-messages = { git = "https://github.com/esrlabs/someip" }
 # someip-payload = { path = "../../../../../someip-payload" }
-someip-payload = { git = "https://github.com/esrlabs/someip-payload" }
+# someip-payload = { git = "https://github.com/esrlabs/someip-payload" }
+# TODO
+someip-payload = { git = "https://github.com/kruss/someip-payload.git", branch = "robustness" }
 
 [dev-dependencies]
 stringreader = "0.1.1"

--- a/application/apps/indexer/parsers/src/nested_parser.rs
+++ b/application/apps/indexer/parsers/src/nested_parser.rs
@@ -75,16 +75,3 @@ impl ParseRestResolver {
 
 // Ensure the type of given argument is Infallible, raising a compile time error if not.
 fn ensure_infalliable(_err: Infallible) {}
-
-/// Get the text message of [`LogMessage`], resolving its rest payloads if existed when possible,
-/// TODO: Otherwise it should save the error to the faulty messages store, which need to be
-/// implemented as well :)
-pub fn resolve_log_msg<T: LogMessage>(item: T, err_resolver: &mut ParseRestResolver) -> String {
-    match item.try_resolve(Some(err_resolver)) {
-        Ok(item) => item.to_string(),
-        Err(err) => {
-            //TODO: Add error to errors cache.
-            err.parse_lossy()
-        }
-    }
-}

--- a/application/apps/indexer/parsers/src/nested_parser.rs
+++ b/application/apps/indexer/parsers/src/nested_parser.rs
@@ -1,0 +1,90 @@
+use std::convert::Infallible;
+
+use crate::GeneralParseLogError;
+use crate::ParseLogMsgError;
+use crate::ParseLogSeverity;
+use crate::Parser;
+use crate::{someip::SomeipParser, LogMessage, ParseYield, ResolveParseHint};
+
+#[derive(Default)]
+pub struct ParseRestResolver {
+    someip_praser: Option<SomeipParser>,
+}
+
+impl ParseRestResolver {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets SomeIP  parser on the resolver
+    pub fn with_someip_parser(&mut self, someip_praser: SomeipParser) -> &mut Self {
+        self.someip_praser = Some(someip_praser);
+        self
+    }
+
+    /// Tries to resolve the given error returning the parsed string if succeeded.
+    pub fn try_resolve(
+        &mut self,
+        bytes: &[u8],
+        resolve_hint: ResolveParseHint,
+    ) -> Option<Result<String, impl ParseLogMsgError>> {
+        match resolve_hint {
+            ResolveParseHint::SomeIP => {
+                let parser = self.someip_praser.as_mut()?;
+                //TODO: Proper error handling for parser return
+                let p_yield = match parser.parse(bytes, None) {
+                    Ok(res) => res.1?,
+                    Err(err) => {
+                        let err = GeneralParseLogError::from_parser_err(
+                            bytes,
+                            ParseLogSeverity::Error,
+                            err,
+                        );
+
+                        return Some(Err(err));
+                    }
+                };
+                match p_yield {
+                    ParseYield::Message(item) => {
+                        let res = match item.try_resolve(Some(self)) {
+                            Ok(parsed) => parsed,
+                            Err(err) => {
+                                if cfg!(debug_assertions) {
+                                    ensure_infalliable(err);
+                                }
+                                panic!("Infallible Error can't be created")
+                            }
+                        };
+
+                        Some(Ok(res.to_string()))
+                    }
+                    // Ignore other parse types for now
+                    ParseYield::Attachment(_) | ParseYield::MessageAndAttachment(_) => {
+                        let err = GeneralParseLogError::new(
+                            format!("{bytes:?}"),
+                            "Found attachment in nested payload".into(),
+                            ParseLogSeverity::Error,
+                        );
+                        Some(Err(err))
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Ensure the type of given argument is Infallible, raising a compile time error if not.
+fn ensure_infalliable(_err: Infallible) {}
+
+/// Get the text message of [`LogMessage`], resolving its rest payloads if existed when possible,
+/// TODO: Otherwise it should save the error to the faulty messages store, which need to be
+/// implemented as well :)
+pub fn resolve_log_msg<T: LogMessage>(item: T, err_resolver: &mut ParseRestResolver) -> String {
+    match item.try_resolve(Some(err_resolver)) {
+        Ok(item) => item.to_string(),
+        Err(err) => {
+            //TODO: Add error to errors cache.
+            err.parse_lossy()
+        }
+    }
+}

--- a/application/apps/indexer/parsers/src/someip.rs
+++ b/application/apps/indexer/parsers/src/someip.rs
@@ -1,5 +1,11 @@
 use crate::{Error, LogMessage, ParseYield, Parser};
-use std::{borrow::Cow, fmt, fmt::Display, io::Write, path::PathBuf};
+use std::{
+    borrow::Cow,
+    convert::Infallible,
+    fmt::{self, Display},
+    io::Write,
+    path::PathBuf,
+};
 
 use someip_messages::*;
 use someip_payload::{
@@ -325,9 +331,18 @@ impl SomeipLogMessage {
 }
 
 impl LogMessage for SomeipLogMessage {
+    type ParseError = Infallible;
+
     fn to_writer<W: Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
         writer.write_all(&self.bytes)?;
         Ok(self.bytes.len())
+    }
+
+    fn try_resolve(
+        &self,
+        _resolver: Option<&mut crate::nested_parser::ParseRestResolver>,
+    ) -> Result<impl Display, Self::ParseError> {
+        Ok(self)
     }
 }
 

--- a/application/apps/indexer/parsers/src/text.rs
+++ b/application/apps/indexer/parsers/src/text.rs
@@ -1,6 +1,6 @@
 use crate::{Error, LogMessage, ParseYield, Parser};
 use serde::Serialize;
-use std::{fmt, io::Write};
+use std::{convert::Infallible, fmt, io::Write};
 
 pub struct StringTokenizer {}
 
@@ -16,10 +16,19 @@ impl fmt::Display for StringMessage {
 }
 
 impl LogMessage for StringMessage {
+    type ParseError = Infallible;
+
     fn to_writer<W: Write>(&self, writer: &mut W) -> Result<usize, std::io::Error> {
         let len = self.content.len();
         writer.write_all(self.content.as_bytes())?;
         Ok(len)
+    }
+
+    fn try_resolve(
+        &self,
+        _resolver: Option<&mut crate::nested_parser::ParseRestResolver>,
+    ) -> Result<impl fmt::Display, Self::ParseError> {
+        Ok(self)
     }
 }
 

--- a/application/apps/indexer/session/Cargo.toml
+++ b/application/apps/indexer/session/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2021"
 blake3 = "1.3"
 crossbeam-channel.workspace = true
 dirs.workspace = true
-dlt-core.workspace = true
+# dlt-core.workspace = true
+# TODO https://github.com/esrlabs/dlt-core/pull/24
+dlt-core = { git = "https://github.com/kruss/dlt-core.git", branch = "dlt_network_traces", features=["statistics"] }
 envvars = "0.1"
 file-tools = { path = "../addons/file-tools" }
 futures.workspace = true

--- a/application/apps/indexer/session/src/handlers/observing/mod.rs
+++ b/application/apps/indexer/session/src/handlers/observing/mod.rs
@@ -8,10 +8,10 @@ use crate::{
 use log::trace;
 use parsers::{
     dlt::{fmt::FormatOptions, DltParser},
-    nested_parser::{resolve_log_msg, ParseRestResolver},
+    nested_parser::ParseRestResolver,
     someip::SomeipParser,
     text::StringTokenizer,
-    LogMessage, MessageStreamItem, ParseYield, Parser,
+    LogMessage, MessageStreamItem, ParseLogMsgError, ParseYield, Parser,
 };
 use sources::{
     factory::ParserType,
@@ -239,4 +239,17 @@ async fn run_producer<T: LogMessage, P: Parser<T>, S: ByteSource>(
     }
     debug!("listen done");
     Ok(None)
+}
+
+/// Get the text message of [`LogMessage`], resolving its rest payloads if existed when possible,
+/// TODO: Otherwise it should save the error to the faulty messages store, which need to be
+/// implemented as well :)
+pub fn resolve_log_msg<T: LogMessage>(item: T, err_resolver: &mut ParseRestResolver) -> String {
+    match item.try_resolve(Some(err_resolver)) {
+        Ok(item) => item.to_string(),
+        Err(err) => {
+            //TODO: Add error to errors cache.
+            err.parse_lossy()
+        }
+    }
 }

--- a/application/apps/rustcore/rs-bindings/Cargo.lock
+++ b/application/apps/rustcore/rs-bindings/Cargo.lock
@@ -698,9 +698,8 @@ dependencies = [
 
 [[package]]
 name = "dlt-core"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6fd69a328826e883613fbbcf468a33a53df1198c3e39bae7ad079c449431bfd"
+version = "0.16.0"
+source = "git+https://github.com/kruss/dlt-core.git?branch=dlt_network_traces#525f591862437ca15c56639143f205a956d01b6a"
 dependencies = [
  "buf_redux 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder",
@@ -2026,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.22.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
+checksum = "11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea"
 dependencies = [
  "memchr",
 ]
@@ -2476,12 +2475,12 @@ dependencies = [
 
 [[package]]
 name = "someip-payload"
-version = "0.1.1"
-source = "git+https://github.com/esrlabs/someip-payload#9a58a561a3d284e37a25ea2dc52188c70694682d"
+version = "0.1.3"
+source = "git+https://github.com/kruss/someip-payload.git?branch=robustness#ccd100907b38f60d9e1ac657250111b2e0a69518"
 dependencies = [
  "byteorder",
  "log",
- "quick-xml 0.22.0",
+ "quick-xml 0.23.1",
  "regex",
  "thiserror",
  "ux",


### PR DESCRIPTION
This PR isn't for to be merged. It's a suggestion in the scope of work on #2073, #2078 and #2084
It provides the basic implementation for #2071 on parser level.

* The struct `ParseRestResolver` implemented to provide methods to parse a given chunks of bytes with a hint about how to parse those bytes.
* `LogMessage` doesn't implement Display anymore. Instead, it has the method `try_resolve(&self, resolver: Option<&mut ParseRestResolver>) -> Result<impl Display, ...>` to try to parse the message using the provided resolver if possible and returning an error to express the case when parsing fails.
* The trait `ParseLogMsgError` is defined with methods to parse the messages lossy (replace none-parsed bytes with their byte representation), besides the severity of the error and an error message to be used to collect the errors for proper error handling of parse log messages (as mentions in #2071)
* `LogMessage` has and associated error type which implement ParseLogMsgError, giving a chance for parser which never fails to provide Infallible Error type, to tell the compiler that this types will never error for compile time optimizations. Parser that can fail can use the struct `GeneralParseLogError` which implements the trait `ParseLogMsgError`.