### PR TITLE
Benchmarks & Build CLI Tool: Small Improvements & Fixes

### DIFF
--- a/application/apps/indexer/sources/benches/bench_utls.rs
+++ b/application/apps/indexer/sources/benches/bench_utls.rs
@@ -16,6 +16,7 @@ use tokio_stream::StreamExt;
 
 pub const INPUT_SOURCE_ENV_VAR: &str = "CHIPMUNK_BENCH_SOURCE";
 pub const CONFIG_ENV_VAR: &str = "CHIPMUNK_BENCH_CONFIG";
+pub const SAMPLE_SIZE_ENV_VAR: &str = "CHIPMUNK_BENCH_SAMPLE_SIZE";
 
 /// Retrieves the path of the binary files from the environment variable [`INPUT_SOURCE_ENV_VAR`]
 /// then reads it providing its content as bytes.
@@ -118,13 +119,19 @@ where
 /// Even with these configurations, it's advisable to run the benchmarks multiple times to increase the
 /// correctness of the results.
 pub fn bench_standrad_config() -> Criterion {
+    // Sample size can be additionally configured via environment variables
+    let sample_size = std::env::var(SAMPLE_SIZE_ENV_VAR)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(200);
+
     Criterion::default()
         // Warm up time is very important here because multiple async runtimes will be spawn in
         // that time which make the next ones to spawn more stable.
         .warm_up_time(Duration::from_secs(10))
         // Measurement time and sample sized to role out noise in the measurements as possible.
         .measurement_time(Duration::from_secs(20))
-        .sample_size(200)
+        .sample_size(sample_size)
         // These two values help to reduce the noise level in the results.
         .significance_level(0.01)
         .noise_threshold(0.03)

--- a/application/apps/indexer/sources/benches/dlt_producer.rs
+++ b/application/apps/indexer/sources/benches/dlt_producer.rs
@@ -34,7 +34,7 @@ fn dlt_producer(c: &mut Criterion) {
             .to_async(tokio::runtime::Runtime::new().unwrap())
             .iter_batched(
                 || {
-                    let parser = DltParser::new(None, fibex.as_ref(), None, None, false);
+                    let parser = DltParser::new(None, fibex.as_ref(), None, None, true);
                     let source = create_binary_bytesource(data);
                     let producer = MessageProducer::new(parser, source, black_box(None));
 

--- a/application/apps/indexer/sources/benches/mocks/mock_source.rs
+++ b/application/apps/indexer/sources/benches/mocks/mock_source.rs
@@ -22,7 +22,8 @@ impl ByteSource for MockByteSource {
             const ZERO: usize = 0;
 
             if offset == black_box(ZERO) {
-                println!("Random message to make sure the compiler won't optimize this");
+                // Print message to avoid misleading compile time optimizations.
+                println!("Consume is called with Zero offset");
             }
         }
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.7
+
+## Features:
+
+* Add sample size CLI argument on benchmarks for rust core.
+
+
 # 0.2.6
 
 ## Features:

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cargo-chipmunk"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chipmunk"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Ammar Abou Zor <ammar.abou.zor@accenture.com>"]
 edition = "2021"
 description = "CLI Tool for chipmunk application development"

--- a/cli/src/benchmark/core.rs
+++ b/cli/src/benchmark/core.rs
@@ -17,6 +17,8 @@ pub const CONFIG_FILENAME: &str = "bench_core.toml";
 pub const INPUT_SOURCE_ENV_VAR: &str = "CHIPMUNK_BENCH_SOURCE";
 /// Environment variables to pass configurations to benchmarks.
 pub const CONFIG_ENV_VAR: &str = "CHIPMUNK_BENCH_CONFIG";
+/// Environment variables to pass sample size to benchmarks.
+pub const SAMPLE_SIZE_ENV_VAR: &str = "CHIPMUNK_BENCH_SAMPLE_SIZE";
 
 #[derive(Debug, Clone, Deserialize)]
 /// Configurations info for rust core benchmarks.
@@ -80,6 +82,7 @@ pub fn run_benchmark(
     input_source: Option<String>,
     additional_config: Option<String>,
     run_count: u8,
+    sample_size: Option<usize>,
 ) -> anyhow::Result<()> {
     let config_info = ConfigsInfos::load()?;
     let bench = config_info
@@ -119,6 +122,10 @@ pub fn run_benchmark(
             // Same Case as input source above
             let config = resolve_if_path(config);
             command.env(CONFIG_ENV_VAR, config);
+        }
+
+        if let Some(sample_size) = sample_size {
+            command.env(SAMPLE_SIZE_ENV_VAR, sample_size.to_string());
         }
 
         command.current_dir(&cwd);

--- a/cli/src/benchmark/mod.rs
+++ b/cli/src/benchmark/mod.rs
@@ -24,6 +24,10 @@ pub enum BenchTarget {
         /// Determines how many times to run the benchmark.
         #[arg(short, long, default_value = "1")]
         run_count: u8,
+
+        /// Sets sample size on criterion benchmarks
+        #[arg(short, long)]
+        sample_size: Option<usize>,
     },
     /// Lists all the available benchmarks in configuration files.
     List,
@@ -38,8 +42,9 @@ impl BenchTarget {
                 input_source,
                 config,
                 run_count,
+                sample_size,
             } => {
-                core::run_benchmark(name, input_source, config, run_count)?;
+                core::run_benchmark(name, input_source, config, run_count, sample_size)?;
             }
             BenchTarget::List => {
                 println!("Listing all benchmarks from configurations...");


### PR DESCRIPTION
This PR provides the following improvements and fixes to the build CIL tool and benchmarks:

* `Sample Size` can be configured via environment variables or with CLI arguments on build CLI tool.
* DLT parser option `with_storage_header` is set to true by default since this is the default case for DLT files (which is the only case for running benchmarks currently)
* Change confusing error message on mock byte source to more meaningful one. 