### PR TITLE
Build CLI: Check for newer version locally & Commands Info in Logs

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.6
+
+## Features:
+
+* Check the latest version of this tool on the local repository and compare it to the installed one.
+
+
 # 0.2.5
 
 ## Features:

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features:
 
 * Check the latest version of this tool on the local repository and compare it to the installed one.
+* Add the running process commands and their current directory to the logs.
 
 
 # 0.2.5

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cargo-chipmunk"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chipmunk"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Ammar Abou Zor <ammar.abou.zor@accenture.com>"]
 edition = "2021"
 description = "CLI Tool for chipmunk application development"

--- a/cli/src/cli_args.rs
+++ b/cli/src/cli_args.rs
@@ -10,6 +10,14 @@ const FAIL_FAST_HELP_TEXT: &str = "Stops execution immediately if any job fails.
 const NO_FAIL_FAST_HELP_TEXT: &str = "Don't stops execution immediately if any job fails.";
 const UI_LOG_OPTION_HELP_TEXT: &str =
     "Specifies the UI options for displaying command logs and progress in the terminal";
+const HELP_TEMPLATE: &str = "\
+{before-help}{about}
+version: {version}
+
+{usage-heading} {usage}
+
+{all-args}{after-help}
+";
 
 // To enable calling the app as cargo subcommand the following changes were made:
 // * Cli commands are nested are subcommand within Chipmunk command
@@ -21,7 +29,7 @@ pub enum CargoCli {
 }
 
 #[derive(clap::Args, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version, about, help_template = HELP_TEMPLATE)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Command,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,6 +18,7 @@ mod shell;
 mod spawner;
 mod target;
 mod tracker;
+mod version;
 
 use anyhow::{bail, Error};
 use checksum_records::ChecksumRecords;
