### PR TITLE
Replace async-trait crate with Rust native support

### DIFF
--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -136,17 +136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.59",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,7 +2091,6 @@ name = "sources"
 version = "0.1.0"
 dependencies = [
  "async-stream",
- "async-trait",
  "buf_redux 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "env_logger",

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 async-stream = "0.3"
-async-trait = "0.1"
 buf_redux.workspace = true
 bytes = "1.3"
 etherparse = "0.13"

--- a/application/apps/indexer/sources/src/binary/pcap/legacy.rs
+++ b/application/apps/indexer/sources/src/binary/pcap/legacy.rs
@@ -2,7 +2,6 @@ use crate::{
     binary::pcap::debug_block, ByteSource, Error as SourceError, ReloadInfo, SourceFilter,
     TransportProtocol,
 };
-use async_trait::async_trait;
 use buf_redux::Buffer;
 use log::{debug, error, trace};
 use pcap_parser::{traits::PcapReaderIterator, LegacyPcapReader, PcapBlockOwned, PcapError};
@@ -27,7 +26,6 @@ impl<R: Read> PcapLegacyByteSource<R> {
     }
 }
 
-#[async_trait]
 impl<R: Read + Send + Sync> ByteSource for PcapLegacyByteSource<R> {
     async fn reload(
         &mut self,

--- a/application/apps/indexer/sources/src/binary/pcap/ng.rs
+++ b/application/apps/indexer/sources/src/binary/pcap/ng.rs
@@ -2,7 +2,6 @@ use crate::{
     binary::pcap::debug_block, ByteSource, Error as SourceError, ReloadInfo, SourceFilter,
     TransportProtocol,
 };
-use async_trait::async_trait;
 use buf_redux::Buffer;
 use log::{debug, error, trace};
 use pcap_parser::{traits::PcapReaderIterator, PcapBlockOwned, PcapError, PcapNGReader};
@@ -27,7 +26,6 @@ impl<R: Read> PcapngByteSource<R> {
     }
 }
 
-#[async_trait]
 impl<R: Read + Send + Sync> ByteSource for PcapngByteSource<R> {
     async fn reload(
         &mut self,

--- a/application/apps/indexer/sources/src/binary/raw.rs
+++ b/application/apps/indexer/sources/src/binary/raw.rs
@@ -2,7 +2,6 @@ use crate::{
     ByteSource, Error as SourceError, ReloadInfo, SourceFilter, DEFAULT_MIN_BUFFER_SPACE,
     DEFAULT_READER_CAPACITY,
 };
-use async_trait::async_trait;
 use buf_redux::{policy::MinBuffered, BufReader as ReduxReader};
 use std::io::{BufRead, Read, Seek};
 
@@ -34,7 +33,6 @@ where
     }
 }
 
-#[async_trait]
 impl<R: Read + Send + Sync + Seek> ByteSource for BinaryByteSource<R> {
     async fn reload(
         &mut self,

--- a/application/apps/indexer/sources/src/command/process.rs
+++ b/application/apps/indexer/sources/src/command/process.rs
@@ -1,5 +1,4 @@
 use crate::{sde, ByteSource, Error as SourceError, ReloadInfo, SourceFilter};
-use async_trait::async_trait;
 use buf_redux::Buffer;
 use futures;
 use regex::{Captures, Regex};
@@ -154,7 +153,6 @@ impl ProcessSource {
     }
 }
 
-#[async_trait]
 impl ByteSource for ProcessSource {
     async fn reload(
         &mut self,

--- a/application/apps/indexer/sources/src/lib.rs
+++ b/application/apps/indexer/sources/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(unused_crate_dependencies)]
-use async_trait::async_trait;
 use thiserror::Error;
 
 #[macro_use]
@@ -77,6 +76,8 @@ pub enum Error {
 pub(crate) const DEFAULT_READER_CAPACITY: usize = 10 * 1024 * 1024;
 pub(crate) const DEFAULT_MIN_BUFFER_SPACE: usize = 10 * 1024;
 
+// Warning can be suppressed here because we are using this trait in our own codebase only.
+#[allow(async_fn_in_trait)]
 /// A `ByteSource` provides a way to read data from some underlying data source. But it does
 /// not provide a simple read interface, rather it allows implementations to filter the data
 /// while reading it from it's underlying source.
@@ -84,7 +85,6 @@ pub(crate) const DEFAULT_MIN_BUFFER_SPACE: usize = 10 * 1024;
 /// want to extract the data part from certain frames, the `relaod` method will load only the relevant
 /// data into an internal buffer.
 /// This data can then be accessed via the `current_slice` method.
-#[async_trait]
 pub trait ByteSource: Send + Sync {
     /// Indicate that we have consumed a certain amount of data from our internal
     /// buffer and that this part can be discarded

--- a/application/apps/indexer/sources/src/serial/serialport.rs
+++ b/application/apps/indexer/sources/src/serial/serialport.rs
@@ -1,7 +1,6 @@
 use crate::{
     factory::SerialTransportConfig, sde, ByteSource, Error as SourceError, ReloadInfo, SourceFilter,
 };
-use async_trait::async_trait;
 use buf_redux::Buffer;
 use bytes::{BufMut, BytesMut};
 use futures::{
@@ -131,7 +130,6 @@ impl SerialSource {
     }
 }
 
-#[async_trait]
 impl ByteSource for SerialSource {
     async fn reload(
         &mut self,

--- a/application/apps/indexer/sources/src/socket/tcp.rs
+++ b/application/apps/indexer/sources/src/socket/tcp.rs
@@ -1,5 +1,4 @@
 use crate::{ByteSource, Error as SourceError, ReloadInfo, SourceFilter};
-use async_trait::async_trait;
 use buf_redux::Buffer;
 use tokio::net::{TcpStream, ToSocketAddrs};
 
@@ -21,7 +20,6 @@ impl TcpSource {
     }
 }
 
-#[async_trait]
 impl ByteSource for TcpSource {
     async fn reload(
         &mut self,

--- a/application/apps/indexer/sources/src/socket/udp.rs
+++ b/application/apps/indexer/sources/src/socket/udp.rs
@@ -1,5 +1,4 @@
 use crate::{ByteSource, Error as SourceError, ReloadInfo, SourceFilter};
-use async_trait::async_trait;
 use buf_redux::Buffer;
 use indexer_base::config::MulticastInfo;
 use log::trace;
@@ -75,7 +74,6 @@ impl UdpSource {
     }
 }
 
-#[async_trait]
 impl ByteSource for UdpSource {
     async fn reload(
         &mut self,

--- a/application/apps/rustcore/rs-bindings/Cargo.lock
+++ b/application/apps/rustcore/rs-bindings/Cargo.lock
@@ -2493,7 +2493,6 @@ name = "sources"
 version = "0.1.0"
 dependencies = [
  "async-stream",
- "async-trait",
  "buf_redux 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "etherparse",


### PR DESCRIPTION
This PR replaces the macro `async-trait` for `ByteSource` trait with rust native support for async functions in traits, avoiding the extra heap allocation on the return value that was enforce by the `async-trait` macro.

The warning about async in public traits is suppressed since we are using the trait in our own codebase only.

I've made simple benchmarks on a DLT file with the size 409M and got a slightly better performance:
```md
**Results in Mili-seconds**

# Native Support for async functions in traits:

File Read Took: 8182
File Read Took: 8113
File Read Took: 8225
File Read Took: 7996

** Avg: 8129 MS **
-----------------------------------------------------
# With 'async-trait' crate

File Read Took: 8395
File Read Took: 8258
File Read Took: 8252
File Read Took: 8291

** Avg: 8299 MS ** 
```