### PR TITLE
Parse DLT network-trace prefix for SOME/IP messages

### DIFF
--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -1437,6 +1437,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memchr",
+ "nom",
  "rand",
  "regex",
  "serde",

--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 
 members = [
     "addons/dlt-tools",
+    "addons/someip-tools",
     "addons/file-tools",
     "addons/text_grep",
     "indexer_base",

--- a/application/apps/indexer/addons/someip-tools/Cargo.toml
+++ b/application/apps/indexer/addons/someip-tools/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "someip-tools"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+nom = "7.1"
+thiserror.workspace = true
+
+[dev-dependencies]

--- a/application/apps/indexer/addons/someip-tools/src/lib.rs
+++ b/application/apps/indexer/addons/someip-tools/src/lib.rs
@@ -1,0 +1,153 @@
+use std::{
+    fmt::{self, Display},
+    net::Ipv4Addr,
+};
+
+use nom::{
+    combinator::map,
+    number::streaming::{be_u16, be_u32, be_u8},
+    sequence::tuple,
+    IResult,
+    Finish,
+};
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Parse error: {0}")]
+    Parse(String),
+    #[error("Incomplete, not enough data for a message")]
+    Incomplete,
+}
+
+impl nom::error::ParseError<&[u8]> for Error {
+    fn from_error_kind(input: &[u8], kind: nom::error::ErrorKind) -> Self {
+        Error::Parse(format!(
+            "Nom error: {:?} ({} bytes left)",
+            kind,
+            input.len()
+        ))
+    }
+
+    fn append(_: &[u8], _: nom::error::ErrorKind, other: Self) -> Self {
+        other
+    }
+}
+
+/// Parses a DLT Network-Trace prefix for a SOME/IP message from the given input.
+///
+/// A valid prefix will consist of:
+/// - 4 bytes as IPv4 address
+/// - 2 bytes as udp/tcp port
+/// - 1 byte as protocol type (0 = local, 1 = tcp, 2 = udp)
+/// - 1 byte as message direction (0 = incoming, 1 = outgoing)
+/// - 1, 2 or 4 bytes as instance-id
+pub fn parse_prefix(input: &[u8]) -> Result<(&[u8], std::string::String), Error> {
+    map(
+        tuple((be_u32, be_u16, be_u8, be_u8, parse_instance)),
+        |(address, port, proto, direction, instance)| {
+            format!(
+                "{}:{}{} INST:{}{}",
+                Ipv4Addr::from(address),
+                port,
+                Direction::try_from(direction)
+                    .ok()
+                    .map_or_else(String::default, |s| format!(" {}", s)),
+                instance,
+                Proto::try_from(proto)
+                    .ok()
+                    .map_or_else(String::default, |s| format!(" {}", s))
+            )
+        },
+    )(input).finish()
+}
+
+fn parse_instance(input: &[u8]) -> IResult<&[u8], usize, Error> {
+    match input.len() {
+        1 => map(be_u8, |i| i as usize)(input),
+        2 => map(be_u16, |i| i as usize)(input),
+        4 => map(be_u32, |i| i as usize)(input),
+        _ => Err(nom::Err::Error(Error::Incomplete)),
+    }
+}
+
+enum Direction {
+    Incoming,
+    Outgoing,
+}
+
+impl Display for Direction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Direction::Incoming => write!(f, "<<"),
+            Direction::Outgoing => write!(f, ">>"),
+        }
+    }
+}
+
+impl TryFrom<u8> for Direction {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Direction::Incoming),
+            1 => Ok(Direction::Outgoing),
+            _ => Err(()),
+        }
+    }
+}
+
+enum Proto {
+    Local,
+    Tcp,
+    Udp,
+}
+
+impl Display for Proto {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Proto::Local => write!(f, "LOCAL"),
+            Proto::Tcp => write!(f, "TCP"),
+            Proto::Udp => write!(f, "UDP"),
+        }
+    }
+}
+
+impl TryFrom<u8> for Proto {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Proto::Local),
+            1 => Ok(Proto::Tcp),
+            2 => Ok(Proto::Udp),
+            _ => Err(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_prefix() {
+        let input = [0x7F, 0x00, 0x00, 0x01, 0x30, 0x39, 0x01, 0x00, 0x01];
+        let result = parse_prefix(&input).expect("prefix");
+        assert_eq!("127.0.0.1:12345 << INST:1 TCP", result.1);
+
+        let input = [0x7F, 0x00, 0x00, 0x01, 0x30, 0x39, 0x02, 0x01, 0x00, 0x01];
+        let result = parse_prefix(&input).expect("prefix");
+        assert_eq!("127.0.0.1:12345 >> INST:1 UDP", result.1);
+
+        let input = [
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x01,
+        ];
+        let result = parse_prefix(&input).expect("prefix");
+        assert_eq!("0.0.0.0:0 INST:1", result.1);
+
+        let input = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        assert!(parse_prefix(&input).is_err())
+    }
+}