@@ -46,6 +47,9 @@ async fn main() -> Result<(), Error> {
 
     // Validate current directory location.
     init_location()?;
+
+    // Check for newer versions
+    version::check_version();
 
     // Handle the app main process in a separate method, keeping this method for handling
     // manual cancelling as well.

--- a/cli/src/spawner.rs
+++ b/cli/src/spawner.rs
@@ -99,9 +99,14 @@ pub async fn spawn(
     combined_env_vars.extend(environment_vars);
 
     let tracker = get_tracker();
+    let cmd_combined = command.combine();
+    let cmd_msg = format!("Running command: {cmd_combined}");
+    tracker.msg(job_def, cmd_msg);
+    let cwd_msg = format!("Running in directory: {}", cwd.display());
+    tracker.msg(job_def, cwd_msg);
 
     let command_result = shell_tokio_command()
-        .arg(command.combine())
+        .arg(cmd_combined)
         .current_dir(&cwd)
         .envs(combined_env_vars)
         .stdout(Stdio::piped())
@@ -198,12 +203,18 @@ pub async fn spawn_blocking(
     let mut combined_env_vars = vec![(String::from("TERM"), String::from("xterm-256color"))];
     combined_env_vars.extend(environment_vars);
 
+    let tracker = get_tracker();
+
+    let cmd_combined = command.combine();
+    let cmd_msg = format!("Running command: {cmd_combined}");
+    tracker.msg(job_def, cmd_msg);
+    let cwd_msg = format!("Running in directory: {}", cwd.display());
+    tracker.msg(job_def, cwd_msg);
+
     let mut cmd = shell_std_command();
-    cmd.arg(command.combine());
+    cmd.arg(cmd_combined);
     cmd.current_dir(&cwd);
     cmd.envs(combined_env_vars);
-
-    let tracker = get_tracker();
 
     let status = tracker.run_synchronously(job_def, cmd).await?;
 

--- a/cli/src/version.rs
+++ b/cli/src/version.rs
@@ -1,0 +1,150 @@
+//! Manages Comparing the current version of the binary to the version of this CLI tool from the
+//! current local repository of the user, printing a message to the user on newer editions.
+
+use std::{fmt::Display, str::FromStr};
+
+use anyhow::{ensure, Context};
+use console::style;
+use toml::Value;
+
+use crate::target::Target;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// Represents a semantic Version with major, minor, patch parts
+struct Version(usize, usize, usize);
+
+impl FromStr for Version {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split('.');
+        const ERROR_MSG: &str = "String is invalid";
+
+        let major = parts
+            .next()
+            .and_then(|m| m.parse().ok())
+            .context(ERROR_MSG)?;
+        let minor = parts
+            .next()
+            .and_then(|m| m.parse().ok())
+            .context(ERROR_MSG)?;
+        let patch = parts
+            .next()
+            .and_then(|m| m.parse().ok())
+            .context(ERROR_MSG)?;
+
+        Ok(Version(major, minor, patch))
+    }
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.0, self.1, self.2)
+    }
+}
+
+/// Compares the version of this CLI tool of the version in `cargo.toml` in the
+/// local repository, printing a warning if a newer version is available.
+pub fn check_version() {
+    if let Err(err) = try_check_version() {
+        let msg = format!("Check for version of Build CLI Tool Failed.\nError: {err:?}\n");
+        eprintln!("{}", style(msg).yellow());
+    }
+}
+
+/// Reads and parses the version from the current local repo and compare it to version of the
+/// current binary file, printing a message if a newer version is available.
+fn try_check_version() -> anyhow::Result<()> {
+    let bin_version = bin_version();
+    let bin_version: Version = bin_version.parse().with_context(|| {
+        format!("Parsing current binary version text failed. Version: {bin_version}")
+    })?;
+    let repo_version =
+        version_in_repo().context("Parsing version of CLI from local repo failed")?;
+    let repo_version: Version = repo_version.parse().with_context(|| {
+        format!("Parsing local repo version text failed. Version: {repo_version}")
+    })?;
+
+    if repo_version > bin_version {
+        let warn_msg = format!("A newer version of the Build CLI Tool is available in your local repository\nInstalled Version: {bin_version}\nLatest Version: {repo_version}\n");
+        eprintln!("{}", style(warn_msg).yellow());
+    }
+
+    Ok(())
+}
+
+/// Returns the version of current binary.
+fn bin_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Reads `cargo.toml` of build CLI tool in the local repo, returning the current version of
+/// the app from it.
+fn version_in_repo() -> anyhow::Result<String> {
+    let cargo_path = Target::Cli.cwd().join("Cargo.toml");
+    ensure!(
+        cargo_path.exists(),
+        "Cargo file for build_cli doesn't exit. Path: {}",
+        cargo_path.display()
+    );
+
+    let cargo_content = std::fs::read_to_string(&cargo_path).with_context(|| {
+        format!(
+            "Reading CLI Cargo file failed. Path {}",
+            cargo_path.display()
+        )
+    })?;
+
+    let cargo_toml: Value = cargo_content.parse().with_context(|| {
+        format!(
+            "Parsing the content of CLI cargo file failed. Path: {}",
+            cargo_path.display()
+        )
+    })?;
+
+    let version = cargo_toml
+        .get("package")
+        .and_then(|pkg| pkg.get("version"))
+        .and_then(|v| match v {
+            Value::String(s) => Some(s.to_owned()),
+            _ => None,
+        })
+        .context("Failed to parse app version from CLI cargo.toml file")?;
+
+    Ok(version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use Version as V;
+
+    #[test]
+    fn version_ord() {
+        assert!(V(1, 1, 1) > V(1, 1, 0));
+        assert!(V(1, 0, 1) < V(1, 1, 0));
+        assert!(V(2, 0, 1) > V(1, 1, 0));
+        assert!(V(0, 0, 1) < V(1, 1, 0));
+    }
+
+    #[test]
+    fn version_parse() {
+        assert_eq!(V::from_str("1.2.3").unwrap(), V(1, 2, 3));
+
+        assert!(V::from_str("1.2").is_err());
+        assert!(V::from_str("1111").is_err());
+        assert!(V::from_str("").is_err());
+        assert!(V::from_str("one.two.three").is_err());
+    }
+
+    #[test]
+    fn version_ord_str() {
+        let ver1: V = "1.2.3".parse().unwrap();
+        let ver2: V = "0.4.5".parse().unwrap();
+        assert!(ver1 > ver2);
+
+        let ver3: V = "2.0.0".parse().unwrap();
+        assert!(ver3 > ver1);
+        assert!(ver3 > ver2);
+    }
+}


### PR DESCRIPTION
This PR closes #2112 

* It adds a check to compare the version of the installed tool to the latest version of the build CLI tool on the user's local repository. This is pragmatic solution to avoid checking for the updates from master branch on GitHub on each run of the tool or develop more complex solution by checking for updates once daily and cache the value somewhere. 
Since the tool will be running inside Chipmunk repo anyway then it would make sense to check the available version on the local repo.
If this check fails, then a warning will be printed to the users, but the tool will continue executing.

* Logs are extended with each running command with the current directory where it's running

* This PR adds the version to the current output of the help command as well.   