### PR TITLE
Build CLI Tool: Remove 'openssl` external dependency  

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -473,8 +473,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
  "url",
 ]
 
@@ -611,24 +609,8 @@ checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -721,24 +703,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "4.4.4", features = ["derive"] }
 console = "0.15.7"
 fs_extra = "1.3.0"
 futures = "0.3.28"
-git2 = "0.18.2"
+git2 = { version = "0.18.2", default-features = false }
 indicatif = "0.17.8"
 tokio = { version = "1.36.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["rt"] }


### PR DESCRIPTION
This PR closes #2089 

Build CLI tool uses `git2` crate to determine Chipmunk root directory only, and for that basic functionality, it doesn't need of the default features on that crate.

Remove the default features also removed the dependency on `openssl` while keeping finding Chipmunk root functionality working as before.