### PR TITLE
DLT: Error Mapping on Parsers & Reference Crate Published Version

### DIFF
--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -651,8 +651,9 @@ dependencies = [
 
 [[package]]
 name = "dlt-core"
-version = "0.16.0"
-source = "git+https://github.com/esrlabs/dlt-core#4299e9fa352b49cf21c5c867c835e18f4cc4a6cd"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52d43b97a134644192c66296e5d3e7ed8b3d409b117c62203047bb42c6b9f1"
 dependencies = [
  "buf_redux 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder",

--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -22,8 +22,7 @@ thiserror = "1.0"
 lazy_static = "1.4"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
-# dlt-core = "0.16"
-dlt-core = { git = "https://github.com/esrlabs/dlt-core" }
+dlt-core = "0.17"
 crossbeam-channel = "0.5"
 futures = "0.3"
 tokio-util = "0.7"

--- a/application/apps/indexer/parsers/src/dlt/mod.rs
+++ b/application/apps/indexer/parsers/src/dlt/mod.rs
@@ -185,7 +185,7 @@ impl Parser<RangeMessage> for DltRangeParser {
         input: &[u8],
         _timestamp: Option<u64>,
     ) -> Result<impl Iterator<Item = (usize, Option<ParseYield<RangeMessage>>)>, Error> {
-        let (rest, consumed) = dlt_consume_msg(input).map_err(|e| Error::Parse(format!("{e}")))?;
+        let (rest, consumed) = dlt_consume_msg(input)?;
         let msg = consumed.map(|c| {
             self.offset += c as usize;
             RangeMessage {
@@ -208,7 +208,7 @@ impl Parser<RawMessage> for DltRawParser {
         input: &[u8],
         _timestamp: Option<u64>,
     ) -> Result<impl Iterator<Item = (usize, Option<ParseYield<RawMessage>>)>, Error> {
-        let (rest, consumed) = dlt_consume_msg(input).map_err(|e| Error::Parse(format!("{e}")))?;
+        let (rest, consumed) = dlt_consume_msg(input)?;
         let msg = consumed.map(|c| RawMessage {
             content: Vec::from(&input[0..c as usize]),
         });


### PR DESCRIPTION
This PR:
* Applies the default error mapping from DLT error into parser error on all DLT parsers after changes on the crate `dlt-core` in the PR https://github.com/esrlabs/dlt-core/pull/27.
* Change referencing `dlt-core` from GitHub link to the current version on `crates.io` after it has been updated there to the latest version too.