### PR TITLE
Benchmarks for actual Parsers & Build CLI Integrations  

### DIFF
--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -30,5 +30,21 @@ env_logger.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
 
 [[bench]]
-name = "producer_benchmarks"
+name = "mocks_benchmarks"
+harness = false
+
+[[bench]]
+name = "dlt_producer"
+harness = false
+
+[[bench]]
+name = "someip_producer"
+harness = false
+
+[[bench]]
+name = "someip_legacy_producer"
+harness = false
+
+[[bench]]
+name = "text_producer"
 harness = false

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -30,7 +30,7 @@ env_logger.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
 
 [[bench]]
-name = "mocks_benchmarks"
+name = "mocks_producer"
 harness = false
 
 [[bench]]

--- a/application/apps/indexer/sources/benches/bench_utls.rs
+++ b/application/apps/indexer/sources/benches/bench_utls.rs
@@ -1,0 +1,101 @@
+// Types here are used within benchmarks but rust checking isn't able to connect the module
+// together yet.
+#![allow(unused)]
+
+use std::{
+    fs::File,
+    io::{Cursor, Read},
+    path::PathBuf,
+};
+
+use parsers::{LogMessage, MessageStreamItem};
+use sources::{binary::raw::BinaryByteSource, producer::MessageProducer};
+use tokio_stream::StreamExt;
+
+pub const INPUT_SOURCE_ENV_VAR: &str = "CHIPMUNK_BENCH_FILE";
+pub const CONFIG_ENV_VAR: &str = "CHIPMUNK_BENCH_CONFIG";
+
+/// Retrieves the path of the binary files from the environment variable [`INPUT_SOURCE_ENV_VAR`]
+/// then reads it providing its content as bytes.
+///
+/// # Panic:
+///
+/// This function panics if the environment variables isn't set, file with the path doesn't exist
+/// or can't be read.
+pub fn read_binary() -> &'static [u8] {
+    let input_file = match std::env::var(INPUT_SOURCE_ENV_VAR) {
+        Ok(input) =>PathBuf::from(input),
+        Err(err) => panic!("Error while retrieving input file.\nPlease ensure to provide the path of input file for benchmarks via environment variable: '{INPUT_SOURCE_ENV_VAR}'\n Error Info: {err}"),
+    };
+
+    assert!(input_file.exists(), "Given input file doesn't exist");
+
+    let mut binary = Vec::new();
+
+    let mut file = File::open(input_file).unwrap();
+    file.read_to_end(&mut binary).unwrap();
+
+    binary.leak()
+}
+
+/// Creates [`BinaryByteSource`] with the given bytes.
+pub fn create_binary_bytesource(data: &'static [u8]) -> BinaryByteSource<Cursor<&'static [u8]>> {
+    BinaryByteSource::new(Cursor::new(data))
+}
+
+/// Provide the content of the configuration environment variable [`CONFIG_ENV_VAR`] if exist.
+pub fn get_config() -> Option<String> {
+    std::env::var(CONFIG_ENV_VAR).ok()
+}
+
+#[derive(Debug, Clone, Default)]
+/// Counters the different output possibilities of producer output.
+/// The purpose of this struct is to convince the compiler that we are using all input
+/// possibilities of producer to avoid unwanted optimizations.
+pub struct ProducerCounter {
+    pub msg: usize,
+    pub txt: usize,
+    pub att: usize,
+    pub skipped: usize,
+    pub incomplete: usize,
+    pub empty: usize,
+}
+
+/// Run producer until the end converting messages into strings too, while counting all the
+/// different types of producer outputs to avoid unwanted compiler optimizations.
+pub async fn run_producer<P, B, T>(mut producer: MessageProducer<T, P, B>) -> ProducerCounter
+where
+    P: parsers::Parser<T>,
+    B: sources::ByteSource,
+    T: LogMessage,
+{
+    let mut counter = ProducerCounter::default();
+
+    let s = producer.as_stream();
+    tokio::pin!(s);
+
+    while let Some((_, i)) = s.next().await {
+        match i {
+            MessageStreamItem::Item(item) => match item {
+                parsers::ParseYield::Message(msg) => {
+                    counter.msg += 1;
+                    counter.txt += msg.to_string().len();
+                }
+                parsers::ParseYield::Attachment(att) => counter.att += att.size,
+                parsers::ParseYield::MessageAndAttachment((msg, att)) => {
+                    counter.msg += 1;
+                    counter.txt += msg.to_string().len();
+                    counter.att += att.size;
+                }
+            },
+            MessageStreamItem::Skipped => {
+                counter.skipped += 1;
+            }
+            MessageStreamItem::Incomplete => counter.incomplete += 1,
+            MessageStreamItem::Empty => counter.empty += 1,
+            MessageStreamItem::Done => break,
+        }
+    }
+
+    counter
+}

--- a/application/apps/indexer/sources/benches/bench_utls.rs
+++ b/application/apps/indexer/sources/benches/bench_utls.rs
@@ -12,7 +12,7 @@ use parsers::{LogMessage, MessageStreamItem};
 use sources::{binary::raw::BinaryByteSource, producer::MessageProducer};
 use tokio_stream::StreamExt;
 
-pub const INPUT_SOURCE_ENV_VAR: &str = "CHIPMUNK_BENCH_FILE";
+pub const INPUT_SOURCE_ENV_VAR: &str = "CHIPMUNK_BENCH_SOURCE";
 pub const CONFIG_ENV_VAR: &str = "CHIPMUNK_BENCH_CONFIG";
 
 /// Retrieves the path of the binary files from the environment variable [`INPUT_SOURCE_ENV_VAR`]

--- a/application/apps/indexer/sources/benches/dlt_producer.rs
+++ b/application/apps/indexer/sources/benches/dlt_producer.rs
@@ -1,0 +1,45 @@
+mod bench_utls;
+
+use criterion::{Criterion, *};
+
+use bench_utls::{create_binary_bytesource, get_config, read_binary, run_producer};
+use parsers::dlt::DltParser;
+use sources::producer::MessageProducer;
+
+fn dlt_benchmark(c: &mut Criterion) {
+    let data = read_binary();
+    println!("Data len: {}", data.len());
+    let config = get_config();
+    dbg!(&config);
+
+    c.bench_function("dlt_producer", |bencher| {
+        bencher
+            .to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter_batched(
+                || {
+                    let parser = create_dlt_parser(config.as_deref());
+                    let source = create_binary_bytesource(data);
+                    let producer = MessageProducer::new(parser, source, black_box(None));
+
+                    producer
+                },
+                |p| run_producer(p),
+                // |p| async {
+                //     let a = run_producer(p).await;
+                //     dbg!(a)
+                // },
+                BatchSize::SmallInput,
+            )
+    });
+}
+
+fn create_dlt_parser<'a>(config: Option<&str>) -> DltParser<'a> {
+    //TODO: Consider Configurations
+    let _ = config;
+    DltParser::new(None, None, None, None, false)
+}
+
+//TODO: This is needed to be configured similar to benchmarking with mocking PR.
+criterion_group!(benches, dlt_benchmark);
+
+criterion_main!(benches);

--- a/application/apps/indexer/sources/benches/mocks_benchmarks.rs
+++ b/application/apps/indexer/sources/benches/mocks_benchmarks.rs
@@ -1,9 +1,10 @@
+mod bench_utls;
+
 use std::time::Duration;
 
+use bench_utls::run_producer;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use futures::StreamExt;
 use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
-use parsers::{LogMessage, MessageStreamItem};
 use sources::producer::MessageProducer;
 
 mod mocks;
@@ -15,11 +16,11 @@ mod mocks;
 /// NOTE: This benchmark suffers unfortunately from a lot of noise because we are running it with
 /// asynchronous runtime. This test is configured to reduce this amount of noise as possible,
 /// However it would be better to run it multiple time for double checking.
-fn producer_benchmark(c: &mut Criterion) {
+fn mocks_benchmark(c: &mut Criterion) {
     let max_parse_calls = 50000;
 
     c.bench_with_input(
-        BenchmarkId::new("run_producer", max_parse_calls),
+        BenchmarkId::new("mocks_producer", max_parse_calls),
         &(max_parse_calls),
         |bencher, &max| {
             bencher
@@ -43,51 +44,6 @@ fn producer_benchmark(c: &mut Criterion) {
     );
 }
 
-/// Creates a message producer from the given arguments, then creates a stream of it and consumes
-/// it, replicating the producer loop inside Chipmunk sessions  
-async fn run_producer<P, B, T>(mut producer: MessageProducer<T, P, B>)
-where
-    P: parsers::Parser<T>,
-    B: sources::ByteSource,
-    T: LogMessage,
-{
-    let s = producer.as_stream();
-    //
-    // using `tokio::pin!()` provided more stable (and faster) benchmarks than
-    // `futures::pin_mut!()`
-    tokio::pin!(s);
-
-    while let Some((_, i)) = s.next().await {
-        match i {
-            MessageStreamItem::Item(item) => match item {
-                parsers::ParseYield::Message(msg) => {
-                    if msg.to_string().is_empty() {
-                        println!("This should never be printed")
-                    }
-                }
-                parsers::ParseYield::Attachment(att) => {
-                    if att.size > 10 {
-                        println!("This should never be printed")
-                    }
-                }
-                parsers::ParseYield::MessageAndAttachment((msg, att)) => {
-                    if msg.to_string().is_empty() || att.size > 10 {
-                        println!("This should never be printed")
-                    }
-                }
-            },
-            MessageStreamItem::Skipped => {
-                println!("This should never be printed")
-            }
-            MessageStreamItem::Incomplete => {
-                println!("This should never be printed")
-            }
-            MessageStreamItem::Empty => println!("This should never be printed"),
-            MessageStreamItem::Done => break,
-        }
-    }
-}
-
 criterion_group! {
     name = benches;
     config = Criterion::default()
@@ -100,7 +56,7 @@ criterion_group! {
         // These two values help to reduce the noise level in the results.
         .significance_level(0.01)
         .noise_threshold(0.03);
-    targets = producer_benchmark
+    targets = mocks_benchmark
 }
 
 criterion_main!(benches);

--- a/application/apps/indexer/sources/benches/mocks_producer.rs
+++ b/application/apps/indexer/sources/benches/mocks_producer.rs
@@ -1,12 +1,9 @@
-mod bench_utls;
-
-use std::time::Duration;
-
-use bench_utls::run_producer;
+use bench_utls::{bench_standrad_config, run_producer};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
 use sources::producer::MessageProducer;
 
+mod bench_utls;
 mod mocks;
 
 /// Runs Benchmarks replicating the producer loop within Chipmunk sessions, using mocks for
@@ -46,16 +43,7 @@ fn mocks_producer(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default()
-        // Warm up time is very important here because multiple async runtimes will be spawn in
-        // that time which make the next ones to spawn more stable.
-        .warm_up_time(Duration::from_secs(10))
-        // Measurement time and sample sized to role out noise in the measurements as possible.
-        .measurement_time(Duration::from_secs(20))
-        .sample_size(200)
-        // These two values help to reduce the noise level in the results.
-        .significance_level(0.01)
-        .noise_threshold(0.03);
+    config = bench_standrad_config();
     targets = mocks_producer
 }
 

--- a/application/apps/indexer/sources/benches/mocks_producer.rs
+++ b/application/apps/indexer/sources/benches/mocks_producer.rs
@@ -16,7 +16,7 @@ mod mocks;
 /// NOTE: This benchmark suffers unfortunately from a lot of noise because we are running it with
 /// asynchronous runtime. This test is configured to reduce this amount of noise as possible,
 /// However it would be better to run it multiple time for double checking.
-fn mocks_benchmark(c: &mut Criterion) {
+fn mocks_producer(c: &mut Criterion) {
     let max_parse_calls = 50000;
 
     c.bench_with_input(
@@ -56,7 +56,7 @@ criterion_group! {
         // These two values help to reduce the noise level in the results.
         .significance_level(0.01)
         .noise_threshold(0.03);
-    targets = mocks_benchmark
+    targets = mocks_producer
 }
 
 criterion_main!(benches);

--- a/application/apps/indexer/sources/benches/someip_legacy_producer.rs
+++ b/application/apps/indexer/sources/benches/someip_legacy_producer.rs
@@ -1,0 +1,65 @@
+mod bench_utls;
+
+use std::{io::Cursor, path::PathBuf};
+
+use bench_utls::{get_config, read_binary, run_producer};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use parsers::someip::SomeipParser;
+use sources::{binary::pcap::legacy::PcapLegacyByteSource, producer::MessageProducer};
+
+fn someip_legacy_benchmark(c: &mut Criterion) {
+    let data = read_binary();
+    println!("Data len: {}", data.len());
+    let config_path = match get_config() {
+        Some(c) => {
+            let config_path = PathBuf::from(c);
+            assert!(
+                config_path.exists(),
+                "Provided configuration path doesn't exist. Path: {}",
+                config_path.display()
+            );
+
+            Some(config_path)
+        }
+        None => None,
+    };
+
+    dbg!(&config_path);
+    let _source = create_bytesource(data);
+
+    c.bench_function("someip_legacy_producer", |bencher| {
+        bencher
+            .to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter_batched(
+                || {
+                    let parser = create_someip_parser(config_path.clone());
+                    let source = create_bytesource(data);
+                    let producer = MessageProducer::new(parser, source, black_box(None));
+
+                    producer
+                },
+                |p| run_producer(p),
+                // |p| async {
+                //     let a = run_producer(p).await;
+                //     dbg!(a)
+                // },
+                BatchSize::SmallInput,
+            )
+    });
+}
+
+fn create_bytesource(data: &'static [u8]) -> PcapLegacyByteSource<Cursor<&'static [u8]>> {
+    PcapLegacyByteSource::new(Cursor::new(data)).unwrap()
+}
+
+fn create_someip_parser(config_path: Option<PathBuf>) -> SomeipParser {
+    match config_path {
+        Some(p) => SomeipParser::from_fibex_files(vec![p]),
+        None => SomeipParser::new(),
+    }
+}
+
+//TODO: This is needed to be configured similar to benchmarking with mocking PR.
+criterion_group!(benches, someip_legacy_benchmark);
+
+criterion_main!(benches);

--- a/application/apps/indexer/sources/benches/someip_legacy_producer.rs
+++ b/application/apps/indexer/sources/benches/someip_legacy_producer.rs
@@ -2,64 +2,57 @@ mod bench_utls;
 
 use std::{io::Cursor, path::PathBuf};
 
-use bench_utls::{get_config, read_binary, run_producer};
+use bench_utls::{bench_standrad_config, get_config, read_binary, run_producer};
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use parsers::someip::SomeipParser;
 use sources::{binary::pcap::legacy::PcapLegacyByteSource, producer::MessageProducer};
 
-fn someip_legacy_benchmark(c: &mut Criterion) {
+/// This benchmark covers parsing from SomeIP file using [`PcapLegacyByteSource`] byte source.
+/// It supports providing the path for a fibex file as additional configuration.
+fn someip_legacy_producer(c: &mut Criterion) {
     let data = read_binary();
-    println!("Data len: {}", data.len());
-    let config_path = match get_config() {
-        Some(c) => {
-            let config_path = PathBuf::from(c);
-            assert!(
-                config_path.exists(),
-                "Provided configuration path doesn't exist. Path: {}",
-                config_path.display()
-            );
 
-            Some(config_path)
-        }
-        None => None,
-    };
+    // Additional configuration are assumed to be one path for a fibex file.
+    let fibex_path = get_config().map(|fibex_path| {
+        let fibex_path = PathBuf::from(fibex_path);
+        assert!(
+            fibex_path.exists(),
+            "Given fibex metadata file as additional configuration doesn't exist"
+        );
 
-    dbg!(&config_path);
-    let _source = create_bytesource(data);
+        println!("Loading fibex metadata file: {}", fibex_path.display());
+
+        fibex_path
+    });
 
     c.bench_function("someip_legacy_producer", |bencher| {
         bencher
             .to_async(tokio::runtime::Runtime::new().unwrap())
             .iter_batched(
                 || {
-                    let parser = create_someip_parser(config_path.clone());
-                    let source = create_bytesource(data);
+                    let parser = create_someip_parser(fibex_path.as_ref());
+                    let source = PcapLegacyByteSource::new(Cursor::new(data)).unwrap();
                     let producer = MessageProducer::new(parser, source, black_box(None));
 
                     producer
                 },
                 |p| run_producer(p),
-                // |p| async {
-                //     let a = run_producer(p).await;
-                //     dbg!(a)
-                // },
                 BatchSize::SmallInput,
             )
     });
 }
 
-fn create_bytesource(data: &'static [u8]) -> PcapLegacyByteSource<Cursor<&'static [u8]>> {
-    PcapLegacyByteSource::new(Cursor::new(data)).unwrap()
-}
-
-fn create_someip_parser(config_path: Option<PathBuf>) -> SomeipParser {
+fn create_someip_parser(config_path: Option<&PathBuf>) -> SomeipParser {
     match config_path {
-        Some(p) => SomeipParser::from_fibex_files(vec![p]),
+        Some(p) => SomeipParser::from_fibex_files(vec![p.to_owned()]),
         None => SomeipParser::new(),
     }
 }
 
-//TODO: This is needed to be configured similar to benchmarking with mocking PR.
-criterion_group!(benches, someip_legacy_benchmark);
+criterion_group! {
+    name = benches;
+    config = bench_standrad_config();
+    targets = someip_legacy_producer
+}
 
 criterion_main!(benches);

--- a/application/apps/indexer/sources/benches/someip_producer.rs
+++ b/application/apps/indexer/sources/benches/someip_producer.rs
@@ -1,0 +1,64 @@
+mod bench_utls;
+
+use std::{io::Cursor, path::PathBuf};
+
+use bench_utls::{get_config, read_binary, run_producer};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use parsers::someip::SomeipParser;
+use sources::{binary::pcap::ng::PcapngByteSource, producer::MessageProducer};
+
+fn someip_benchmark(c: &mut Criterion) {
+    let data = read_binary();
+    println!("Data len: {}", data.len());
+    let config_path = match get_config() {
+        Some(c) => {
+            let config_path = PathBuf::from(c);
+            assert!(
+                config_path.exists(),
+                "Provided configuration path doesn't exist. Path: {}",
+                config_path.display()
+            );
+
+            Some(config_path)
+        }
+        None => None,
+    };
+
+    dbg!(&config_path);
+
+    c.bench_function("someip_producer", |bencher| {
+        bencher
+            .to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter_batched(
+                || {
+                    let parser = create_someip_parser(config_path.clone());
+                    let source = create_bytesource(data);
+                    let producer = MessageProducer::new(parser, source, black_box(None));
+
+                    producer
+                },
+                |p| run_producer(p),
+                // |p| async {
+                //     let a = run_producer(p).await;
+                //     dbg!(a)
+                // },
+                BatchSize::SmallInput,
+            )
+    });
+}
+
+fn create_bytesource(data: &'static [u8]) -> PcapngByteSource<Cursor<&'static [u8]>> {
+    PcapngByteSource::new(Cursor::new(data)).unwrap()
+}
+
+fn create_someip_parser(config_path: Option<PathBuf>) -> SomeipParser {
+    match config_path {
+        Some(p) => SomeipParser::from_fibex_files(vec![p]),
+        None => SomeipParser::new(),
+    }
+}
+
+//TODO: This is needed to be configured similar to benchmarking with mocking PR.
+criterion_group!(benches, someip_benchmark);
+
+criterion_main!(benches);

--- a/application/apps/indexer/sources/benches/someip_producer.rs
+++ b/application/apps/indexer/sources/benches/someip_producer.rs
@@ -1,64 +1,58 @@
-mod bench_utls;
-
 use std::{io::Cursor, path::PathBuf};
 
-use bench_utls::{get_config, read_binary, run_producer};
+use bench_utls::{bench_standrad_config, get_config, read_binary, run_producer};
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use parsers::someip::SomeipParser;
 use sources::{binary::pcap::ng::PcapngByteSource, producer::MessageProducer};
 
-fn someip_benchmark(c: &mut Criterion) {
+mod bench_utls;
+
+/// This benchmark covers parsing from SomeIP file using [`PcapngByteSource`] byte source.
+/// It supports providing the path for a fibex file as additional configuration.
+fn someip_producer(c: &mut Criterion) {
     let data = read_binary();
-    println!("Data len: {}", data.len());
-    let config_path = match get_config() {
-        Some(c) => {
-            let config_path = PathBuf::from(c);
-            assert!(
-                config_path.exists(),
-                "Provided configuration path doesn't exist. Path: {}",
-                config_path.display()
-            );
 
-            Some(config_path)
-        }
-        None => None,
-    };
+    // Additional configuration are assumed to be one path for a fibex file.
+    let fibex_path = get_config().map(|fibex_path| {
+        let fibex_path = PathBuf::from(fibex_path);
+        assert!(
+            fibex_path.exists(),
+            "Given fibex metadata file as additional configuration doesn't exist"
+        );
 
-    dbg!(&config_path);
+        println!("Loading fibex metadata file: {}", fibex_path.display());
+
+        fibex_path
+    });
 
     c.bench_function("someip_producer", |bencher| {
         bencher
             .to_async(tokio::runtime::Runtime::new().unwrap())
             .iter_batched(
                 || {
-                    let parser = create_someip_parser(config_path.clone());
-                    let source = create_bytesource(data);
+                    let parser = create_someip_parser(fibex_path.as_ref());
+                    let source = PcapngByteSource::new(Cursor::new(data)).unwrap();
                     let producer = MessageProducer::new(parser, source, black_box(None));
 
                     producer
                 },
                 |p| run_producer(p),
-                // |p| async {
-                //     let a = run_producer(p).await;
-                //     dbg!(a)
-                // },
                 BatchSize::SmallInput,
             )
     });
 }
 
-fn create_bytesource(data: &'static [u8]) -> PcapngByteSource<Cursor<&'static [u8]>> {
-    PcapngByteSource::new(Cursor::new(data)).unwrap()
-}
-
-fn create_someip_parser(config_path: Option<PathBuf>) -> SomeipParser {
+fn create_someip_parser(config_path: Option<&PathBuf>) -> SomeipParser {
     match config_path {
-        Some(p) => SomeipParser::from_fibex_files(vec![p]),
+        Some(p) => SomeipParser::from_fibex_files(vec![p.to_owned()]),
         None => SomeipParser::new(),
     }
 }
 
-//TODO: This is needed to be configured similar to benchmarking with mocking PR.
-criterion_group!(benches, someip_benchmark);
+criterion_group! {
+    name = benches;
+    config = bench_standrad_config();
+    targets = someip_producer
+}
 
 criterion_main!(benches);

--- a/application/apps/indexer/sources/benches/text_producer.rs
+++ b/application/apps/indexer/sources/benches/text_producer.rs
@@ -1,0 +1,37 @@
+mod bench_utls;
+
+use criterion::{Criterion, *};
+
+use bench_utls::{create_binary_bytesource, read_binary, run_producer};
+use parsers::text::StringTokenizer;
+use sources::producer::MessageProducer;
+
+fn text_benchmark(c: &mut Criterion) {
+    let data = read_binary();
+    println!("Data len: {}", data.len());
+
+    c.bench_function("text_producer", |bencher| {
+        bencher
+            .to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter_batched(
+                || {
+                    let parser = StringTokenizer {};
+                    let source = create_binary_bytesource(data);
+                    let producer = MessageProducer::new(parser, source, black_box(None));
+
+                    producer
+                },
+                |p| run_producer(p),
+                // |p| async {
+                //     let a = run_producer(p).await;
+                //     dbg!(a)
+                // },
+                BatchSize::SmallInput,
+            )
+    });
+}
+
+//TODO: This is needed to be configured similar to benchmarking with mocking PR.
+criterion_group!(benches, text_benchmark);
+
+criterion_main!(benches);

--- a/application/apps/indexer/sources/benches/text_producer.rs
+++ b/application/apps/indexer/sources/benches/text_producer.rs
@@ -1,14 +1,15 @@
-mod bench_utls;
-
 use criterion::{Criterion, *};
 
-use bench_utls::{create_binary_bytesource, read_binary, run_producer};
+use bench_utls::{bench_standrad_config, create_binary_bytesource, read_binary, run_producer};
 use parsers::text::StringTokenizer;
 use sources::producer::MessageProducer;
 
-fn text_benchmark(c: &mut Criterion) {
+mod bench_utls;
+
+/// This benchmark covers parsing from text file file using [`BinaryByteSource`].
+/// This benchmark doesn't support any additional configurations.
+fn text_producer(c: &mut Criterion) {
     let data = read_binary();
-    println!("Data len: {}", data.len());
 
     c.bench_function("text_producer", |bencher| {
         bencher
@@ -22,16 +23,15 @@ fn text_benchmark(c: &mut Criterion) {
                     producer
                 },
                 |p| run_producer(p),
-                // |p| async {
-                //     let a = run_producer(p).await;
-                //     dbg!(a)
-                // },
                 BatchSize::SmallInput,
             )
     });
 }
 
-//TODO: This is needed to be configured similar to benchmarking with mocking PR.
-criterion_group!(benches, text_benchmark);
+criterion_group! {
+    name = benches;
+    config = bench_standrad_config();
+    targets = text_producer
+}
 
 criterion_main!(benches);

--- a/application/apps/indexer/sources/src/binary/pcap/legacy.rs
+++ b/application/apps/indexer/sources/src/binary/pcap/legacy.rs
@@ -45,13 +45,11 @@ impl<R: Read + Send + Sync> ByteSource for PcapLegacyByteSource<R> {
                     );
                     consumed = bytes_read;
                     match block {
-                        PcapBlockOwned::LegacyHeader(ref hdr) => {
-                            println!("LegacyHeader {:?}", hdr);
+                        PcapBlockOwned::LegacyHeader(ref _hdr) => {
                             self.pcap_reader.consume(consumed);
                             continue;
                         }
                         PcapBlockOwned::Legacy(ref b) => {
-                            println!("Legacy: {:?}", b);
                             raw_data = &b.data[..b.origlen as usize];
                             break;
                         }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,3 @@
-<!--TODO AAZ: Increase lib real version after the other PR is merged. -->
 # 0.2.5
 
 ## Features:

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,11 @@
+<!--TODO AAZ: Increase lib real version after the other PR is merged. -->
+# 0.2.5
+
+## Features:
+
+* Added `benchmark` commands to run benchmarks specified in a separate configuration `toml` file.
+
+
 # 0.2.4
 
 ## Changes:

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cargo-chipmunk"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chipmunk"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Ammar Abou Zor <ammar.abou.zor@accenture.com>"]
 edition = "2021"
 description = "CLI Tool for chipmunk application development"

--- a/cli/README.md
+++ b/cli/README.md
@@ -97,6 +97,15 @@ Options:
           Print help (see a summary with '-h')
 ```
 
+
+## Benchmarks via Build CLI Tool
+
+You can run benchmarks of the Rust Core part directly using the Build CLI tool. Some benchmarks require input sources and additional configurations, which should be provided via environment variables.
+
+The CLI tool simplifies running these benchmarks from anywhere in the Chipmunk repository. You can provide the input sources and configurations as CLI arguments, and the tool will handle setting the environment variables for the benchmarks. For more details, use the help command: `cargo chipmunk bench --help`.
+
+The registered benchmarks are loaded from `chipmunk/cli/config/bench_core.toml`. To add a new benchmark, please include it in this configuration file.
+
 ## Shell Completion
 
 The Chipmunk CLI tool supports shell completion for various shells. You can generate shell completions and print them to `stdout` using the following command:

--- a/cli/README.md
+++ b/cli/README.md
@@ -45,6 +45,7 @@ Commands:
   test              Run tests for all or the specified targets
   run               Build and Run the application
   release           Builds Chipmunk and generates a release (defaults to Release mode)
+  benchmark         Runs benchmarks for the given target, its input source and configuration [aliases: bench]
   reset-checksum    Resets the checksums records what is used to check if there were any code changes for each target [aliases: reset]
   shell-completion  Generate shell completion for the commands of this tool in the given shell, printing them to stdout [aliases: compl]
   help              Print this message or the help of the given subcommand(s)

--- a/cli/config/bench_core.toml
+++ b/cli/config/bench_core.toml
@@ -1,0 +1,24 @@
+[[bench]]
+name = "mocks_producer"
+library = "sources"
+
+[[bench]]
+name = "dlt_producer"
+library = "sources"
+
+[[bench]]
+name = "someip_producer"
+library = "sources"
+
+[[bench]]
+name = "someip_legacy_producer"
+library = "sources"
+
+[[bench]]
+name = "text_producer"
+library = "sources"
+
+[[bench]]
+name = "map_benchmarks"
+library = "processor"
+

--- a/cli/integration_tests/bench.py
+++ b/cli/integration_tests/bench.py
@@ -1,0 +1,36 @@
+"""
+Provides methods to test the Benchmark command in Chipmunk Build CLI Tool.
+"""
+
+from utls import get_root, run_command, print_green_bold, print_blue_bold
+
+
+# We can only list the benchmarks since this command will test loading the benchmarks from the configuration file.
+# Running the actual benchmarks will take too much time and it will be tedious to keep the benchmarks between
+# this script and the configuration file in sync.
+BENCH_LIST_COMMAND = [
+    "cargo",
+    "run",
+    "-r",
+    "--",
+    "chipmunk",
+    "bench",
+    "list",
+]
+
+
+def run_benchmark_command():
+    """
+    Runs benchmark command for Chipmunk.
+    This command will list the available tests only, loading the configuration of all benchmarks.
+    """
+
+    print_blue_bold("Running Benchmark Command...")
+
+    run_command(BENCH_LIST_COMMAND)
+
+    print_green_bold("*** Check for Benchmark Command Succeeded ***")
+
+
+if __name__ == "__main__":
+    run_benchmark_command()

--- a/cli/integration_tests/run_all.py
+++ b/cli/integration_tests/run_all.py
@@ -13,6 +13,7 @@ from print_dot import run_print_dot_commands
 from shell_compl import run_shell_completion_commands
 from test_cmd import run_test_command
 from release import run_release_command
+from bench import run_benchmark_command
 
 
 def run_all():
@@ -64,6 +65,14 @@ def run_all():
         run_release_command()
     except Exception:
         print_err("Release")
+        raise
+    print_separator()
+
+    ### Benchmarks ###
+    try:
+        run_benchmark_command()
+    except Exception:
+        print_err("Benchmarks")
         raise
     print_separator()
 

--- a/cli/src/benchmark/core.rs
+++ b/cli/src/benchmark/core.rs
@@ -1,0 +1,70 @@
+use std::fs::read_to_string;
+
+use anyhow::{ensure, Context};
+use serde::Deserialize;
+
+use crate::location::config_path;
+
+/// Filename for rust core benchmarks configurations.
+pub const CONFIG_FILENAME: &str = "bench_core.toml";
+
+#[derive(Debug, Clone, Deserialize)]
+/// Configurations info for rust core benchmarks.
+pub struct ConfigsInfos {
+    #[serde(rename = "bench")]
+    benches: Vec<BenchmarkInfo>,
+}
+
+impl ConfigsInfos {
+    /// Loads benchmarks infos from configuration file.
+    pub fn load() -> anyhow::Result<Self> {
+        let config_file_path = config_path().join(CONFIG_FILENAME);
+        ensure!(
+            config_file_path.exists(),
+            "Configuration file doesn't exist. Path: {}",
+            config_file_path.display()
+        );
+
+        let content = read_to_string(&config_file_path).with_context(|| {
+            format!(
+                "Error while reading configuration file. Path: {}",
+                config_file_path.display()
+            )
+        })?;
+
+        let config = toml::from_str(&content).with_context(|| {
+            format!(
+                "Error while parsing configuration file. Path: {}",
+                config_file_path.display()
+            )
+        })?;
+
+        Ok(config)
+    }
+
+    /// Prints the benchmarks infos from the configuration file.
+    pub fn print_list(&self) {
+        println!("Target Rust Core:");
+        for (idx, bench) in self.benches.iter().enumerate() {
+            if idx > 0 {
+                println!("  --------------------");
+            }
+            println!("  Benchmark: {}", bench.name);
+            println!("  Library: {}", bench.library);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+/// Infos for a benchmark in rust core.
+pub struct BenchmarkInfo {
+    /// Name of the benchmark as defined in `Cargo.toml` file.
+    name: String,
+    /// Library name where the benchmark is defined.
+    /// It represents the relative path of this library starting from rust core main path `.../indexer`.
+    library: String,
+}
+
+pub fn run_benchmark(name: String, input_source: String, config: Option<String>, run_count: u8) {
+    todo!()
+}

--- a/cli/src/benchmark/core.rs
+++ b/cli/src/benchmark/core.rs
@@ -1,12 +1,20 @@
+//! Manages benchmarks commands for rust core target.
+
 use std::fs::read_to_string;
 
 use anyhow::{ensure, Context};
+use console::style;
 use serde::Deserialize;
 
-use crate::location::config_path;
+use crate::{location::config_path, log_print::print_log_separator, target::Target};
 
 /// Filename for rust core benchmarks configurations.
 pub const CONFIG_FILENAME: &str = "bench_core.toml";
+
+/// Environment variables to pass input source to benchmarks.
+pub const INPUT_SOURCE_ENV_VAR: &str = "CHIPMUNK_BENCH_SOURCE";
+/// Environment variables to pass configurations to benchmarks.
+pub const CONFIG_ENV_VAR: &str = "CHIPMUNK_BENCH_CONFIG";
 
 #[derive(Debug, Clone, Deserialize)]
 /// Configurations info for rust core benchmarks.
@@ -65,6 +73,59 @@ pub struct BenchmarkInfo {
     library: String,
 }
 
-pub fn run_benchmark(name: String, input_source: String, config: Option<String>, run_count: u8) {
-    todo!()
+pub fn run_benchmark(
+    name: String,
+    input_source: Option<String>,
+    additional_config: Option<String>,
+    run_count: u8,
+) -> anyhow::Result<()> {
+    let config_info = ConfigsInfos::load()?;
+    let bench = config_info
+        .benches
+        .into_iter()
+        .find(|b| b.name == name)
+        .with_context(|| format!("Benchmark with the name '{name}' is not defined"))?;
+
+    let cwd = Target::Core.cwd().join(bench.library);
+    let cmd = format!("cargo bench --bench {}", bench.name);
+
+    for i in 0..run_count {
+        if i > 0 {
+            print_log_separator();
+        }
+
+        let msg = format!("Running benchmark {name} for the {} time...", i + 1);
+        println!("{}\n", style(msg).bold().blue());
+
+        //TODO AAZ: Use the unified function for creating command once their PR is merged.
+        let mut command = if cfg!(target_os = "windows") {
+            let mut cmd = std::process::Command::new("cmd");
+            cmd.arg("/C");
+            cmd
+        } else {
+            let mut cmd = std::process::Command::new("sh");
+            cmd.arg("-c");
+            cmd
+        };
+
+        command.arg(&cmd);
+
+        if let Some(input) = &input_source {
+            command.env(INPUT_SOURCE_ENV_VAR, input);
+        }
+
+        if let Some(config) = &additional_config {
+            command.env(CONFIG_ENV_VAR, config);
+        }
+
+        command.current_dir(&cwd);
+
+        let status = command
+            .status()
+            .with_context(|| format!("Error while running bench command: {cmd}"))?;
+
+        ensure!(status.success(), "Benchmark command failed. Command: {cmd}");
+    }
+
+    Ok(())
 }

--- a/cli/src/benchmark/core.rs
+++ b/cli/src/benchmark/core.rs
@@ -6,7 +6,9 @@ use anyhow::{ensure, Context};
 use console::style;
 use serde::Deserialize;
 
-use crate::{location::config_path, log_print::print_log_separator, target::Target};
+use crate::{
+    location::config_path, log_print::print_log_separator, shell::shell_std_command, target::Target,
+};
 
 /// Filename for rust core benchmarks configurations.
 pub const CONFIG_FILENAME: &str = "bench_core.toml";
@@ -102,17 +104,7 @@ pub fn run_benchmark(
 
         println!("{}\n", style(msg).bold().blue());
 
-        //TODO AAZ: Use the unified function for creating command once their PR is merged.
-        let mut command = if cfg!(target_os = "windows") {
-            let mut cmd = std::process::Command::new("cmd");
-            cmd.arg("/C");
-            cmd
-        } else {
-            let mut cmd = std::process::Command::new("sh");
-            cmd.arg("-c");
-            cmd
-        };
-
+        let mut command = shell_std_command();
         command.arg(&cmd);
 
         if let Some(input) = input_source.as_deref() {

--- a/cli/src/benchmark/core.rs
+++ b/cli/src/benchmark/core.rs
@@ -94,7 +94,12 @@ pub fn run_benchmark(
             print_log_separator();
         }
 
-        let msg = format!("Running benchmark {name} for the {} time...", i + 1);
+        let msg = if run_count > 1 {
+            format!("Running benchmark {name} for the {} time...", i + 1)
+        } else {
+            format!("Running benchmark {name}...")
+        };
+
         println!("{}\n", style(msg).bold().blue());
 
         //TODO AAZ: Use the unified function for creating command once their PR is merged.

--- a/cli/src/benchmark/mod.rs
+++ b/cli/src/benchmark/mod.rs
@@ -1,8 +1,11 @@
+//! Manages benchmarks commands to run the given benchmark or list all of the available ones.
+
 mod core;
 
 use clap::Subcommand;
 
 #[derive(Debug, Clone, Subcommand)]
+/// Represents benchmarks commands to run the given benchmark or list all of the available ones.
 pub enum BenchTarget {
     /// Run benchmarks in Rust Core
     Core {
@@ -10,9 +13,9 @@ pub enum BenchTarget {
         #[arg(index = 1, required = true)]
         name: String,
 
-        /// Path of configs of the input source to be used in the benchmarks
-        #[arg(index = 2, required = true)]
-        input_source: String,
+        /// Path or configurations of the input source to be used in the benchmarks
+        #[arg(short, long = "input")]
+        input_source: Option<String>,
 
         /// Additional configurations for the benchmarks
         #[arg(short, long)]
@@ -36,13 +39,7 @@ impl BenchTarget {
                 config,
                 run_count,
             } => {
-                //TODO AAZ: Remove debug code after done.
-                println!("Name: {}", name);
-                println!("Input: {}", input_source);
-                println!("Config: {:?}", config);
-                println!("Run Count: {:?}", run_count);
-
-                core::run_benchmark(name, input_source, config, run_count)
+                core::run_benchmark(name, input_source, config, run_count)?;
             }
             BenchTarget::List => {
                 println!("Listing all benchmarks from configurations...");

--- a/cli/src/benchmark/mod.rs
+++ b/cli/src/benchmark/mod.rs
@@ -1,0 +1,46 @@
+use clap::Subcommand;
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum BenchTarget {
+    /// Run benchmarks in Rust Core
+    Core {
+        /// Name of the benchmark as stated in configurations file.
+        #[arg(index = 1, required = true)]
+        name: String,
+
+        /// Path of configs of the input source to be used in the benchmarks
+        #[arg(index = 2, required = true)]
+        input_source: String,
+
+        /// Additional configurations for the benchmarks
+        #[arg(short, long)]
+        config: Option<String>,
+
+        /// Determines how many times to repeat the benchmark.
+        #[arg(short, long)]
+        repeat: Option<u8>,
+    },
+    /// Lists all the available benchmarks in configuration files.
+    List,
+}
+
+impl BenchTarget {
+    pub fn run(self) -> anyhow::Result<()> {
+        match self {
+            BenchTarget::Core {
+                name,
+                input_source,
+                config,
+                repeat,
+            } => {
+                println!("name: {}", name);
+                println!("input: {}", input_source);
+                println!("config: {:?}", config);
+                println!("Repeat: {:?}", repeat);
+            }
+            BenchTarget::List => println!(" List Called"),
+        }
+
+        Ok(())
+    }
+}

--- a/cli/src/benchmark/mod.rs
+++ b/cli/src/benchmark/mod.rs
@@ -1,3 +1,5 @@
+mod core;
+
 use clap::Subcommand;
 
 #[derive(Debug, Clone, Subcommand)]
@@ -16,29 +18,40 @@ pub enum BenchTarget {
         #[arg(short, long)]
         config: Option<String>,
 
-        /// Determines how many times to repeat the benchmark.
-        #[arg(short, long)]
-        repeat: Option<u8>,
+        /// Determines how many times to run the benchmark.
+        #[arg(short, long, default_value = "1")]
+        run_count: u8,
     },
     /// Lists all the available benchmarks in configuration files.
     List,
 }
 
 impl BenchTarget {
+    /// Runs the operations defined by each [`BenchTarget`]
     pub fn run(self) -> anyhow::Result<()> {
         match self {
             BenchTarget::Core {
                 name,
                 input_source,
                 config,
-                repeat,
+                run_count,
             } => {
-                println!("name: {}", name);
-                println!("input: {}", input_source);
-                println!("config: {:?}", config);
-                println!("Repeat: {:?}", repeat);
+                //TODO AAZ: Remove debug code after done.
+                println!("Name: {}", name);
+                println!("Input: {}", input_source);
+                println!("Config: {:?}", config);
+                println!("Run Count: {:?}", run_count);
+
+                core::run_benchmark(name, input_source, config, run_count)
             }
-            BenchTarget::List => println!(" List Called"),
+            BenchTarget::List => {
+                println!("Listing all benchmarks from configurations...");
+                println!();
+
+                let core = core::ConfigsInfos::load()?;
+                core.print_list();
+                println!();
+            }
         }
 
         Ok(())

--- a/cli/src/cli_args.rs
+++ b/cli/src/cli_args.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 
-use crate::target::Target;
+use crate::{benchmark::BenchTarget, target::Target};
 
 const FAIL_FAST_HELP_TEXT: &str = "Stops execution immediately if any job fails.";
 const NO_FAIL_FAST_HELP_TEXT: &str = "Don't stops execution immediately if any job fails.";
@@ -144,6 +144,10 @@ pub enum Command {
         #[arg(short, long)]
         code_sign: Option<PathBuf>,
     },
+    /// Runs benchmarks for the given target, its input source and configuration.
+    #[clap(visible_alias = "bench")]
+    #[command(subcommand)]
+    Benchmark(BenchTarget),
     /// Resets the checksums records what is used to check if there were any code changes for
     /// each target.
     #[clap(visible_alias = "reset")]

--- a/cli/src/dev_environment.rs
+++ b/cli/src/dev_environment.rs
@@ -64,7 +64,8 @@ pub fn validate_dev_tools() -> anyhow::Result<()> {
 
 /// Prints the information of the needed tools for the development if available, otherwise prints
 /// error information to `stderr`
-pub fn print_env_info() {
+pub fn print_env_info() -> anyhow::Result<()> {
+    let mut errored = false;
     for tool in DevTool::all() {
         println!("{tool} Info:");
         let cmd = tool.cmd();
@@ -74,11 +75,21 @@ pub fn print_env_info() {
         {
             Ok(s) => {
                 if !s.success() {
+                    errored = true;
                     eprintln!("Error while retrieving dependency's information");
                 }
             }
-            Err(err) => eprintln!("Error while retrieving dependency's information: {err}"),
+            Err(err) => {
+                errored = true;
+                eprintln!("Error while retrieving dependency's information: {err}")
+            }
         }
         println!("------------------------------------------------------------------");
     }
+
+    if errored {
+        bail!("Error(s) while resolving development tools");
+    }
+
+    Ok(())
 }

--- a/cli/src/location.rs
+++ b/cli/src/location.rs
@@ -51,3 +51,8 @@ pub fn init_location() -> Result<(), Error> {
         .expect("Developer Error: init location can't be called more than once");
     Ok(())
 }
+
+/// Return the path for the configuration directory of the Build CLI Tool.
+pub fn config_path() -> PathBuf {
+    get_root().join("cli").join("config")
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,7 @@
 // Use the readme as the main documentation page.
 #![doc = include_str!("../README.md")]
 
+mod benchmark;
 mod checksum_records;
 mod chipmunk_runner;
 mod cli_args;
@@ -185,6 +186,7 @@ async fn main_process(command: Command) -> Result<(), Error> {
 
             return Ok(());
         }
+        Command::Benchmark(bench) => return bench.run(),
     };
 
     // Shutdown and show results & report

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -83,8 +83,7 @@ async fn main_process(command: Command) -> Result<(), Error> {
                 return Ok(());
             }
             EnvironmentCommand::Print => {
-                print_env_info();
-                return Ok(());
+                return print_env_info();
             }
         },
         Command::PrintDot { all_jobs } => {
@@ -160,9 +159,7 @@ async fn main_process(command: Command) -> Result<(), Error> {
             return Ok(());
         }
         Command::ShellCompletion { shell } => {
-            shell::generate_completion(shell)?;
-
-            return Ok(());
+            return shell::generate_completion(shell);
         }
         Command::Release {
             verbose,


### PR DESCRIPTION
This PR can't be merged until #2102 is merged to avoid merge conflicts since both of them are increasing the version of the build CLI tool.

* This PR provide benchmarks for actual parser in Chipmunk in the producer loop, similar to the benchmark with mocking parsers introduced in #2088. These benchmarks accept their input source and additional configurations via environment variables and load them before start measuring to reduce any noise from IO operations.

* A new subcommand is introduced to the Build CLI to run the benchmarks directly with the option to provide the input source and additional configuration as cli arguments to avoid the complexity of using environment variables.

* The available benchmarks will be listed in a configuration file to avoid increasing the version of the CLI tool when the benchmarks change.

* Build CLI tool will check if the input arguments are paths, then it'll try to resolve the relative ones and provide them as absolute paths before running the benchmarks commands, because this process involves changing the current directly.

* Benchmarks for mocking were adjusted as well to fit with the newly added benches in the same framework.

* The additional configurations argument for DLT and SomeIP parsers is considered to be the path for a one `fibex` file if provided. This is considered the general case. For more complex cases we can add new benchmarks to cover them (Like `dlt_with_someip`).

* Text Parser require input source but ignores any additional configuration.

* Mocks Benchmarks ignore all environment variables.

* All benchmarks share the same criterion configurations which are set to avoid the noise from the async runtime as possible while providing reasonable run duration for the benchmarks.

 
@itsmesamster: The current path for the configuration file of codesign for mac has changed so we'll need to change it in the script once this PR is merged.  

