### PR TITLE
Benchmark for Producer loop

### DIFF
--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -96,6 +96,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,31 +363,35 @@ dependencies = [
  "atty",
  "bitflags 1.3.2",
  "strsim 0.8.0",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
  "vec_map",
 ]
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
- "bitflags 1.3.2",
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+dependencies = [
+ "anstyle",
  "clap_lex",
- "indexmap",
- "textwrap 0.16.0",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "clipboard-win"
@@ -427,19 +437,20 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "criterion"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
  "anes",
- "atty",
  "cast",
  "ciborium",
- "clap 3.2.25",
+ "clap 4.5.16",
  "criterion-plot",
+ "futures",
+ "is-terminal",
  "itertools",
- "lazy_static",
  "num-traits",
+ "once_cell",
  "oorandom",
  "plotters",
  "rayon",
@@ -448,6 +459,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -959,12 +971,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
@@ -1076,16 +1082,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "uuid",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1437,12 +1433,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "parking_lot"
@@ -2093,6 +2083,7 @@ dependencies = [
  "async-stream",
  "buf_redux 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
+ "criterion",
  "env_logger",
  "etherparse",
  "futures",
@@ -2237,12 +2228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "thiserror"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,7 +2322,7 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "futures-util",
- "hashbrown 0.14.2",
+ "hashbrown",
  "pin-project-lite",
  "slab",
  "tokio",

--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -35,6 +35,8 @@ uuid = "1.3"
 grep-searcher = "0.1"
 tempfile = "3.10.0"
 env_logger = "0.10"
+# Support for `html_reports` needs running the benchmarks via `cargo-criterion` tool.
+criterion = { version = "0.5", features = ["html_reports"] }
 
 # only uncomment when profiling
 # [profile.release]

--- a/application/apps/indexer/processor/Cargo.toml
+++ b/application/apps/indexer/processor/Cargo.toml
@@ -24,7 +24,7 @@ tokio-util.workspace = true
 uuid = { workspace = true , features = ["serde", "v4"] }
 
 [dev-dependencies]
-criterion = { version = "0.4", features = ["html_reports"] }
+criterion.workspace = true
 pretty_assertions = "1.3"
 rand.workspace = true
 tempfile.workspace = true

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -27,3 +27,4 @@ shellexpand = "3.0.0"
 
 [dev-dependencies]
 env_logger.workspace = true
+criterion = { workspace = true, features = ["async_tokio"] }

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -28,3 +28,7 @@ shellexpand = "3.0.0"
 [dev-dependencies]
 env_logger.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
+
+[[bench]]
+name = "producer_benchmarks"
+harness = false

--- a/application/apps/indexer/sources/benches/mocks/mock_parser.rs
+++ b/application/apps/indexer/sources/benches/mocks/mock_parser.rs
@@ -1,0 +1,83 @@
+use std::fmt::Display;
+
+use parsers::{LogMessage, Parser};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy)]
+pub struct MockParser {
+    /// Sets how much bytes each call of [`Parser::parse()`] should consume.
+    consume: usize,
+    /// Sets how many times the method [`Parser::parse()`] will be called before it'll return None.
+    max_count: usize,
+    /// Internal counter to keep track how many times [`Parser::parse()`] has been called.
+    counter: usize,
+}
+
+impl MockParser {
+    /// Creates new instance of the mock parser with the given settings.
+    ///
+    /// * `consume`: Sets how much bytes each call of [`Parser::parse()`] should consume.
+    /// * `max_count`: Sets how many times the method [`Parser::parse()`] will be called before it'll return None.
+    pub fn new(consume: usize, max_count: usize) -> Self {
+        Self {
+            consume,
+            max_count,
+            counter: 0,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+/// Return type of [`Parser::parse()`] method for [`MockParser`]
+pub struct MockMessage {
+    content: String,
+}
+
+impl Display for MockMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.content)
+    }
+}
+
+impl LogMessage for MockMessage {
+    fn to_writer<W: std::io::prelude::Write>(
+        &self,
+        writer: &mut W,
+    ) -> Result<usize, std::io::Error> {
+        let len = self.content.len();
+        writer.write_all(self.content.as_bytes())?;
+        Ok(len)
+    }
+}
+
+impl MockMessage {
+    pub fn new(msg: String) -> Self {
+        Self { content: msg }
+    }
+}
+
+impl From<String> for MockMessage {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Parser<MockMessage> for MockParser {
+    fn parse<'a>(
+        &mut self,
+        input: &'a [u8],
+        _timestamp: Option<u64>,
+    ) -> Result<(&'a [u8], Option<parsers::ParseYield<MockMessage>>), parsers::Error> {
+        if self.counter >= self.max_count {
+            return Err(parsers::Error::Eof);
+        }
+        self.counter += 1;
+
+        let msg = String::from_utf8_lossy(&input[..self.consume]).to_string();
+
+        Ok((
+            &input[..self.consume],
+            Some(parsers::ParseYield::Message(msg.into())),
+        ))
+    }
+}

