### PR TITLE
Core: Producer Loop with Multi Parse Result Items 

### DIFF
--- a/application/apps/indexer/addons/dlt-tools/src/lib.rs
+++ b/application/apps/indexer/addons/dlt-tools/src/lib.rs
@@ -57,13 +57,15 @@ pub async fn scan_dlt_ft(
                         canceled = true;
                         break;
                     }
-                    item = tokio_stream::StreamExt::next(&mut stream) => {
-                        match item {
-                            Some((_, item)) => {
-                                if let MessageStreamItem::Item(ParseYield::MessageAndAttachment((_msg, attachment))) = item {
-                                    attachments.push(attachment);
-                                } else if let MessageStreamItem::Item(ParseYield::Attachment(attachment)) = item {
-                                    attachments.push(attachment);
+                    items = tokio_stream::StreamExt::next(&mut stream) => {
+                        match items {
+                            Some(items) => {
+                                for (_, item) in items {
+                                    if let MessageStreamItem::Item(ParseYield::MessageAndAttachment((_msg, attachment))) = item {
+                                        attachments.push(attachment);
+                                    } else if let MessageStreamItem::Item(ParseYield::Attachment(attachment)) = item {
+                                        attachments.push(attachment);
+                                    }
                                 }
                             }
                             _ => {

--- a/application/apps/indexer/indexer_cli/src/interactive.rs
+++ b/application/apps/indexer/indexer_cli/src/interactive.rs
@@ -54,18 +54,28 @@ pub(crate) async fn handle_interactive_session(input: Option<PathBuf>) {
                                         println!("received shutdown through future channel");
                                         break;
                                     }
-                                    item = msg_stream.next() => {
+                                    items = msg_stream.next() => {
+                                        let items = match items {
+                                            Some(item) => item,
+                                            None => {
+                                                println!("no msg");
+                                                continue;
+                                            }
+                                        };
+                                        for item in items {
+
                                         match item {
-                                            Some((_, MessageStreamItem::Item(ParseYield::Message(msg)))) => {
+                                            (_, MessageStreamItem::Item(ParseYield::Message(msg))) => {
                                                 println!("msg: {msg}");
                                             }
-                                            Some((_, MessageStreamItem::Item(ParseYield::MessageAndAttachment((msg, attachment))))) => {
+                                            (_, MessageStreamItem::Item(ParseYield::MessageAndAttachment((msg, attachment)))) => {
                                                 println!("msg: {msg}, attachment: {attachment:?}");
                                             }
-                                            Some((_, MessageStreamItem::Item(ParseYield::Attachment(attachment)))) => {
+                                            (_, MessageStreamItem::Item(ParseYield::Attachment(attachment))) => {
                                                 println!("attachment: {attachment:?}");
                                             }
                                             _ => println!("no msg"),
+                                        }
                                         }
                                     }
                                 }

--- a/application/apps/indexer/indexer_cli/src/main.rs
+++ b/application/apps/indexer/indexer_cli/src/main.rs
@@ -1395,37 +1395,38 @@ async fn detect_messages_type(input: &Path) -> Result<bool, DltParseError> {
             let mut attachment_count = 0usize;
             let mut err_count = 0usize;
             let mut consumed = 0usize;
-            loop {
-                match msg_stream.next().await {
-                    Some((_, MessageStreamItem::Item(ParseYield::Message(item)))) => {
-                        item_count += 1;
-                        consumed += item.range.len();
+            'outer: while let Some(items) = msg_stream.next().await {
+                for item in items {
+                    match item {
+                        (_, MessageStreamItem::Item(ParseYield::Message(item))) => {
+                            item_count += 1;
+                            consumed += item.range.len();
+                        }
+                        (
+                            _,
+                            MessageStreamItem::Item(ParseYield::MessageAndAttachment((
+                                item,
+                                _attachment,
+                            ))),
+                        ) => {
+                            item_count += 1;
+                            attachment_count += 1;
+                            consumed += item.range.len();
+                        }
+                        (_, MessageStreamItem::Item(ParseYield::Attachment(_attachment))) => {
+                            attachment_count += 1;
+                        }
+                        (_, MessageStreamItem::Skipped) => item_count += 1,
+                        (_, MessageStreamItem::Incomplete) => err_count += 1,
+                        (_, MessageStreamItem::Empty) => err_count += 1,
+                        (_, MessageStreamItem::Done) => break 'outer,
                     }
-                    Some((
-                        _,
-                        MessageStreamItem::Item(ParseYield::MessageAndAttachment((
-                            item,
-                            _attachment,
-                        ))),
-                    )) => {
-                        item_count += 1;
-                        attachment_count += 1;
-                        consumed += item.range.len();
-                    }
-                    Some((_, MessageStreamItem::Item(ParseYield::Attachment(_attachment)))) => {
-                        attachment_count += 1;
-                    }
-                    Some((_, MessageStreamItem::Skipped)) => item_count += 1,
-                    Some((_, MessageStreamItem::Incomplete)) => err_count += 1,
-                    Some((_, MessageStreamItem::Empty)) => err_count += 1,
-                    Some((_, MessageStreamItem::Done)) => break,
-                    None => break,
                 }
                 if item_count > 10 || err_count > 10 {
                     println!(
                         "DLT parser, item_count: {item_count}, err_count: {err_count}, consumed: {consumed}, attachments: {attachment_count}"
                     );
-                    break;
+                    break 'outer;
                 }
             }
         }
@@ -1441,24 +1442,24 @@ async fn detect_messages_type(input: &Path) -> Result<bool, DltParseError> {
                     let mut err_count = 0usize;
                     let mut consumed = 0usize;
                     let mut skipped_count = 0usize;
-                    loop {
-                        let x = msg_stream.next().await;
-                        match x {
-                            Some((used, MessageStreamItem::Item(_))) => {
-                                item_count += 1;
-                                consumed += used;
+                    'outer: while let Some(items) = msg_stream.next().await {
+                        for item in items {
+                            match item {
+                                (used, MessageStreamItem::Item(_)) => {
+                                    item_count += 1;
+                                    consumed += used;
+                                }
+                                (_, MessageStreamItem::Skipped) => skipped_count += 1,
+                                (_, MessageStreamItem::Incomplete) => err_count += 1,
+                                (_, MessageStreamItem::Empty) => err_count += 1,
+                                (_, MessageStreamItem::Done) => break 'outer,
                             }
-                            Some((_, MessageStreamItem::Skipped)) => skipped_count += 1,
-                            Some((_, MessageStreamItem::Incomplete)) => err_count += 1,
-                            Some((_, MessageStreamItem::Empty)) => err_count += 1,
-                            Some((_, MessageStreamItem::Done)) => break,
-                            None => break,
-                        }
-                        if item_count > 10 || err_count > 10 {
-                            println!(
+                            if item_count > 10 || err_count > 10 {
+                                println!(
                                 "Someip pcap parser, item_count: {item_count}, err_count: {err_count}, consumed: {consumed} (skipped: {skipped_count})"
                             );
-                            break;
+                                break 'outer;
+                            }
                         }
                     }
                 }
@@ -1481,37 +1482,37 @@ async fn detect_messages_type(input: &Path) -> Result<bool, DltParseError> {
                     let mut err_count = 0usize;
                     let mut consumed = 0usize;
                     let mut skipped_count = 0usize;
-                    loop {
-                        let x = msg_stream.next().await;
-                        match x {
-                            Some((_, MessageStreamItem::Item(ParseYield::Message(item)))) => {
-                                item_count += 1;
-                                consumed += item.message.byte_len() as usize;
+                    'outer: while let Some(items) = msg_stream.next().await {
+                        for item in items {
+                            match item {
+                                (_, MessageStreamItem::Item(ParseYield::Message(item))) => {
+                                    item_count += 1;
+                                    consumed += item.message.byte_len() as usize;
+                                }
+                                (
+                                    _,
+                                    MessageStreamItem::Item(ParseYield::MessageAndAttachment((
+                                        item,
+                                        _attachment,
+                                    ))),
+                                ) => {
+                                    item_count += 1;
+                                    consumed += item.message.byte_len() as usize;
+                                }
+                                (_, MessageStreamItem::Item(ParseYield::Attachment(_))) => {
+                                    attachment_count += 1
+                                }
+                                (_, MessageStreamItem::Skipped) => skipped_count += 1,
+                                (_, MessageStreamItem::Incomplete) => err_count += 1,
+                                (_, MessageStreamItem::Empty) => err_count += 1,
+                                (_, MessageStreamItem::Done) => break 'outer,
                             }
-                            Some((
-                                _,
-                                MessageStreamItem::Item(ParseYield::MessageAndAttachment((
-                                    item,
-                                    _attachment,
-                                ))),
-                            )) => {
-                                item_count += 1;
-                                consumed += item.message.byte_len() as usize;
-                            }
-                            Some((_, MessageStreamItem::Item(ParseYield::Attachment(_)))) => {
-                                attachment_count += 1
-                            }
-                            Some((_, MessageStreamItem::Skipped)) => skipped_count += 1,
-                            Some((_, MessageStreamItem::Incomplete)) => err_count += 1,
-                            Some((_, MessageStreamItem::Empty)) => err_count += 1,
-                            Some((_, MessageStreamItem::Done)) => break,
-                            None => break,
-                        }
-                        if item_count > 10 || err_count > 10 {
-                            println!(
+                            if item_count > 10 || err_count > 10 {
+                                println!(
                                 "DLT pcap parser, item_count: {item_count}, err_count: {err_count}, consumed: {consumed}, attachment_count: {attachment_count} (skipped: {skipped_count})"
                             );
-                            break;
+                                break 'outer;
+                            }
                         }
                     }
                 }
@@ -1534,50 +1535,51 @@ async fn detect_messages_type(input: &Path) -> Result<bool, DltParseError> {
             let mut consumed = 0usize;
             let mut attachment_count = 0usize;
             use std::io::Cursor;
-            loop {
-                match msg_stream.next().await {
-                    Some((_rest, MessageStreamItem::Item(ParseYield::Message(item)))) => {
-                        let mut buff = Cursor::new(vec![0; 100 * 1024]);
-                        let cnt = item.to_writer(&mut buff);
-                        consumed += cnt.unwrap_or(0);
-                        match std::str::from_utf8(buff.get_ref()) {
-                            Ok(_) => println!("valid utf8-text"),
-                            Err(_) => println!("INVALID utf8-text"),
-                        }
+            'outer: while let Some(items) = msg_stream.next().await {
+                for item in items {
+                    match item {
+                        (_rest, MessageStreamItem::Item(ParseYield::Message(item))) => {
+                            let mut buff = Cursor::new(vec![0; 100 * 1024]);
+                            let cnt = item.to_writer(&mut buff);
+                            consumed += cnt.unwrap_or(0);
+                            match std::str::from_utf8(buff.get_ref()) {
+                                Ok(_) => println!("valid utf8-text"),
+                                Err(_) => println!("INVALID utf8-text"),
+                            }
 
-                        item_count += 1
-                    }
-                    Some((
-                        _rest,
-                        MessageStreamItem::Item(ParseYield::MessageAndAttachment((
-                            item,
-                            _attachment,
-                        ))),
-                    )) => {
-                        let mut buff = Cursor::new(vec![0; 100 * 1024]);
-                        let cnt = item.to_writer(&mut buff);
-                        consumed += cnt.unwrap_or(0);
-                        match std::str::from_utf8(buff.get_ref()) {
-                            Ok(_) => println!("valid utf8-text"),
-                            Err(_) => println!("INVALID utf8-text"),
+                            item_count += 1
                         }
+                        (
+                            _rest,
+                            MessageStreamItem::Item(ParseYield::MessageAndAttachment((
+                                item,
+                                _attachment,
+                            ))),
+                        ) => {
+                            let mut buff = Cursor::new(vec![0; 100 * 1024]);
+                            let cnt = item.to_writer(&mut buff);
+                            consumed += cnt.unwrap_or(0);
+                            match std::str::from_utf8(buff.get_ref()) {
+                                Ok(_) => println!("valid utf8-text"),
+                                Err(_) => println!("INVALID utf8-text"),
+                            }
 
-                        item_count += 1
+                            item_count += 1
+                        }
+                        (_rest, MessageStreamItem::Item(ParseYield::Attachment(_attachment))) => {
+                            attachment_count += 1
+                        }
+                        (_, MessageStreamItem::Skipped) => skipped_count += 1,
+                        (_, MessageStreamItem::Incomplete) => err_count += 1,
+                        (_, MessageStreamItem::Empty) => err_count += 1,
+                        (_, MessageStreamItem::Done) => break 'outer,
                     }
-                    Some((_rest, MessageStreamItem::Item(ParseYield::Attachment(_attachment)))) => {
-                        attachment_count += 1
-                    }
-                    Some((_, MessageStreamItem::Skipped)) => skipped_count += 1,
-                    Some((_, MessageStreamItem::Incomplete)) => err_count += 1,
-                    Some((_, MessageStreamItem::Empty)) => err_count += 1,
-                    Some((_, MessageStreamItem::Done)) => break,
-                    None => break,
-                }
-                if item_count > 10 || err_count > 10 {
-                    println!(
+                    if item_count > 10 || err_count > 10 {
+                        println!(
                         "TEXT parser, item_count: {item_count}, err_count: {err_count}, skipped count: {skipped_count}, consumed: {consumed}, attachment_count: {attachment_count}"
                     );
-                    break;
+                        break 'outer;
+                    }
                 }
             }
         }

--- a/application/apps/indexer/parsers/src/dlt/mod.rs
+++ b/application/apps/indexer/parsers/src/dlt/mod.rs
@@ -133,15 +133,16 @@ impl From<DltParseError> for Error {
 }
 
 impl<'m> Parser<FormattableMessage<'m>> for DltParser<'m> {
-    fn parse<'b>(
+    fn parse(
         &mut self,
-        input: &'b [u8],
+        input: &[u8],
         timestamp: Option<u64>,
-    ) -> Result<(&'b [u8], Option<ParseYield<FormattableMessage<'m>>>), Error> {
+    ) -> Result<(usize, Option<ParseYield<FormattableMessage<'m>>>), Error> {
         match dlt_message(input, self.filter_config.as_ref(), self.with_storage_header)? {
             (rest, dlt_core::parse::ParsedMessage::FilteredOut(_n)) => {
-                self.offset += input.len() - rest.len();
-                Ok((rest, None))
+                let consumed = input.len() - rest.len();
+                self.offset += consumed;
+                Ok((consumed, None))
             }
             (_, dlt_core::parse::ParsedMessage::Invalid) => {
                 Err(Error::Parse("Invalid parse".to_owned()))
@@ -160,9 +161,10 @@ impl<'m> Parser<FormattableMessage<'m>> for DltParser<'m> {
                     options: self.fmt_options,
                     fibex_someip_metadata: self.fibex_someip_metadata,
                 };
-                self.offset += input.len() - rest.len();
+                let consumed = input.len() - rest.len();
+                self.offset += consumed;
                 Ok((
-                    rest,
+                    consumed,
                     if let Some(attachment) = attachment {
                         Some(ParseYield::MessageAndAttachment((msg, attachment)))
                     } else {
@@ -175,11 +177,11 @@ impl<'m> Parser<FormattableMessage<'m>> for DltParser<'m> {
 }
 
 impl Parser<RangeMessage> for DltRangeParser {
-    fn parse<'b>(
+    fn parse(
         &mut self,
-        input: &'b [u8],
+        input: &[u8],
         _timestamp: Option<u64>,
-    ) -> Result<(&'b [u8], Option<ParseYield<RangeMessage>>), Error> {
+    ) -> Result<(usize, Option<ParseYield<RangeMessage>>), Error> {
         let (rest, consumed) = dlt_consume_msg(input).map_err(|e| Error::Parse(format!("{e}")))?;
         let msg = consumed.map(|c| {
             self.offset += c as usize;
@@ -190,20 +192,22 @@ impl Parser<RangeMessage> for DltRangeParser {
                 },
             }
         });
-        Ok((rest, msg.map(|m| m.into())))
+        let total_consumed = input.len() - rest.len();
+        Ok((total_consumed, msg.map(|m| m.into())))
     }
 }
 
 impl Parser<RawMessage> for DltRawParser {
-    fn parse<'b>(
+    fn parse(
         &mut self,
-        input: &'b [u8],
+        input: &[u8],
         _timestamp: Option<u64>,
-    ) -> Result<(&'b [u8], Option<ParseYield<RawMessage>>), Error> {
+    ) -> Result<(usize, Option<ParseYield<RawMessage>>), Error> {
         let (rest, consumed) = dlt_consume_msg(input).map_err(|e| Error::Parse(format!("{e}")))?;
         let msg = consumed.map(|c| RawMessage {
             content: Vec::from(&input[0..c as usize]),
         });
-        Ok((rest, msg.map(|m| m.into())))
+        let total_consumed = input.len() - rest.len();
+        Ok((total_consumed, msg.map(|m| m.into())))
     }
 }

--- a/application/apps/indexer/parsers/src/lib.rs
+++ b/application/apps/indexer/parsers/src/lib.rs
@@ -35,16 +35,16 @@ impl<T> From<T> for ParseYield<T> {
 /// in chipmunk
 pub trait Parser<T> {
     /// take a slice of bytes and try to apply a parser. If the parse was
-    /// successfull, this will yield  the rest of the slice along with `Some(log_message)`
+    /// successful, this will yield the consumed bytes count along with `Some(log_message)`
     ///
     /// if the slice does not have enough bytes, an `Incomplete` error is returned.
     ///
     /// in case we could parse a message but the message was filtered out, `None` is returned
-    fn parse<'a>(
+    fn parse(
         &mut self,
-        input: &'a [u8],
+        input: &[u8],
         timestamp: Option<u64>,
-    ) -> Result<(&'a [u8], Option<ParseYield<T>>), Error>;
+    ) -> Result<(usize, Option<ParseYield<T>>), Error>;
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/application/apps/indexer/parsers/src/lib.rs
+++ b/application/apps/indexer/parsers/src/lib.rs
@@ -34,17 +34,18 @@ impl<T> From<T> for ParseYield<T> {
 /// Parser trait that needs to be implemented for any parser we support
 /// in chipmunk
 pub trait Parser<T> {
-    /// take a slice of bytes and try to apply a parser. If the parse was
-    /// successful, this will yield the consumed bytes count along with `Some(log_message)`
+    /// Takes a slice of bytes and try to apply a parser. If it can parse any item of them,
+    /// it will return iterator of items with the consumed bytes count along with `Some(log_message)`
     ///
-    /// if the slice does not have enough bytes, an `Incomplete` error is returned.
+    /// if the slice does not have enough bytes to parse any item, an `Incomplete` error is returned.
     ///
-    /// in case we could parse a message but the message was filtered out, `None` is returned
+    /// in case we could parse a message but the message was filtered out, `None` is returned on
+    /// that item.
     fn parse(
         &mut self,
         input: &[u8],
         timestamp: Option<u64>,
-    ) -> Result<(usize, Option<ParseYield<T>>), Error>;
+    ) -> Result<impl Iterator<Item = (usize, Option<ParseYield<T>>)>, Error>;
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/application/apps/indexer/parsers/src/lib.rs
+++ b/application/apps/indexer/parsers/src/lib.rs
@@ -35,12 +35,18 @@ impl<T> From<T> for ParseYield<T> {
 /// in chipmunk
 pub trait Parser<T> {
     /// Takes a slice of bytes and try to apply a parser. If it can parse any item of them,
-    /// it will return iterator of items with the consumed bytes count along with `Some(log_message)`
+    /// it will return iterator of items each with the consumed bytes count along with `Some(log_message)`
     ///
-    /// if the slice does not have enough bytes to parse any item, an `Incomplete` error is returned.
+    /// if the slice does not have enough bytes to parse any item, an [`Error`] is returned.
     ///
     /// in case we could parse a message but the message was filtered out, `None` is returned on
     /// that item.
+    ///
+    /// # Note:
+    ///
+    /// If the parsers encounter any error while it already has parsed any items, then it must
+    /// return those items without the error, then on the next call it can return the errors in
+    /// case it was provided with the same slice of bytes.
     fn parse(
         &mut self,
         input: &[u8],

--- a/application/apps/indexer/parsers/src/someip.rs
+++ b/application/apps/indexer/parsers/src/someip.rs
@@ -5,6 +5,7 @@ use std::{
     collections::HashMap,
     fmt::{self, Display},
     io::Write,
+    iter,
     path::PathBuf,
     sync::Mutex,
 };
@@ -279,9 +280,11 @@ impl Parser<SomeipLogMessage> for SomeipParser {
         &mut self,
         input: &[u8],
         timestamp: Option<u64>,
-    ) -> Result<(usize, Option<ParseYield<SomeipLogMessage>>), Error> {
-        SomeipParser::parse_message(self.fibex_metadata.as_ref(), input, timestamp)
-            .map(|(rest, message)| (rest, Some(ParseYield::from(message))))
+    ) -> Result<impl Iterator<Item = (usize, Option<ParseYield<SomeipLogMessage>>)>, Error> {
+        let item = SomeipParser::parse_message(self.fibex_metadata.as_ref(), input, timestamp)
+            .map(|(rest, message)| (rest, Some(ParseYield::from(message))))?;
+
+        Ok(iter::once(item))
     }
 }
 
@@ -620,7 +623,7 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser.parse(input, None).unwrap().next().unwrap();
         assert_eq!(consumed, input.len());
 
         if let ParseYield::Message(item) = message.unwrap() {
@@ -641,7 +644,7 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser.parse(input, None).unwrap().next().unwrap();
         assert_eq!(consumed, input.len());
 
         if let ParseYield::Message(item) = message.unwrap() {
@@ -662,7 +665,7 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser.parse(input, None).unwrap().next().unwrap();
         assert_eq!(consumed, input.len());
 
         if let ParseYield::Message(item) = message.unwrap() {
@@ -692,7 +695,7 @@ mod test {
         let mut parser = SomeipParser {
             fibex_metadata: Some(fibex_metadata),
         };
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser.parse(input, None).unwrap().next().unwrap();
         assert_eq!(consumed, input.len());
 
         if let ParseYield::Message(item) = message.unwrap() {
@@ -714,7 +717,7 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser.parse(input, None).unwrap().next().unwrap();
         assert_eq!(consumed, input.len());
 
         if let ParseYield::Message(item) = message.unwrap() {
@@ -745,7 +748,7 @@ mod test {
         let mut parser = SomeipParser {
             fibex_metadata: Some(fibex_metadata),
         };
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser.parse(input, None).unwrap().next().unwrap();
         assert_eq!(consumed, input.len());
 
         if let ParseYield::Message(item) = message.unwrap() {
@@ -770,7 +773,7 @@ mod test {
         let mut parser = SomeipParser {
             fibex_metadata: Some(fibex_metadata),
         };
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser.parse(input, None).unwrap().next().unwrap();
         assert_eq!(consumed, input.len());
 
         if let ParseYield::Message(item) = message.unwrap() {
@@ -795,7 +798,7 @@ mod test {
         let mut parser = SomeipParser {
             fibex_metadata: Some(fibex_metadata),
         };
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser.parse(input, None).unwrap().next().unwrap();
         assert_eq!(consumed, input.len());
 
         if let ParseYield::Message(item) = message.unwrap() {
@@ -820,7 +823,7 @@ mod test {
         let mut parser = SomeipParser {
             fibex_metadata: Some(fibex_metadata),
         };
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser.parse(input, None).unwrap().next().unwrap();
         assert_eq!(consumed, input.len());
 
         if let ParseYield::Message(item) = message.unwrap() {
@@ -845,7 +848,7 @@ mod test {
         let mut parser = SomeipParser {
             fibex_metadata: Some(fibex_metadata),
         };
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser.parse(input, None).unwrap().next().unwrap();
         assert_eq!(consumed, input.len());
 
         if let ParseYield::Message(item) = message.unwrap() {
@@ -869,7 +872,7 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser.parse(input, None).unwrap().next().unwrap();
         assert_eq!(consumed, input.len());
 
         if let ParseYield::Message(item) = message.unwrap() {
@@ -915,7 +918,7 @@ mod test {
         ];
 
         let mut parser = SomeipParser::new();
-        let (consumed, message) = parser.parse(input, None).unwrap();
+        let (consumed, message) = parser.parse(input, None).unwrap().next().unwrap();
         assert_eq!(consumed, input.len());
 
         if let ParseYield::Message(item) = message.unwrap() {

--- a/application/apps/indexer/parsers/src/text.rs
+++ b/application/apps/indexer/parsers/src/text.rs
@@ -27,25 +27,25 @@ impl Parser<StringMessage> for StringTokenizer
 where
     StringMessage: LogMessage,
 {
-    fn parse<'b>(
+    fn parse(
         &mut self,
-        input: &'b [u8],
+        input: &[u8],
         _timestamp: Option<u64>,
-    ) -> Result<(&'b [u8], Option<ParseYield<StringMessage>>), Error> {
+    ) -> Result<(usize, Option<ParseYield<StringMessage>>), Error> {
         // TODO: support non-utf8 encodings
         use memchr::memchr;
         if input.is_empty() {
-            return Ok((input, None));
+            return Ok((input.len(), None));
         }
         if let Some(msg_size) = memchr(b'\n', input) {
             let content = String::from_utf8_lossy(&input[..msg_size]);
             let string_msg = StringMessage {
                 content: content.to_string(),
             };
-            Ok((&input[msg_size + 1..], Some(string_msg.into())))
+            Ok((msg_size + 1, Some(string_msg.into())))
         } else {
             Ok((
-                &[],
+                input.len(),
                 Some(ParseYield::from(StringMessage {
                     content: String::new(),
                 })),
@@ -58,18 +58,23 @@ where
 fn test_string_tokenizer() {
     let mut parser = StringTokenizer {};
     let content = b"hello\nworld\n";
-    let (rest_1, first_msg) = parser.parse(content, None).unwrap();
+    let (consumed_1, first_msg) = parser.parse(content, None).unwrap();
     match first_msg {
         Some(ParseYield::Message(StringMessage { content })) if content.eq("hello") => {}
         _ => panic!("First message did not match"),
     }
+    let rest_1 = &content[consumed_1..];
     println!("rest_1 = {:?}", String::from_utf8_lossy(rest_1));
-    let (rest_2, second_msg) = parser.parse(rest_1, None).unwrap();
+    let (consumed_2, second_msg) = parser.parse(rest_1, None).unwrap();
     match second_msg {
         Some(ParseYield::Message(StringMessage { content })) if content.eq("world") => {}
         _ => panic!("Second message did not match"),
     }
-    let (rest_3, third_msg) = parser.parse(rest_2, None).unwrap();
-    println!("rest_3 = {:?}", String::from_utf8_lossy(rest_3));
+    let rest_2 = &rest_1[consumed_2..];
+    let (consumed_3, third_msg) = parser.parse(rest_2, None).unwrap();
+    println!(
+        "rest_3 = {:?}",
+        String::from_utf8_lossy(&rest_2[consumed_3..])
+    );
     assert!(third_msg.is_none());
 }

--- a/application/apps/indexer/processor/src/export/mod.rs
+++ b/application/apps/indexer/processor/src/export/mod.rs
@@ -49,7 +49,7 @@ pub async fn export_raw<S, T>(
 ) -> Result<usize, ExportError>
 where
     T: LogMessage + Sized,
-    S: futures::Stream<Item = (usize, MessageStreamItem<T>)> + Unpin,
+    S: futures::Stream<Item = Box<[(usize, MessageStreamItem<T>)]>> + Unpin,
 {
     trace!("export_raw, sections: {sections:?}");
     if !sections_valid(sections) {
@@ -70,93 +70,100 @@ where
     if sections.is_empty() {
         debug!("no sections configured");
         // export everything
-        while let Some((_, item)) = s.next().await {
+        while let Some(items) = s.next().await {
             if cancel.is_cancelled() {
                 return Err(ExportError::Cancelled);
             }
-            let written = match item {
-                MessageStreamItem::Item(ParseYield::Message(msg)) => {
-                    msg.to_writer(&mut out_writer)?;
-                    true
+
+            for (_, item) in items {
+                let written = match item {
+                    MessageStreamItem::Item(ParseYield::Message(msg)) => {
+                        msg.to_writer(&mut out_writer)?;
+                        true
+                    }
+                    MessageStreamItem::Item(ParseYield::MessageAndAttachment((msg, _))) => {
+                        msg.to_writer(&mut out_writer)?;
+                        true
+                    }
+                    MessageStreamItem::Done => break,
+                    _ => false,
+                };
+                if written && text_file {
+                    out_writer.write_all("\n".as_bytes())?;
                 }
-                MessageStreamItem::Item(ParseYield::MessageAndAttachment((msg, _))) => {
-                    msg.to_writer(&mut out_writer)?;
-                    true
+                if written {
+                    exported += 1;
                 }
-                MessageStreamItem::Done => break,
-                _ => false,
-            };
-            if written && text_file {
-                out_writer.write_all("\n".as_bytes())?;
-            }
-            if written {
-                exported += 1;
             }
         }
         return Ok(exported);
     }
 
-    while let Some((_, item)) = s.next().await {
+    while let Some(items) = s.next().await {
         if cancel.is_cancelled() {
             return Err(ExportError::Cancelled);
         }
-        if !inside {
-            if sections[section_index].first_line == current_index {
-                inside = true;
+        for (_, item) in items {
+            if !inside {
+                if sections[section_index].first_line == current_index {
+                    inside = true;
+                }
+            } else if sections[section_index].last_line < current_index {
+                inside = false;
+                section_index += 1;
+                if sections.len() <= section_index {
+                    // no more sections
+                    if matches!(item, MessageStreamItem::Item(_)) {
+                        current_index += 1;
+                    }
+                    break;
+                }
+                // check if we are in next section again
+                if sections[section_index].first_line == current_index {
+                    inside = true;
+                }
             }
-        } else if sections[section_index].last_line < current_index {
-            inside = false;
-            section_index += 1;
-            if sections.len() <= section_index {
-                // no more sections
-                if matches!(item, MessageStreamItem::Item(_)) {
+            let written = match item {
+                MessageStreamItem::Item(ParseYield::Message(msg)) => {
+                    if inside {
+                        msg.to_writer(&mut out_writer)?;
+                    }
                     current_index += 1;
+                    inside
                 }
-                break;
-            }
-            // check if we are in next section again
-            if sections[section_index].first_line == current_index {
-                inside = true;
-            }
-        }
-        let written = match item {
-            MessageStreamItem::Item(ParseYield::Message(msg)) => {
-                if inside {
-                    msg.to_writer(&mut out_writer)?;
+                MessageStreamItem::Item(ParseYield::MessageAndAttachment((msg, _))) => {
+                    if inside {
+                        msg.to_writer(&mut out_writer)?;
+                    }
+                    current_index += 1;
+                    inside
                 }
-                current_index += 1;
-                inside
-            }
-            MessageStreamItem::Item(ParseYield::MessageAndAttachment((msg, _))) => {
-                if inside {
-                    msg.to_writer(&mut out_writer)?;
+                MessageStreamItem::Done => {
+                    debug!("No more messages to export");
+                    break;
                 }
-                current_index += 1;
-                inside
+                _ => false,
+            };
+            if written && text_file {
+                out_writer.write_all("\n".as_bytes())?;
             }
-            MessageStreamItem::Done => {
-                debug!("No more messages to export");
-                break;
-            }
-            _ => false,
-        };
-        if written && text_file {
-            out_writer.write_all("\n".as_bytes())?;
         }
     }
     if read_to_end {
-        while let Some((_, item)) = s.next().await {
+        while let Some(items) = s.next().await {
             if cancel.is_cancelled() {
                 return Err(ExportError::Cancelled);
             }
-            match item {
-                MessageStreamItem::Item(_) => {
-                    current_index += 1;
+            for (_, item) in items {
+                match item {
+                    MessageStreamItem::Item(_) => {
+                        current_index += 1;
+                    }
+                    MessageStreamItem::Done => {
+                        break;
+                    }
+                    _ => {}
                 }
-                MessageStreamItem::Done => {
-                    break;
-                }
-                _ => {}
             }
         }
     }

--- a/application/apps/indexer/session/src/handlers/export_raw.rs
+++ b/application/apps/indexer/session/src/handlers/export_raw.rs
@@ -200,7 +200,7 @@ pub async fn export_runner<S, T>(
 ) -> Result<Option<usize>, NativeError>
 where
     T: LogMessage + Sized,
-    S: futures::Stream<Item = (usize, MessageStreamItem<T>)> + Unpin,
+    S: futures::Stream<Item = Box<[(usize, MessageStreamItem<T>)]>> + Unpin,
 {
     export_raw(s, dest, sections, read_to_end, text_file, cancel)
         .await

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -30,7 +30,11 @@ env_logger.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
 
 [[bench]]
-name = "mocks_producer"
+name = "mocks_once_producer"
+harness = false
+
+[[bench]]
+name = "mocks_multi_producer"
 harness = false
 
 [[bench]]

--- a/application/apps/indexer/sources/benches/mocks/mock_parser.rs
+++ b/application/apps/indexer/sources/benches/mocks/mock_parser.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{fmt::Display, iter};
 
 use criterion::black_box;
 use parsers::{Attachment, LogMessage, Parser};
@@ -55,7 +55,10 @@ impl Parser<MockMessage> for MockParser {
         &mut self,
         input: &[u8],
         timestamp: Option<u64>,
-    ) -> Result<(usize, Option<parsers::ParseYield<MockMessage>>), parsers::Error> {
+    ) -> Result<
+        impl Iterator<Item = (usize, Option<parsers::ParseYield<MockMessage>>)>,
+        parsers::Error,
+    > {
         #[inline(never)]
         fn inner(
             counter: usize,
@@ -123,6 +126,8 @@ impl Parser<MockMessage> for MockParser {
 
         self.counter += 1;
 
-        inner(self.counter, self.max_count, input, timestamp)
+        let item = inner(self.counter, self.max_count, input, timestamp)?;
+
+        Ok(iter::once(item))
     }
 }

--- a/application/apps/indexer/sources/benches/mocks/mock_parser.rs
+++ b/application/apps/indexer/sources/benches/mocks/mock_parser.rs
@@ -51,19 +51,18 @@ impl LogMessage for MockMessage {
 impl Parser<MockMessage> for MockParser {
     /// This will keep returning a valid item result until the counter reaches max count then it
     /// will be return [`parsers::Error::Eof`]
-    fn parse<'a>(
+    fn parse(
         &mut self,
-        input: &'a [u8],
+        input: &[u8],
         timestamp: Option<u64>,
-    ) -> Result<(&'a [u8], Option<parsers::ParseYield<MockMessage>>), parsers::Error> {
+    ) -> Result<(usize, Option<parsers::ParseYield<MockMessage>>), parsers::Error> {
         #[inline(never)]
         fn inner(
             counter: usize,
             max_count: usize,
             input: &[u8],
             _timestamp: Option<u64>,
-        ) -> Result<(&'static [u8], Option<parsers::ParseYield<MockMessage>>), parsers::Error>
-        {
+        ) -> Result<(usize, Option<parsers::ParseYield<MockMessage>>), parsers::Error> {
             // Return `Eof` Once the counter reaches max_count.
             if counter >= max_count {
                 const ERR: parsers::Error = parsers::Error::Eof;
@@ -85,14 +84,14 @@ impl Parser<MockMessage> for MockParser {
                 // Only this value will be always returned if the calls counter still smaller than
                 // the max value.
                 Ok((
-                    black_box(&[]),
+                    black_box(input.len()),
                     Some(parsers::ParseYield::Message(MockMessage {
                         content: black_box(MSG).into(),
                     })),
                 ))
             } else if black_box(20) > black_box(30) {
                 Ok((
-                    black_box(&[]),
+                    black_box(input.len()),
                     Some(parsers::ParseYield::Attachment(Attachment {
                         size: black_box(10),
                         name: String::from(black_box(MSG)),
@@ -104,7 +103,7 @@ impl Parser<MockMessage> for MockParser {
                 ))
             } else {
                 Ok((
-                    black_box(&[]),
+                    black_box(input.len()),
                     Some(parsers::ParseYield::MessageAndAttachment((
                         MockMessage {
                             content: black_box(MSG).into(),

--- a/application/apps/indexer/sources/benches/mocks/mock_parser.rs
+++ b/application/apps/indexer/sources/benches/mocks/mock_parser.rs
@@ -1,24 +1,57 @@
-use std::{fmt::Display, iter};
+use std::{fmt::Display, iter, marker::PhantomData};
 
 use criterion::black_box;
 use parsers::{Attachment, LogMessage, Parser};
 use serde::Serialize;
 
+/// Empty type used as phantom data with mock parser to indicate that its [`Parser::parse()`]
+/// implementation will always return [`iter::once()`].
+pub struct IterOnce;
+
+/// Empty type used as phantom data with mock parser to indicate that its [`Parser::parse()`]
+/// implementation will always return an iterator with multiple value.
+pub struct IterMany;
+
 #[derive(Debug, Clone, Copy)]
-pub struct MockParser {
+pub struct MockParser<T> {
     /// Sets how many times the method [`Parser::parse()`] will be called before it'll return None.
     max_count: usize,
     /// Internal counter to keep track how many times [`Parser::parse()`] has been called.
     counter: usize,
+    /// Marker to have two implementations for [`Parser`] trait.
+    _phantom: PhantomData<T>,
 }
 
-impl MockParser {
+// This is used in once benchmark only which lead to a warning when this module is
+// imported into multiple benchmark.
+#[allow(dead_code)]
+impl MockParser<IterOnce> {
     /// Creates new instance of the mock parser with the given settings.
+    /// This returns [`iter::once()`] on [`Parser::parse()`]
+    ///
     /// * `max_count`: Sets how many times the method [`Parser::parse()`] will be called before it'll return None.
-    pub const fn new(max_count: usize) -> Self {
+    pub const fn new_once(max_count: usize) -> Self {
         Self {
             max_count,
             counter: 0,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+// This is used in multiple benchmark only which lead to a warning when this module is
+// imported into once benchmark.
+#[allow(dead_code)]
+impl MockParser<IterMany> {
+    /// Creates new instance of the mock parser with the given settings.
+    /// This returns an iterator with multiple values on [`Parser::parse()`]
+    ///
+    /// * `max_count`: Sets how many times the method [`Parser::parse()`] will be called before it'll return None.
+    pub const fn new_multi(max_count: usize) -> Self {
+        Self {
+            max_count,
+            counter: 0,
+            _phantom: PhantomData,
         }
     }
 }
@@ -46,11 +79,78 @@ impl LogMessage for MockMessage {
     }
 }
 
+impl<T> MockParser<T> {
+    #[inline(never)]
+    fn inner(
+        counter: usize,
+        max_count: usize,
+        input: &[u8],
+        _timestamp: Option<u64>,
+    ) -> Result<(usize, Option<parsers::ParseYield<MockMessage>>), parsers::Error> {
+        // Return `Eof` Once the counter reaches max_count.
+        if counter >= max_count {
+            const ERR: parsers::Error = parsers::Error::Eof;
+
+            return Err(criterion::black_box(ERR));
+        }
+
+        // Unnecessary check to convince the compiler that we are using the input.
+        if input.is_empty() {
+            return Err(black_box(parsers::Error::Eof));
+        }
+
+        const MSG: &str = "msg";
+
+        // Unnecessary checks to convince the compiler that all return options are possible.
+        if black_box(50) > black_box(60) {
+            Err(parsers::Error::Incomplete)
+        } else if black_box(50) > black_box(0) {
+            // Only this value will be always returned if the calls counter still smaller than
+            // the max value.
+            Ok((
+                black_box(input.len()),
+                Some(parsers::ParseYield::Message(MockMessage {
+                    content: black_box(MSG).into(),
+                })),
+            ))
+        } else if black_box(20) > black_box(30) {
+            Ok((
+                black_box(input.len()),
+                Some(parsers::ParseYield::Attachment(Attachment {
+                    size: black_box(10),
+                    name: String::from(black_box(MSG)),
+                    data: Vec::new(),
+                    messages: Vec::new(),
+                    created_date: None,
+                    modified_date: None,
+                })),
+            ))
+        } else {
+            Ok((
+                black_box(input.len()),
+                Some(parsers::ParseYield::MessageAndAttachment((
+                    MockMessage {
+                        content: black_box(MSG).into(),
+                    },
+                    Attachment {
+                        size: black_box(10),
+                        name: String::from(black_box(MSG)),
+                        data: Vec::new(),
+                        messages: Vec::new(),
+                        created_date: None,
+                        modified_date: None,
+                    },
+                ))),
+            ))
+        }
+    }
+}
+
 // NOTE: Methods within trait implementation have inner non-async function that should never be
 // inline and the trait method should be always inline. This reduces the noise in the benchmarks.
-impl Parser<MockMessage> for MockParser {
-    /// This will keep returning a valid item result until the counter reaches max count then it
-    /// will be return [`parsers::Error::Eof`]
+impl Parser<MockMessage> for MockParser<IterOnce> {
+    /// This will keep returning a valid item result withing an [`iter::once`] until the counter
+    /// reaches max count then it will be return [`parsers::Error::Eof`]
     fn parse(
         &mut self,
         input: &[u8],
@@ -59,75 +159,36 @@ impl Parser<MockMessage> for MockParser {
         impl Iterator<Item = (usize, Option<parsers::ParseYield<MockMessage>>)>,
         parsers::Error,
     > {
-        #[inline(never)]
-        fn inner(
-            counter: usize,
-            max_count: usize,
-            input: &[u8],
-            _timestamp: Option<u64>,
-        ) -> Result<(usize, Option<parsers::ParseYield<MockMessage>>), parsers::Error> {
-            // Return `Eof` Once the counter reaches max_count.
-            if counter >= max_count {
-                const ERR: parsers::Error = parsers::Error::Eof;
-
-                return Err(criterion::black_box(ERR));
-            }
-
-            // Unnecessary check to convince the compiler that we are using the input.
-            if input.is_empty() {
-                return Err(black_box(parsers::Error::Eof));
-            }
-
-            const MSG: &str = "msg";
-
-            // Unnecessary checks to convince the compiler that all return options are possible.
-            if black_box(50) > black_box(60) {
-                Err(parsers::Error::Incomplete)
-            } else if black_box(50) > black_box(0) {
-                // Only this value will be always returned if the calls counter still smaller than
-                // the max value.
-                Ok((
-                    black_box(input.len()),
-                    Some(parsers::ParseYield::Message(MockMessage {
-                        content: black_box(MSG).into(),
-                    })),
-                ))
-            } else if black_box(20) > black_box(30) {
-                Ok((
-                    black_box(input.len()),
-                    Some(parsers::ParseYield::Attachment(Attachment {
-                        size: black_box(10),
-                        name: String::from(black_box(MSG)),
-                        data: Vec::new(),
-                        messages: Vec::new(),
-                        created_date: None,
-                        modified_date: None,
-                    })),
-                ))
-            } else {
-                Ok((
-                    black_box(input.len()),
-                    Some(parsers::ParseYield::MessageAndAttachment((
-                        MockMessage {
-                            content: black_box(MSG).into(),
-                        },
-                        Attachment {
-                            size: black_box(10),
-                            name: String::from(black_box(MSG)),
-                            data: Vec::new(),
-                            messages: Vec::new(),
-                            created_date: None,
-                            modified_date: None,
-                        },
-                    ))),
-                ))
-            }
-        }
-
         self.counter += 1;
 
-        let item = inner(self.counter, self.max_count, input, timestamp)?;
+        let item = Self::inner(self.counter, self.max_count, input, timestamp)?;
 
         Ok(iter::once(item))
+    }
+}
+
+// NOTE: Methods within trait implementation have inner non-async function that should never be
+// inline and the trait method should be always inline. This reduces the noise in the benchmarks.
+impl Parser<MockMessage> for MockParser<IterMany> {
+    /// This will keep returning an iterator of multiple valid items until the counter reaches max
+    /// count then it will be return [`parsers::Error::Eof`]
+    fn parse(
+        &mut self,
+        input: &[u8],
+        timestamp: Option<u64>,
+    ) -> Result<
+        impl Iterator<Item = (usize, Option<parsers::ParseYield<MockMessage>>)>,
+        parsers::Error,
+    > {
+        self.counter += 1;
+
+        const REPEAT: usize = 10;
+        let mut res = Vec::with_capacity(black_box(REPEAT));
+        for _ in 0..black_box(REPEAT) {
+            let item = Self::inner(self.counter, self.max_count, input, timestamp)?;
+            res.push(item)
+        }
+
+        Ok(res.into_iter())
     }
 }

--- a/application/apps/indexer/sources/benches/mocks_multi_producer.rs
+++ b/application/apps/indexer/sources/benches/mocks_multi_producer.rs
@@ -1,0 +1,53 @@
+use bench_utls::{bench_standrad_config, run_producer};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
+use sources::producer::MessageProducer;
+
+mod bench_utls;
+mod mocks;
+
+/// Runs Benchmarks replicating the producer loop within Chipmunk sessions, using mocks for
+/// [`parsers::Parser`] and [`sources::ByteSource`] to ensure that the measurements is for the
+/// producer loop only.
+///
+/// The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
+/// behavior of the potential plugins in Chipmunk.
+///
+/// NOTE: This benchmark suffers unfortunately from a lot of noise because we are running it with
+/// asynchronous runtime. This test is configured to reduce this amount of noise as possible,
+/// However it would be better to run it multiple time for double checking.
+fn mocks_multi_producer(c: &mut Criterion) {
+    let max_parse_calls = 10000;
+
+    c.bench_with_input(
+        BenchmarkId::new("mocks_multi_producer", max_parse_calls),
+        &(max_parse_calls),
+        |bencher, &max| {
+            bencher
+                // It's important to spawn a new runtime on each run to ensure to reduce the
+                // potential noise produced from one runtime created at the start of all benchmarks
+                // only.
+                .to_async(tokio::runtime::Runtime::new().unwrap())
+                .iter_batched(
+                    || {
+                        // Exclude initiation time from benchmarks.
+                        let parser = MockParser::new_multi(max);
+                        let byte_source = MockByteSource::new();
+                        let producer = MessageProducer::new(parser, byte_source, black_box(None));
+
+                        producer
+                    },
+                    |producer| run_producer(producer),
+                    criterion::BatchSize::SmallInput,
+                )
+        },
+    );
+}
+
+criterion_group! {
+    name = benches;
+    config = bench_standrad_config();
+    targets = mocks_multi_producer
+}
+
+criterion_main!(benches);

--- a/application/apps/indexer/sources/benches/mocks_once_producer.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_producer.rs
@@ -10,14 +10,17 @@ mod mocks;
 /// [`parsers::Parser`] and [`sources::ByteSource`] to ensure that the measurements is for the
 /// producer loop only.
 ///
+/// The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
+/// the current built-in parsers in Chipmunk.
+///
 /// NOTE: This benchmark suffers unfortunately from a lot of noise because we are running it with
 /// asynchronous runtime. This test is configured to reduce this amount of noise as possible,
 /// However it would be better to run it multiple time for double checking.
-fn mocks_producer(c: &mut Criterion) {
+fn mocks_once_producer(c: &mut Criterion) {
     let max_parse_calls = 50000;
 
     c.bench_with_input(
-        BenchmarkId::new("mocks_producer", max_parse_calls),
+        BenchmarkId::new("mocks_once_producer", max_parse_calls),
         &(max_parse_calls),
         |bencher, &max| {
             bencher
@@ -28,7 +31,7 @@ fn mocks_producer(c: &mut Criterion) {
                 .iter_batched(
                     || {
                         // Exclude initiation time from benchmarks.
-                        let parser = MockParser::new(max);
+                        let parser = MockParser::new_once(max);
                         let byte_source = MockByteSource::new();
                         let producer = MessageProducer::new(parser, byte_source, black_box(None));
 
@@ -44,7 +47,7 @@ fn mocks_producer(c: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = bench_standrad_config();
-    targets = mocks_producer
+    targets = mocks_once_producer
 }
 
 criterion_main!(benches);

--- a/application/apps/indexer/sources/src/producer.rs
+++ b/application/apps/indexer/sources/src/producer.rs
@@ -145,6 +145,8 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
                     iter.map(|item| match item {
                         (consumed, Some(m)) => {
                             let total_used_bytes = consumed + skipped_bytes;
+                            // Reset skipped bytes after it had been counted.
+                            skipped_bytes = 0;
                             debug!(
                             "Extracted a valid message, consumed {} bytes (total used {} bytes)",
                             consumed, total_used_bytes
@@ -156,6 +158,8 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
                             total_consumed += consumed;
                             trace!("None, consumed {} bytes", consumed);
                             let total_used_bytes = consumed + skipped_bytes;
+                            // Reset skipped bytes after it had been counted.
+                            skipped_bytes = 0;
                             (total_used_bytes, MessageStreamItem::Skipped)
                         }
                     })

--- a/application/apps/indexer/sources/src/producer.rs
+++ b/application/apps/indexer/sources/src/producer.rs
@@ -141,8 +141,7 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
                 .parser
                 .parse(self.byte_source.current_slice(), self.last_seen_ts)
             {
-                Ok((rest, Some(m))) => {
-                    let consumed = available - rest.len();
+                Ok((consumed, Some(m))) => {
                     let total_used_bytes = consumed + skipped_bytes;
                     debug!(
                         "Extracted a valid message, consumed {} bytes (total used {} bytes)",
@@ -151,8 +150,7 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
                     self.byte_source.consume(consumed);
                     return Some((total_used_bytes, MessageStreamItem::Item(m)));
                 }
-                Ok((rest, None)) => {
-                    let consumed = available - rest.len();
+                Ok((consumed, None)) => {
                     self.byte_source.consume(consumed);
                     trace!("None, consumed {} bytes", consumed);
                     let total_used_bytes = consumed + skipped_bytes;

--- a/application/apps/indexer/sources/src/producer.rs
+++ b/application/apps/indexer/sources/src/producer.rs
@@ -56,15 +56,11 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
         }
     }
     /// create a stream of pairs that contain the count of all consumed bytes and the
-    /// MessageStreamItem
-    pub fn as_stream(&mut self) -> impl Stream<Item = (usize, MessageStreamItem<T>)> + '_ {
+    /// MessageStreamItems
+    pub fn as_stream(&mut self) -> impl Stream<Item = Box<[(usize, MessageStreamItem<T>)]>> + '_ {
         stream! {
             while let Some(items) = self.read_next_segment().await {
-                //TODO AAZ: Temporary solution for now. Change function signature as final
-                //solution.
-                for item in items {
-                    yield item;
-                }
+                yield items;
             }
         }
     }

--- a/application/apps/indexer/sources/src/producer/tests.rs
+++ b/application/apps/indexer/sources/src/producer/tests.rs
@@ -26,8 +26,9 @@ async fn empty_byte_source() {
     let stream = producer.as_stream();
     pin_mut!(stream);
 
-    let next = stream.next().await;
-    assert!(matches!(next, Some((0, MessageStreamItem::Done))));
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(next[0], (0, MessageStreamItem::Done)));
 
     let next = stream.next().await;
     assert!(next.is_none());
@@ -44,8 +45,9 @@ async fn byte_source_fail() {
     pin_mut!(stream);
 
     // Done message should be sent
-    let next = stream.next().await;
-    assert!(matches!(next, Some((0, MessageStreamItem::Done))));
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(next[0], (0, MessageStreamItem::Done)));
 
     // Then the stream should be closed
     let next = stream.next().await;
@@ -55,11 +57,11 @@ async fn byte_source_fail() {
 #[tokio::test]
 async fn parse_item_then_skip() {
     let parser = MockParser::new([
-        Ok(MockParseSeed::new(
+        Ok(vec![MockParseSeed::new(
             5,
             Some(ParseYield::Message(MockMessage::from(1))),
-        )),
-        Ok(MockParseSeed::new(5, None)),
+        )]),
+        Ok(vec![MockParseSeed::new(5, None)]),
     ]);
     let source = MockByteSource::new(
         0,
@@ -75,23 +77,26 @@ async fn parse_item_then_skip() {
     let stream = producer.as_stream();
     pin_mut!(stream);
 
-    // First message should be message with content
-    let next = stream.next().await;
+    // First results should be one message with content
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
     assert!(matches!(
-        next,
-        Some((
+        next[0],
+        (
             5,
             MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
-        ))
+        )
     ));
 
     // Skipped message when Parser is returning None
-    let next = stream.next().await;
-    assert!(matches!(next, Some((5, MessageStreamItem::Skipped))));
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(next[0], (5, MessageStreamItem::Skipped)));
 
     // Done message should be sent
-    let next = stream.next().await;
-    assert!(matches!(next, Some((0, MessageStreamItem::Done))));
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(next[0], (0, MessageStreamItem::Done)));
 
     // Then the stream should be closed
     let next = stream.next().await;
@@ -103,14 +108,14 @@ async fn parse_incomplete() {
     let parser = MockParser::new([
         Err(ParseError::Incomplete),
         Err(ParseError::Incomplete),
-        Ok(MockParseSeed::new(
+        Ok(vec![MockParseSeed::new(
             5,
             Some(ParseYield::Message(MockMessage::from(1))),
-        )),
-        Ok(MockParseSeed::new(
+        )]),
+        Ok(vec![MockParseSeed::new(
             25,
             Some(ParseYield::Message(MockMessage::from(1))),
-        )),
+        )]),
     ]);
     let source = MockByteSource::new(
         0,
@@ -129,28 +134,31 @@ async fn parse_incomplete() {
     pin_mut!(stream);
 
     // First message should be message with content
-    let next = stream.next().await;
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
     assert!(matches!(
-        next,
-        Some((
+        next[0],
+        (
             5,
             MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
-        ))
+        )
     ));
 
     // Second message consumes all the remaining bytes.
-    let next = stream.next().await;
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
     assert!(matches!(
-        next,
-        Some((
+        next[0],
+        (
             25,
             MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
-        ))
+        )
     ));
 
     // Done message should be sent
-    let next = stream.next().await;
-    assert!(matches!(next, Some((0, MessageStreamItem::Done))));
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(next[0], (0, MessageStreamItem::Done)));
 
     // Then the stream should be closed
     let next = stream.next().await;
@@ -197,10 +205,10 @@ async fn parse_err_eof() {
 async fn parsing_error_success_reload() {
     let parser = MockParser::new([
         Err(ParseError::Parse(Default::default())),
-        Ok(MockParseSeed::new(
+        Ok(vec![MockParseSeed::new(
             10,
             Some(ParseYield::Message(MockMessage::from(1))),
-        )),
+        )]),
     ]);
 
     let source = MockByteSource::new(
@@ -218,18 +226,20 @@ async fn parsing_error_success_reload() {
     pin_mut!(stream);
 
     // Message with content should be yielded consuming all the bytes.
-    let next = stream.next().await;
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
     assert!(matches!(
-        next,
-        Some((
+        next[0],
+        (
             20,
             MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
-        ))
+        )
     ));
 
     // Done message should be sent
-    let next = stream.next().await;
-    assert!(matches!(next, Some((0, MessageStreamItem::Done))));
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(next[0], (0, MessageStreamItem::Done)));
 
     // Then the stream should be closed
     let next = stream.next().await;
@@ -240,10 +250,10 @@ async fn parsing_error_success_reload() {
 async fn parsing_error_then_fail_reload() {
     let parser = MockParser::new([
         Err(ParseError::Parse(Default::default())),
-        Ok(MockParseSeed::new(
+        Ok(vec![MockParseSeed::new(
             5,
             Some(ParseYield::Message(MockMessage::from(1))),
-        )),
+        )]),
     ]);
 
     let source = MockByteSource::new(0, [Ok(Some(MockReloadSeed::new(10, 0))), Ok(None)]);
@@ -254,8 +264,9 @@ async fn parsing_error_then_fail_reload() {
     pin_mut!(stream);
 
     // Done message should be sent with unused bytes.
-    let next = stream.next().await;
-    assert!(matches!(next, Some((10, MessageStreamItem::Done))));
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(next[0], (10, MessageStreamItem::Done)));
 
     // Then the stream should be closed
     let next = stream.next().await;
@@ -265,12 +276,12 @@ async fn parsing_error_then_fail_reload() {
 #[tokio::test]
 async fn parse_with_skipped_bytes() {
     let parser = MockParser::new([
-        Ok(MockParseSeed::new(
+        Ok(vec![MockParseSeed::new(
             3,
             Some(ParseYield::Message(MockMessage::from(1))),
-        )),
-        Ok(MockParseSeed::new(2, None)),
-        Ok(MockParseSeed::new(15, None)),
+        )]),
+        Ok(vec![MockParseSeed::new(2, None)]),
+        Ok(vec![MockParseSeed::new(15, None)]),
     ]);
 
     let source = MockByteSource::new(
@@ -289,38 +300,42 @@ async fn parse_with_skipped_bytes() {
     pin_mut!(stream);
 
     // Message with content 1 should be yielded considering skipped bytes
-    let next = stream.next().await;
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
     assert!(matches!(
-        next,
-        Some((
+        next[0],
+        (
             7, // 7: 3 consumed + 4 skipped
             MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
-        ))
+        )
     ));
 
     // Skipped Message should be yielded considering skipped bytes
-    let next = stream.next().await;
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
     assert!(matches!(
-        next,
-        Some((
+        next[0],
+        (
             6, // 6: 2 consumed + 4 skipped
             MessageStreamItem::Skipped
-        ))
+        )
     ));
 
     // Consume the remaining bytes with successful parse.
-    let next = stream.next().await;
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
     assert!(matches!(
-        next,
-        Some((
+        next[0],
+        (
             15, // 15 consumed + 0 skipped
             MessageStreamItem::Skipped
-        ))
+        )
     ));
 
     // Done message should be sent.
-    let next = stream.next().await;
-    assert!(matches!(next, Some((0, MessageStreamItem::Done))));
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(next[0], (0, MessageStreamItem::Done)));
 
     // Then the stream should be closed
     let next = stream.next().await;
@@ -331,10 +346,10 @@ async fn parse_with_skipped_bytes() {
 async fn parsing_error_then_fail_reload_with_skipped_bytes() {
     let parser = MockParser::new([
         Err(ParseError::Parse(Default::default())),
-        Ok(MockParseSeed::new(
+        Ok(vec![MockParseSeed::new(
             5,
             Some(ParseYield::Message(MockMessage::from(1))),
-        )),
+        )]),
     ]);
 
     let source = MockByteSource::new(0, [Ok(Some(MockReloadSeed::new(10, 3))), Ok(None)]);
@@ -345,8 +360,9 @@ async fn parsing_error_then_fail_reload_with_skipped_bytes() {
     pin_mut!(stream);
 
     // Done message should be sent with unused bytes, considering the skipped bytes.
-    let next = stream.next().await;
-    assert!(matches!(next, Some((13, MessageStreamItem::Done))));
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(next[0], (13, MessageStreamItem::Done)));
 
     // Then the stream should be closed
     let next = stream.next().await;
@@ -357,14 +373,14 @@ async fn parsing_error_then_fail_reload_with_skipped_bytes() {
 async fn parsing_error_success_reload_with_skipped_bytes() {
     let parser = MockParser::new([
         Err(ParseError::Parse(Default::default())),
-        Ok(MockParseSeed::new(
+        Ok(vec![MockParseSeed::new(
             5,
             Some(ParseYield::Message(MockMessage::from(1))),
-        )),
-        Ok(MockParseSeed::new(
+        )]),
+        Ok(vec![MockParseSeed::new(
             5,
             Some(ParseYield::Message(MockMessage::from(1))),
-        )),
+        )]),
     ]);
 
     let source = MockByteSource::new(
@@ -383,28 +399,31 @@ async fn parsing_error_success_reload_with_skipped_bytes() {
     pin_mut!(stream);
 
     // Message with content should be yielded considering the skipped bytes on both reload calls
-    let next = stream.next().await;
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
     assert!(matches!(
-        next,
-        Some((
+        next[0],
+        (
             23, // 23: 5 consumed + 10 skipped from Error::Parse match branch + (4 + 4) skipped
             MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
-        ))
+        )
     ));
 
     // Message uses all available bytes.
-    let next = stream.next().await;
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
     assert!(matches!(
-        next,
-        Some((
+        next[0],
+        (
             5,
             MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
-        ))
+        )
     ));
 
     // Done message should be sent
-    let next = stream.next().await;
-    assert!(matches!(next, Some((0, MessageStreamItem::Done))));
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(next[0], (0, MessageStreamItem::Done)));
 
     // Then the stream should be closed
     let next = stream.next().await;
@@ -414,10 +433,10 @@ async fn parsing_error_success_reload_with_skipped_bytes() {
 #[tokio::test]
 /// This function tests the sde SDE Communication in the producer loop
 async fn sde_communication() {
-    let parser = MockParser::new([Ok(MockParseSeed::new(
+    let parser = MockParser::new([Ok(vec![MockParseSeed::new(
         5,
         Some(ParseYield::Message(MockMessage::from(1))),
-    ))]);
+    )])]);
 
     // The duration which `reload()` should wait for before delivering the data.
     const SLEEP_DURATION: Duration = Duration::from_millis(50);
@@ -456,13 +475,14 @@ async fn sde_communication() {
 
     // The first source seed has a delay and won't be picked in the `select!` macro in the producer
     // loop, and it will be dropped because `reload()` in `MockByteSource` isn't cancel safe.
-    let next = stream.next().await;
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
     assert!(matches!(
-        next,
-        Some((
+        next[0],
+        (
             5,
             MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
-        ))
+        )
     ));
 
     // Producer loop must have called `income()` and sent the message by now.

--- a/application/apps/indexer/sources/src/producer/tests/mock_parser.rs
+++ b/application/apps/indexer/sources/src/producer/tests/mock_parser.rs
@@ -1,4 +1,3 @@
-use std::iter;
 use std::{collections::VecDeque, fmt, io::Write, mem, usize};
 
 use parsers::Error;
@@ -36,12 +35,12 @@ impl LogMessage for MockMessage {
 /// Mock Parser to use in prototyping and unit-tests
 pub struct MockParser {
     /// The seeds that will be used to return value on [`Parser::parse()`] calls
-    seeds: VecDeque<Result<MockParseSeed, Error>>,
+    seeds: VecDeque<Result<Vec<MockParseSeed>, Error>>,
 }
 
 impl MockParser {
     /// * `seeds`: Seeds items which that will be used to produce return-values on [`Parser::parse()`] calls
-    pub fn new(seeds: impl Into<VecDeque<Result<MockParseSeed, Error>>>) -> Self {
+    pub fn new(seeds: impl Into<VecDeque<Result<Vec<MockParseSeed>, Error>>>) -> Self {
         Self {
             seeds: seeds.into(),
         }
@@ -80,20 +79,22 @@ where
             .pop_front()
             .expect("Seeds count must match parse count");
 
-        let seed = seed_res?;
+        let seeds = seed_res?;
 
-        Ok(iter::once((seed.cosumed, seed.parse_yeild)))
+        Ok(seeds
+            .into_iter()
+            .map(|seed| (seed.cosumed, seed.parse_yeild)))
     }
 }
 
 #[test]
 fn test_mock_parser() {
     let mut parser = MockParser::new([
-        Ok(MockParseSeed::new(1, None)),
-        Ok(MockParseSeed::new(
+        Ok(vec![MockParseSeed::new(1, None)]),
+        Ok(vec![MockParseSeed::new(
             2,
             Some(ParseYield::Message(MockMessage::from(1))),
-        )),
+        )]),
         Err(ParserError::Eof),
     ]);
 

--- a/application/apps/indexer/sources/src/producer/tests/mock_parser.rs
+++ b/application/apps/indexer/sources/src/producer/tests/mock_parser.rs
@@ -69,11 +69,11 @@ impl Parser<MockMessage> for MockParser
 where
     MockMessage: LogMessage,
 {
-    fn parse<'b>(
+    fn parse(
         &mut self,
-        input: &'b [u8],
+        _input: &[u8],
         _timestamp: Option<u64>,
-    ) -> Result<(&'b [u8], Option<ParseYield<MockMessage>>), Error> {
+    ) -> Result<(usize, Option<ParseYield<MockMessage>>), Error> {
         let seed_res = self
             .seeds
             .pop_front()
@@ -81,7 +81,7 @@ where
 
         let seed = seed_res?;
 
-        Ok((&input[seed.cosumed..], seed.parse_yeild))
+        Ok((seed.cosumed, seed.parse_yeild))
     }
 }
 
@@ -97,12 +97,12 @@ fn test_mock_parser() {
     ]);
 
     let parse_result_ok_none = parser.parse(&[b'a', b'b'], None);
-    assert!(matches!(parse_result_ok_none, Ok((&[b'b'], None))));
+    assert!(matches!(parse_result_ok_none, Ok((1, None))));
 
     let parse_result_ok_val = parser.parse(&[b'a', b'b'], None);
     assert!(matches!(
         parse_result_ok_val,
-        Ok((&[], Some(ParseYield::Message(MockMessage { content: 1 }))))
+        Ok((2, Some(ParseYield::Message(MockMessage { content: 1 }))))
     ));
 
     let parse_result_err = parser.parse(&[b'a', b'b'], None);

--- a/application/apps/indexer/sources/src/producer/tests/mock_parser.rs
+++ b/application/apps/indexer/sources/src/producer/tests/mock_parser.rs
@@ -1,3 +1,4 @@
+use std::iter;
 use std::{collections::VecDeque, fmt, io::Write, mem, usize};
 
 use parsers::Error;
@@ -73,7 +74,7 @@ where
         &mut self,
         _input: &[u8],
         _timestamp: Option<u64>,
-    ) -> Result<(usize, Option<ParseYield<MockMessage>>), Error> {
+    ) -> Result<impl Iterator<Item = (usize, Option<ParseYield<MockMessage>>)>, Error> {
         let seed_res = self
             .seeds
             .pop_front()
@@ -81,7 +82,7 @@ where
 
         let seed = seed_res?;
 
-        Ok((seed.cosumed, seed.parse_yeild))
+        Ok(iter::once((seed.cosumed, seed.parse_yeild)))
     }
 }
 
@@ -96,13 +97,13 @@ fn test_mock_parser() {
         Err(ParserError::Eof),
     ]);
 
-    let parse_result_ok_none = parser.parse(&[b'a', b'b'], None);
-    assert!(matches!(parse_result_ok_none, Ok((1, None))));
+    let parse_result_ok_none = parser.parse(&[b'a', b'b'], None).unwrap().next().unwrap();
+    assert!(matches!(parse_result_ok_none, (1, None)));
 
-    let parse_result_ok_val = parser.parse(&[b'a', b'b'], None);
+    let parse_result_ok_val = parser.parse(&[b'a', b'b'], None).unwrap().next().unwrap();
     assert!(matches!(
         parse_result_ok_val,
-        Ok((2, Some(ParseYield::Message(MockMessage { content: 1 }))))
+        (2, Some(ParseYield::Message(MockMessage { content: 1 })))
     ));
 
     let parse_result_err = parser.parse(&[b'a', b'b'], None);

--- a/application/apps/indexer/sources/src/producer/tests/mock_parser.rs
+++ b/application/apps/indexer/sources/src/producer/tests/mock_parser.rs
@@ -34,7 +34,7 @@ impl LogMessage for MockMessage {
 
 /// Mock Parser to use in prototyping and unit-tests
 pub struct MockParser {
-    /// The seeds that will be used to return value on [`Parser::parse()`] calls
+    /// The seeds that will be used to return values on [`Parser::parse()`] calls
     seeds: VecDeque<Result<Vec<MockParseSeed>, Error>>,
 }
 

--- a/application/apps/indexer/sources/src/producer/tests/mod.rs
+++ b/application/apps/indexer/sources/src/producer/tests/mod.rs
@@ -1,0 +1,5 @@
+mod mock_byte_source;
+mod mock_parser;
+mod single_parse;
+
+use super::*;

--- a/application/apps/indexer/sources/src/producer/tests/mod.rs
+++ b/application/apps/indexer/sources/src/producer/tests/mod.rs
@@ -1,5 +1,6 @@
 mod mock_byte_source;
 mod mock_parser;
+mod multi_parse;
 mod single_parse;
 
 use super::*;

--- a/application/apps/indexer/sources/src/producer/tests/mod.rs
+++ b/application/apps/indexer/sources/src/producer/tests/mod.rs
@@ -1,5 +1,6 @@
 mod mock_byte_source;
 mod mock_parser;
+
 mod multi_parse;
 mod single_parse;
 

--- a/application/apps/indexer/sources/src/producer/tests/multi_parse.rs
+++ b/application/apps/indexer/sources/src/producer/tests/multi_parse.rs
@@ -1,0 +1,445 @@
+//! Tests for parsers returning multiple values
+
+use std::time::Duration;
+
+use super::mock_byte_source::*;
+use super::mock_parser::*;
+use super::*;
+
+use futures::{pin_mut, StreamExt};
+use parsers::{Error as ParseError, ParseYield};
+use tokio::sync::{mpsc::unbounded_channel, oneshot};
+
+use crate::{producer::MessageProducer, sde::SdeRequest};
+
+#[tokio::test]
+async fn parse_items_then_skip() {
+    let parser = MockParser::new([
+        Ok(vec![
+            MockParseSeed::new(4, Some(ParseYield::Message(MockMessage::from(1)))),
+            MockParseSeed::new(6, Some(ParseYield::Message(MockMessage::from(2)))),
+        ]),
+        Ok(vec![
+            MockParseSeed::new(4, None),
+            MockParseSeed::new(6, None),
+        ]),
+    ]);
+    let source = MockByteSource::new(
+        0,
+        [
+            Ok(Some(MockReloadSeed::new(20, 0))),
+            Ok(Some(MockReloadSeed::new(0, 0))),
+            Ok(None),
+        ],
+    );
+
+    let mut producer = MessageProducer::new(parser, source, None);
+
+    let stream = producer.as_stream();
+    pin_mut!(stream);
+
+    // First results should be two messages with content
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 2);
+    assert!(matches!(
+        next[0],
+        (
+            4,
+            MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
+        )
+    ));
+    assert!(matches!(
+        next[1],
+        (
+            6,
+            MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 2 }))
+        )
+    ));
+
+    // Two Skipped messages when Parser is returning None
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 2);
+    assert!(matches!(next[0], (4, MessageStreamItem::Skipped)));
+    assert!(matches!(next[1], (6, MessageStreamItem::Skipped)));
+
+    // Done message should be sent
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(next[0], (0, MessageStreamItem::Done)));
+
+    // Then the stream should be closed
+    let next = stream.next().await;
+    assert!(next.is_none());
+}
+
+#[tokio::test]
+async fn parse_incomplete() {
+    let parser = MockParser::new([
+        Err(ParseError::Incomplete),
+        Err(ParseError::Incomplete),
+        Ok(vec![
+            MockParseSeed::new(5, Some(ParseYield::Message(MockMessage::from(1)))),
+            MockParseSeed::new(25, Some(ParseYield::Message(MockMessage::from(1)))),
+        ]),
+    ]);
+    let source = MockByteSource::new(
+        0,
+        [
+            Ok(Some(MockReloadSeed::new(10, 0))),
+            Ok(Some(MockReloadSeed::new(10, 0))),
+            Ok(Some(MockReloadSeed::new(10, 0))),
+            Ok(None),
+        ],
+    );
+
+    let mut producer = MessageProducer::new(parser, source, None);
+
+    let stream = producer.as_stream();
+    pin_mut!(stream);
+
+    // First message should be message with content and two items
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 2);
+    assert!(matches!(
+        next[0],
+        (
+            5,
+            MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
+        )
+    ));
+
+    assert!(matches!(
+        next[1],
+        (
+            25,
+            MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
+        )
+    ));
+
+    // Done message should be sent
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(next[0], (0, MessageStreamItem::Done)));
+
+    // Then the stream should be closed
+    let next = stream.next().await;
+    assert!(next.is_none());
+}
+
+#[tokio::test]
+async fn parsing_error_success_reload() {
+    let parser = MockParser::new([
+        Err(ParseError::Parse(Default::default())),
+        Ok(vec![
+            MockParseSeed::new(10, Some(ParseYield::Message(MockMessage::from(1)))),
+            MockParseSeed::new(5, Some(ParseYield::Message(MockMessage::from(1)))),
+        ]),
+    ]);
+
+    let source = MockByteSource::new(
+        0,
+        [
+            Ok(Some(MockReloadSeed::new(10, 0))),
+            Ok(Some(MockReloadSeed::new(15, 0))),
+            Ok(None),
+        ],
+    );
+
+    let mut producer = MessageProducer::new(parser, source, None);
+
+    let stream = producer.as_stream();
+    pin_mut!(stream);
+
+    // Message with content should be yielded consuming all the bytes.
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 2);
+    assert!(matches!(
+        next[0],
+        (
+            20,
+            MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
+        )
+    ));
+    assert!(matches!(
+        next[1],
+        (
+            5,
+            MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
+        )
+    ));
+
+    // Done message should be sent
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(next[0], (0, MessageStreamItem::Done)));
+
+    // Then the stream should be closed
+    let next = stream.next().await;
+    assert!(next.is_none());
+}
+
+#[tokio::test]
+async fn parse_with_skipped_bytes() {
+    let parser = MockParser::new([
+        Ok(vec![
+            MockParseSeed::new(3, Some(ParseYield::Message(MockMessage::from(1)))),
+            MockParseSeed::new(5, Some(ParseYield::Message(MockMessage::from(1)))),
+        ]),
+        Ok(vec![
+            MockParseSeed::new(2, None),
+            MockParseSeed::new(4, None),
+        ]),
+        Ok(vec![MockParseSeed::new(15, None)]),
+    ]);
+
+    let source = MockByteSource::new(
+        0,
+        [
+            Ok(Some(MockReloadSeed::new(14, 4))),
+            Ok(Some(MockReloadSeed::new(15, 4))),
+            Ok(None),
+            Ok(None),
+        ],
+    );
+
+    let mut producer = MessageProducer::new(parser, source, None);
+
+    let stream = producer.as_stream();
+    pin_mut!(stream);
+
+    // Two Messages with content 1 should be yielded considering skipped bytes on the first item
+    // only
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 2);
+    assert!(matches!(
+        next[0],
+        (
+            7, // 7: 3 consumed + 4 skipped
+            MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
+        )
+    ));
+    assert!(matches!(
+        next[1],
+        (
+            5, // 5consumed
+            MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
+        )
+    ));
+
+    // Two Skipped Message should be yielded considering skipped bytes on the first item only
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 2);
+    assert!(matches!(
+        next[0],
+        (
+            6, // 6: 2 consumed + 4 skipped
+            MessageStreamItem::Skipped
+        )
+    ));
+    assert!(matches!(
+        next[1],
+        (
+            4, // 4 consumed
+            MessageStreamItem::Skipped
+        )
+    ));
+
+    // Consume the remaining bytes with successful parse.
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(
+        next[0],
+        (
+            15, // 15 consumed + 0 skipped
+            MessageStreamItem::Skipped
+        )
+    ));
+
+    // Done message should be sent.
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(next[0], (0, MessageStreamItem::Done)));
+
+    // Then the stream should be closed
+    let next = stream.next().await;
+    assert!(next.is_none());
+}
+
+#[tokio::test]
+async fn parsing_error_then_fail_reload_with_skipped_bytes() {
+    let parser = MockParser::new([
+        Err(ParseError::Parse(Default::default())),
+        Ok(vec![
+            MockParseSeed::new(4, Some(ParseYield::Message(MockMessage::from(1)))),
+            MockParseSeed::new(6, Some(ParseYield::Message(MockMessage::from(1)))),
+        ]),
+    ]);
+
+    let source = MockByteSource::new(0, [Ok(Some(MockReloadSeed::new(10, 3))), Ok(None)]);
+
+    let mut producer = MessageProducer::new(parser, source, None);
+
+    let stream = producer.as_stream();
+    pin_mut!(stream);
+
+    // Done message should be sent with unused bytes, considering the skipped bytes.
+    // Multiple return parse values shouldn't matter here.
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(next[0], (13, MessageStreamItem::Done)));
+
+    // Then the stream should be closed
+    let next = stream.next().await;
+    assert!(next.is_none());
+}
+
+#[tokio::test]
+async fn parsing_error_success_reload_with_skipped_bytes() {
+    let parser = MockParser::new([
+        Err(ParseError::Parse(Default::default())),
+        Ok(vec![
+            MockParseSeed::new(4, Some(ParseYield::Message(MockMessage::from(1)))),
+            MockParseSeed::new(6, Some(ParseYield::Message(MockMessage::from(1)))),
+        ]),
+        Ok(vec![
+            MockParseSeed::new(4, Some(ParseYield::Message(MockMessage::from(1)))),
+            MockParseSeed::new(6, Some(ParseYield::Message(MockMessage::from(1)))),
+        ]),
+    ]);
+
+    let source = MockByteSource::new(
+        0,
+        [
+            Ok(Some(MockReloadSeed::new(10, 4))),
+            Ok(Some(MockReloadSeed::new(20, 4))),
+            Ok(None),
+            Ok(None),
+        ],
+    );
+
+    let mut producer = MessageProducer::new(parser, source, None);
+
+    let stream = producer.as_stream();
+    pin_mut!(stream);
+
+    // Two Messages with content should be yielded considering the skipped bytes on the first item
+    // only with both reload calls.
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 2);
+    assert!(matches!(
+        next[0],
+        (
+            22, // 22: 4 consumed + 10 skipped from Error::Parse match branch + (4 + 4) skipped
+            MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
+        )
+    ));
+    assert!(matches!(
+        next[1],
+        (
+            6, // 6 consumed
+            MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
+        )
+    ));
+
+    // Two Messages use all available bytes.
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 2);
+    assert!(matches!(
+        next[0],
+        (
+            4,
+            MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
+        )
+    ));
+    assert!(matches!(
+        next[1],
+        (
+            6,
+            MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
+        )
+    ));
+
+    // Done message should be sent
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 1);
+    assert!(matches!(next[0], (0, MessageStreamItem::Done)));
+
+    // Then the stream should be closed
+    let next = stream.next().await;
+    assert!(next.is_none());
+}
+
+#[tokio::test]
+/// This function tests the sde SDE Communication in the producer loop
+async fn sde_communication() {
+    let parser = MockParser::new([Ok(vec![
+        MockParseSeed::new(4, Some(ParseYield::Message(MockMessage::from(1)))),
+        MockParseSeed::new(6, Some(ParseYield::Message(MockMessage::from(1)))),
+    ])]);
+
+    // The duration which `reload()` should wait for before delivering the data.
+    const SLEEP_DURATION: Duration = Duration::from_millis(50);
+
+    let source = MockByteSource::new(
+        0,
+        [
+            // This value must never be delivered because `reload()` on `MockByteSource`
+            // isn't cancel safe, and the value here will be dropped with the `reload()` future
+            // within the `select!()` macro in producer loop.
+            Ok(Some(
+                MockReloadSeed::new(10, 0).sleep_duration(SLEEP_DURATION),
+            )),
+            // This value should be delivered because the first one must be dropped because of the
+            // cancel safety issue
+            Ok(Some(MockReloadSeed::new(10, 0))),
+        ],
+    );
+
+    // Create producer with sde channels
+    let (tx_sde, rx_sde) = unbounded_channel();
+    let mut producer = MessageProducer::new(parser, source, Some(rx_sde));
+
+    let stream = producer.as_stream();
+    pin_mut!(stream);
+
+    // Send message to sde receiver before calling next.
+    let (tx_sde_response, mut rx_sde_response) = oneshot::channel();
+    const SDE_TEXT: &str = "sde_msg";
+    tx_sde
+        .send((
+            SdeRequest::WriteText(String::from(SDE_TEXT)),
+            tx_sde_response,
+        ))
+        .unwrap();
+
+    // The first source seed has a delay and won't be picked in the `select!` macro in the producer
+    // loop, and it will be dropped because `reload()` in `MockByteSource` isn't cancel safe.
+    let next = stream.next().await.unwrap();
+    assert_eq!(next.len(), 2);
+    assert!(matches!(
+        next[0],
+        (
+            4,
+            MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
+        )
+    ));
+    assert!(matches!(
+        next[1],
+        (
+            6,
+            MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
+        )
+    ));
+
+    // Producer loop must have called `income()` and sent the message by now.
+    // The bytes length must match the sent message length as it implemented and tested in `MockByteSource`
+    let sde_response_res = rx_sde_response
+        .try_recv()
+        .expect("Sde Response must be sent by now because of the delay");
+
+    let sde_response =
+        sde_response_res.expect("`income()` method on `MockByteSource` should never fail");
+
+    // Returned bytes' length must match the length of the sent data.
+    assert_eq!(sde_response.bytes, SDE_TEXT.len());
+}

--- a/application/apps/indexer/sources/src/producer/tests/multi_parse.rs
+++ b/application/apps/indexer/sources/src/producer/tests/multi_parse.rs
@@ -97,7 +97,7 @@ async fn parse_incomplete() {
     let stream = producer.as_stream();
     pin_mut!(stream);
 
-    // First message should be message with content and two items
+    // First message should be two messages with content
     let next = stream.next().await.unwrap();
     assert_eq!(next.len(), 2);
     assert!(matches!(
@@ -150,7 +150,7 @@ async fn parsing_error_success_reload() {
     let stream = producer.as_stream();
     pin_mut!(stream);
 
-    // Message with content should be yielded consuming all the bytes.
+    // Two Messages with content should be yielded consuming all the bytes.
     let next = stream.next().await.unwrap();
     assert_eq!(next.len(), 2);
     assert!(matches!(

--- a/application/apps/indexer/sources/src/producer/tests/single_parse.rs
+++ b/application/apps/indexer/sources/src/producer/tests/single_parse.rs
@@ -1,20 +1,16 @@
-mod mock_byte_source;
-mod mock_parser;
+//! Tests for parsers returning single value always
 
 use std::time::Duration;
 
+use super::mock_byte_source::*;
+use super::mock_parser::*;
+use super::*;
+
 use futures::{pin_mut, StreamExt};
 use parsers::{Error as ParseError, ParseYield};
-use tests::mock_parser::*;
 use tokio::sync::{mpsc::unbounded_channel, oneshot};
 
-use crate::{
-    producer::tests::mock_byte_source::{MockByteSource, MockReloadSeed},
-    sde::SdeRequest,
-    Error,
-};
-
-use super::*;
+use crate::{producer::MessageProducer, sde::SdeRequest, Error};
 
 #[tokio::test]
 async fn empty_byte_source() {

--- a/cli/config/bench_core.toml
+++ b/cli/config/bench_core.toml
@@ -1,5 +1,9 @@
 [[bench]]
-name = "mocks_producer"
+name = "mocks_once_producer"
+library = "sources"
+
+[[bench]]
+name = "mocks_multi_producer"
 library = "sources"
 
 [[bench]]


### PR DESCRIPTION
This PR Changes the Producer Loop to support parsers returning multiple items at once on calling `parse()` method, which is essentially for implementing parsers in the plugins system.

Following has been implemented:
- [x] Parse returns the consumed count of bytes as `usize` instead of the reference to the remaining slice.
- [x] Parse returns an iterator of messages inside a result, to indicate that it should try parsing all messages in the given slice and return them or return an Error of no item has been parsed with the current call
- [x] Implementation of the current parsers hasn't changed much. They use `iter::once()` to indicate that they have one item only to get most compile time optimization from the compiler
- [x] Producer stream returns a boxed slice of all mapped items from `parse()` call, which gives the compiler the info that the consumer of them won't change it to get more optimizations.
- [x] Producer unit tests has been adjusted for `iter::once()` case without much change and extend with new tests with mock parsers returning multiple items at once
- [x] We have two benchmarks with mocks now instead of one (one for `iter::once()` and one for multiple values). Adjustments to the configuration of Build CLI tool are done too.
- [x] I've considered using `smallvec` but it had worse performance compared to boxed slice. 

Here are some benchmarks from DLT file (541 MB) running in Chipmunk app and in dlt benches of the current master and this branch for comparison + Benchmarks with mock parser returning single item in master and `iter::once()` in this Branch:

```Markdown

# Master: 

## App DLT:
File Read Took: 11.464 ms
File Read Took: 11.343 ms
File Read Took: 11.382 ms

## Bench DLT:
dlt_producer            time:   [4.0264 s 4.0323 s 4.0381 s]
dlt_producer            time:   [4.0504 s 4.0603 s 4.0698 s]

## Bench Mock (single):
mocks_producer/50000    time:   [5.0924 ms 5.1012 ms 5.1111 ms]
mocks_producer/50000    time:   [4.8922 ms 4.9009 ms 4.9105 ms]
mocks_producer/50000    time:   [5.4412 ms 5.4490 ms 5.4575 ms]

=========================================================

# PR:

## App DLT:
File Read Took: 11.430 ms
File Read Took: 11.309 ms
File Read Took: 11.261 ms

## Bench DLT:
dlt_producer            time:   [4.0641 s 4.0709 s 4.0781 s]
dlt_producer            time:   [4.0621 s 4.0713 s 4.0799 s]
dlt_producer            time:   [4.0772 s 4.0855 s 4.0936 s]

## Bench Mock (single):
mocks_producer/50000    time:   [4.3264 ms 4.3353 ms 4.3453 ms]
mocks_producer/50000    time:   [4.2533 ms 4.2647 ms 4.2769 ms]
mocks_producer/50000    time:   [4.2273 ms 4.2433 ms 4.2609 ms]

```