--- a/application/apps/indexer/parsers/Cargo.toml
+++ b/application/apps/indexer/parsers/Cargo.toml
@@ -18,6 +18,7 @@ thiserror.workspace = true
 rand.workspace = true
 someip-messages = { git = "https://github.com/esrlabs/someip" }
 someip-payload = { git = "https://github.com/esrlabs/someip-payload" }
+someip-tools = { path = "../addons/someip-tools" }
 
 [dev-dependencies]
 stringreader = "0.1.1"

--- a/application/apps/indexer/parsers/src/dlt/fmt.rs
+++ b/application/apps/indexer/parsers/src/dlt/fmt.rs
@@ -25,6 +25,7 @@ use dlt_core::{
     service_id::service_id_lookup,
 };
 use log::trace;
+use someip_tools::parse_prefix;
 
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 
@@ -604,7 +605,12 @@ impl<'a> fmt::Display for FormattableMessage<'a> {
                     if let Some(slice) = slices.get(1) {
                         match SomeipParser::parse_message(self.fibex_someip_metadata, slice, None) {
                             Ok((_, message)) => {
-                                return write!(f, "SOME/IP {:?}", message);
+                                let prefix = slices.first().map_or_else(String::default, |s| {
+                                    parse_prefix(s)
+                                        .ok()
+                                        .map_or_else(String::default, |p| format!("{} ", p.1))
+                                });
+                                return write!(f, "SOME/IP {}{:?}", prefix, message);
                             }
                             Err(error) => {
                                 return write!(f, "SOME/IP '{}' {:02X?}", error, slice);

--- a/application/apps/indexer/parsers/src/someip.rs
+++ b/application/apps/indexer/parsers/src/someip.rs
@@ -192,6 +192,7 @@ impl SomeipParser {
         }
     }
 
+    /// Parses a SOME/IP message (header and payload) from the given input.
     pub(crate) fn parse_message(
         fibex_metadata: Option<&FibexMetadata>,
         input: &[u8],

--- a/application/apps/rustcore/ts-bindings/spec/session.observe.spec.ts
+++ b/application/apps/rustcore/ts-bindings/spec/session.observe.spec.ts
@@ -627,7 +627,7 @@ describe('Observe', function () {
                                 expect(result.length).toEqual(6);
                                 expect(result[0].content.split('\u0004')).toEqual([
                                     '2024-02-20T13:17:26.713537000Z', 'ECU1', '1', '571', '204', '28138506', 'ECU1', 'APP1', 'C1', 'IPC',
-                                    'SOME/IP RPC SERV:123 METH:32773 LENG:16 CLID:0 SEID:58252 IVER:1 MSTP:2 RETC:0 [00, 00, 01, 88, 01, C3, C4, 1D]',
+                                    'SOME/IP 0.0.0.0:0 >> INST:1 RPC SERV:123 METH:32773 LENG:16 CLID:0 SEID:58252 IVER:1 MSTP:2 RETC:0 [00, 00, 01, 88, 01, C3, C4, 1D]',
                                 ]);
                                 expect(result[5].content.split('\u0004')).toEqual([
                                     '2024-02-20T13:17:26.713537000Z', 'ECU1', '1', '571', '209', '28138506', 'ECU1', 'APP1', 'C1', 'IPC',
@@ -692,23 +692,23 @@ describe('Observe', function () {
                                 expect(result.length).toEqual(6);
                                 expect(result[0].content.split('\u0004')).toEqual([
                                     '2024-02-20T13:17:26.713537000Z', 'ECU1', '1', '571', '204', '28138506', 'ECU1', 'APP1', 'C1', 'IPC',
-                                    'SOME/IP RPC SERV:123 METH:32773 LENG:16 CLID:0 SEID:58252 IVER:1 MSTP:2 RETC:0 TestService::timeEvent {\u0006\ttimestamp (INT64) : 1683656786973,\u0006}',
+                                    'SOME/IP 0.0.0.0:0 >> INST:1 RPC SERV:123 METH:32773 LENG:16 CLID:0 SEID:58252 IVER:1 MSTP:2 RETC:0 TestService::timeEvent {\u0006\ttimestamp (INT64) : 1683656786973,\u0006}',
                                 ]);
                                 expect(result[1].content.split('\u0004')).toEqual([
                                     '2024-02-20T13:17:26.713537000Z', 'ECU1', '1', '571', '205', '28138506', 'ECU1', 'APP1', 'C1', 'IPC',
-                                    'SOME/IP RPC SERV:124 METH:32773 LENG:16 CLID:0 SEID:58252 IVER:1 MSTP:2 RETC:0 UnknownService [00, 00, 01, 88, 01, C3, C4, 1D]',
+                                    'SOME/IP 0.0.0.0:0 >> INST:1 RPC SERV:124 METH:32773 LENG:16 CLID:0 SEID:58252 IVER:1 MSTP:2 RETC:0 UnknownService [00, 00, 01, 88, 01, C3, C4, 1D]',
                                 ]);
                                 expect(result[2].content.split('\u0004')).toEqual([
                                     '2024-02-20T13:17:26.713537000Z', 'ECU1', '1', '571', '206', '28138506', 'ECU1', 'APP1', 'C1', 'IPC',
-                                    'SOME/IP RPC SERV:123 METH:32773 LENG:16 CLID:0 SEID:58252 IVER:3 MSTP:2 RETC:0 TestService<1?>::timeEvent {\u0006\ttimestamp (INT64) : 1683656786973,\u0006}',
+                                    'SOME/IP 0.0.0.0:0 >> INST:1 RPC SERV:123 METH:32773 LENG:16 CLID:0 SEID:58252 IVER:3 MSTP:2 RETC:0 TestService<1?>::timeEvent {\u0006\ttimestamp (INT64) : 1683656786973,\u0006}',
                                 ]);
                                 expect(result[3].content.split('\u0004')).toEqual([
                                     '2024-02-20T13:17:26.713537000Z', 'ECU1', '1', '571', '207', '28138506', 'ECU1', 'APP1', 'C1', 'IPC',
-                                    'SOME/IP RPC SERV:123 METH:32774 LENG:16 CLID:0 SEID:58252 IVER:1 MSTP:2 RETC:0 TestService::UnknownMethod [00, 00, 01, 88, 01, C3, C4, 1D]',
+                                    'SOME/IP 0.0.0.0:0 >> INST:1 RPC SERV:123 METH:32774 LENG:16 CLID:0 SEID:58252 IVER:1 MSTP:2 RETC:0 TestService::UnknownMethod [00, 00, 01, 88, 01, C3, C4, 1D]',
                                 ]);
                                 expect(result[4].content.split('\u0004')).toEqual([
                                     '2024-02-20T13:17:26.713537000Z', 'ECU1', '1', '571', '208', '28138506', 'ECU1', 'APP1', 'C1', 'IPC',
-                                    'SOME/IP RPC SERV:123 METH:32773 LENG:15 CLID:0 SEID:58252 IVER:1 MSTP:2 RETC:0 TestService::timeEvent \'SOME/IP Error: Parser exhausted at offset 0 for Object size 8\' [00, 00, 01, 88, 01, C3, C4]',
+                                    'SOME/IP 0.0.0.0:0 >> INST:1 RPC SERV:123 METH:32773 LENG:15 CLID:0 SEID:58252 IVER:1 MSTP:2 RETC:0 TestService::timeEvent \'SOME/IP Error: Parser exhausted at offset 0 for Object size 8\' [00, 00, 01, 88, 01, C3, C4]',
                                 ]);
                                 expect(result[5].content.split('\u0004')).toEqual([
                                     '2024-02-20T13:17:26.713537000Z', 'ECU1', '1', '571', '209', '28138506', 'ECU1', 'APP1', 'C1', 'IPC',


### PR DESCRIPTION
This PR will add information from the DLT network-trace prefix to the resulting SOME/IP information being displayed.

In DLT network-traces for SOME/IP the DLT payload contains of two arguments, where the first argument is a prefix with additional information on the actual SOME/IP message in the the second argument.

For the implementation the prefix will be expected to consist of:
- 4 bytes as IPv4 address
- 2 bytes as udp/tcp port
- 1 byte as protocol type (0 = local, 1 = tcp, 2 = udp)
- 1 byte as message direction (0 = incoming, 1 = outgoing)
- 1, 2 or 4 bytes as SOME/IP instance-id