--- a/application/apps/indexer/sources/benches/mocks/mock_source.rs
+++ b/application/apps/indexer/sources/benches/mocks/mock_source.rs
@@ -1,0 +1,58 @@
+use std::iter;
+
+use async_trait::async_trait;
+use sources::{ByteSource, ReloadInfo};
+
+#[derive(Debug, Clone)]
+pub struct MockByteSource {
+    /// Represent the bytes that will be repeated to fill the internal buffer
+    data_sample: u8,
+    /// Sets how many bytes will be loaded into the internal buffer on each
+    /// [`ByteSource::reload()`] call.
+    load_amount: usize,
+    /// The internal buffer
+    buffer: Vec<u8>,
+}
+
+impl MockByteSource {
+    /// Creates a new instant of [`MockByteSource`]
+    ///
+    /// * `data_sample`: Represent the bytes that will be repeated to fill the internal buffer
+    /// * `load_amount`: Sets how many bytes will be loaded into the internal buffer on
+    /// each [`ByteSource::reload()`] call.
+    pub fn new(data_sample: u8, load_amount: usize) -> Self {
+        Self {
+            data_sample,
+            load_amount,
+            buffer: Vec::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl ByteSource for MockByteSource {
+    fn consume(&mut self, offset: usize) {
+        self.buffer
+            .truncate(self.buffer.len().checked_sub(offset).unwrap())
+    }
+
+    fn current_slice(&self) -> &[u8] {
+        &self.buffer
+    }
+
+    fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    async fn reload(
+        &mut self,
+        _filter: Option<&sources::SourceFilter>,
+    ) -> Result<Option<sources::ReloadInfo>, sources::Error> {
+        self.buffer
+            .extend(iter::repeat(self.data_sample).take(self.load_amount));
+
+        let info = ReloadInfo::new(self.load_amount, self.len(), 0, None);
+
+        Ok(Some(info))
+    }
+}

--- a/application/apps/indexer/sources/benches/mocks/mod.rs
+++ b/application/apps/indexer/sources/benches/mocks/mod.rs
@@ -1,0 +1,2 @@
+pub mod mock_parser;
+pub mod mock_source;

--- a/application/apps/indexer/sources/benches/producer_benchmarks.rs
+++ b/application/apps/indexer/sources/benches/producer_benchmarks.rs
@@ -1,21 +1,106 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::time::Duration;
 
-async fn produce(val: usize, val_2: usize) {
-    //TODO AAZ:
-    assert_eq!(val, val_2);
-}
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use futures::StreamExt;
+use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
+use parsers::{LogMessage, MessageStreamItem};
+use sources::producer::MessageProducer;
 
 mod mocks;
 
+/// Runs Benchmarks replicating the producer loop within Chipmunk sessions, using mocks for
+/// [`parsers::Parser`] and [`sources::ByteSource`] to ensure that the measurements is for the
+/// producer loop only.
+///
+/// NOTE: This benchmark suffers unfortunately from a lot of noise because we are running it with
+/// asynchronous runtime. This test is configured to reduce this amount of noise as possible,
+/// However it would be better to run it multiple time for double checking.
 fn producer_benchmark(c: &mut Criterion) {
-    let val = 1024;
+    let max_parse_calls = 50000;
 
-    c.bench_with_input(BenchmarkId::new("producer", val), &val, |bencher, &v| {
-        bencher
-            .to_async(tokio::runtime::Runtime::new().unwrap())
-            .iter(|| produce(v, v));
-    });
+    c.bench_with_input(
+        BenchmarkId::new("run_producer", max_parse_calls),
+        &(max_parse_calls),
+        |bencher, &max| {
+            bencher
+                // It's important to spawn a new runtime on each run to ensure to reduce the
+                // potential noise produced from one runtime created at the start of all benchmarks
+                // only.
+                .to_async(tokio::runtime::Runtime::new().unwrap())
+                .iter_batched(
+                    || {
+                        // Exclude initiation time from benchmarks.
+                        let parser = MockParser::new(max);
+                        let byte_source = MockByteSource::new();
+                        let producer = MessageProducer::new(parser, byte_source, black_box(None));
+
+                        producer
+                    },
+                    |producer| run_producer(producer),
+                    criterion::BatchSize::SmallInput,
+                )
+        },
+    );
 }
 
-criterion_group!(benches, producer_benchmark);
+/// Creates a message producer from the given arguments, then creates a stream of it and consumes
+/// it, replicating the producer loop inside Chipmunk sessions  
+async fn run_producer<P, B, T>(mut producer: MessageProducer<T, P, B>)
+where
+    P: parsers::Parser<T>,
+    B: sources::ByteSource,
+    T: LogMessage,
+{
+    let s = producer.as_stream();
+    //
+    // using `tokio::pin!()` provided more stable (and faster) benchmarks than
+    // `futures::pin_mut!()`
+    tokio::pin!(s);
+
+    while let Some((_, i)) = s.next().await {
+        match i {
+            MessageStreamItem::Item(item) => match item {
+                parsers::ParseYield::Message(msg) => {
+                    if msg.to_string().is_empty() {
+                        println!("This should never be printed")
+                    }
+                }
+                parsers::ParseYield::Attachment(att) => {
+                    if att.size > 10 {
+                        println!("This should never be printed")
+                    }
+                }
+                parsers::ParseYield::MessageAndAttachment((msg, att)) => {
+                    if msg.to_string().is_empty() || att.size > 10 {
+                        println!("This should never be printed")
+                    }
+                }
+            },
+            MessageStreamItem::Skipped => {
+                println!("This should never be printed")
+            }
+            MessageStreamItem::Incomplete => {
+                println!("This should never be printed")
+            }
+            MessageStreamItem::Empty => println!("This should never be printed"),
+            MessageStreamItem::Done => break,
+        }
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        // Warm up time is very important here because multiple async runtimes will be spawn in
+        // that time which make the next ones to spawn more stable.
+        .warm_up_time(Duration::from_secs(10))
+        // Measurement time and sample sized to role out noise in the measurements as possible.
+        .measurement_time(Duration::from_secs(20))
+        .sample_size(200)
+        // These two values help to reduce the noise level in the results.
+        .significance_level(0.01)
+        .noise_threshold(0.03);
+    targets = producer_benchmark
+}
+
 criterion_main!(benches);

--- a/application/apps/indexer/sources/benches/producer_benchmarks.rs
+++ b/application/apps/indexer/sources/benches/producer_benchmarks.rs
@@ -5,6 +5,8 @@ async fn produce(val: usize, val_2: usize) {
     assert_eq!(val, val_2);
 }
 
+mod mocks;
+
 fn producer_benchmark(c: &mut Criterion) {
     let val = 1024;
 

--- a/application/apps/indexer/sources/benches/producer_benchmarks.rs
+++ b/application/apps/indexer/sources/benches/producer_benchmarks.rs
@@ -1,0 +1,19 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+async fn produce(val: usize, val_2: usize) {
+    //TODO AAZ:
+    assert_eq!(val, val_2);
+}
+
+fn producer_benchmark(c: &mut Criterion) {
+    let val = 1024;
+
+    c.bench_with_input(BenchmarkId::new("producer", val), &val, |bencher, &v| {
+        bencher
+            .to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter(|| produce(v, v));
+    });
+}
+
+criterion_group!(benches, producer_benchmark);
+criterion_main!(benches);

--- a/application/apps/indexer/sources/src/lib.rs
+++ b/application/apps/indexer/sources/src/lib.rs
@@ -1,4 +1,7 @@
-#![deny(unused_crate_dependencies)]
+// TODO AAZ: Write better comment.
+// This can't be used with benchmarks for now until issue "https://github.com/rust-lang/rust/issues/129637" is resolved.
+// #![deny(unused_crate_dependencies)]
+
 use thiserror::Error;
 
 #[macro_use]

--- a/application/apps/indexer/sources/src/lib.rs
+++ b/application/apps/indexer/sources/src/lib.rs
@@ -1,6 +1,5 @@
-// TODO AAZ: Write better comment.
-// This can't be used with benchmarks for now until issue "https://github.com/rust-lang/rust/issues/129637" is resolved.
-// #![deny(unused_crate_dependencies)]
+// Rust can't currently distinguish between dev and none-dev dependencies at the moment. There is
+// an open issue for this case: "https://github.com/rust-lang/rust/issues/129637"
 
 use thiserror::Error;
 


### PR DESCRIPTION
This PR provides a new benchmark for the producer loop with mock structs for `Parser` and `ByteSource`.

This point from this benchmark to have a solid comparison for the producer loop only without the noise of the parsers and the byte sources and all their IO operations. 
However, the noise of the async runtime is noticeable here since the producer loop with mocks parser and byte-source is simple and doesn't have a lot of logic in it, which made the overhead from the runtime unfortunately noticeable.

I've tried to reduce the noise from async runtime as possible by configuring the benchmark and implementing some tricks on the mocks to avoid calling `Future::poll()` on their methods by using and inlining inner functions.
Those changes made the benchmarks fairly stable (Changes normally within 3%), but it would be needed to run the benchmark multiple time to ensure the correctness of the results