### PR TITLE
Up to 3.13.0

### DIFF
--- a/application/client/package.json
+++ b/application/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chipmunk",
-  "version": "3.12.9",
+  "version": "3.13.0",
   "description": "Logs analyzer tool",
   "author": "Dmitry Astafyev",
   "scripts": {

--- a/application/holder/package.json
+++ b/application/holder/package.json
@@ -1,6 +1,6 @@
 {
     "name": "chipmunk",
-    "version": "3.12.9",
+    "version": "3.13.0",
     "chipmunk": {
         "versions": {}
     },

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,19 @@
+# 3.13.0 (19.09.2024)
+
+## Fixes
+- prevent requests to the nearest position (search results) on empty results
+
+## Changes
+- remove "Copy As Formatted Table"
+- apply formatted coping as soon as the render is columns
+
+## Features
+- add support Some/IP messages from DLT payload
+
+## Developing
+- switching build workflow from ruby scripts (rake) to own build CLI module
+- add benchmark tests to keep control of performance
+
 # 3.12.9 (06.06.2024)
 
 ## Fixes


### PR DESCRIPTION
# 3.13.0 (19.09.2024)

## Fixes
- prevent requests to the nearest position (search results) on empty results

## Changes
- remove "Copy As Formatted Table"
- apply formatted coping as soon as the render is columns

## Features
- add support Some/IP messages from DLT payload

## Developing
- switching build workflow from ruby scripts (rake) to own build CLI module
- add benchmark tests to keep control of performance