### PR TITLE
Use `mimalloc` Memory Allocator & Extend Benchmarks with Different Memory Allocators 

### DIFF
--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -1129,6 +1129,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,6 +1240,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1595,6 +1614,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
+ "mimalloc",
  "parsers",
  "pretty_assertions",
  "rand",
@@ -2029,6 +2049,7 @@ dependencies = [
  "indexer_base",
  "lazy_static",
  "log",
+ "mimalloc",
  "parsers",
  "pcap-parser",
  "regex",

--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -2056,7 +2056,6 @@ dependencies = [
  "serde",
  "shellexpand",
  "thiserror",
- "tikv-jemallocator",
  "tokio",
  "tokio-serial",
  "tokio-stream",
@@ -2203,26 +2202,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.85",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -2056,6 +2056,7 @@ dependencies = [
  "serde",
  "shellexpand",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "tokio-serial",
  "tokio-stream",
@@ -2202,6 +2203,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.85",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -40,7 +40,6 @@ env_logger = "0.10"
 # Support for `html_reports` needs running the benchmarks via `cargo-criterion` tool.
 criterion = { version = "0.5", features = ["html_reports"] }
 mimalloc = "0.1"
-tikv-jemallocator = "0.6"
 
 # only uncomment when profiling
 # [profile.release]

--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -37,6 +37,7 @@ tempfile = "3.10.0"
 env_logger = "0.10"
 # Support for `html_reports` needs running the benchmarks via `cargo-criterion` tool.
 criterion = { version = "0.5", features = ["html_reports"] }
+mimalloc = "0.1"
 
 # only uncomment when profiling
 # [profile.release]

--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -35,9 +35,12 @@ uuid = "1.3"
 grep-searcher = "0.1"
 tempfile = "3.10.0"
 env_logger = "0.10"
+
+## Development Dependencies ##
 # Support for `html_reports` needs running the benchmarks via `cargo-criterion` tool.
 criterion = { version = "0.5", features = ["html_reports"] }
 mimalloc = "0.1"
+tikv-jemallocator = "0.6"
 
 # only uncomment when profiling
 # [profile.release]

--- a/application/apps/indexer/processor/Cargo.toml
+++ b/application/apps/indexer/processor/Cargo.toml
@@ -28,6 +28,7 @@ criterion.workspace = true
 pretty_assertions = "1.3"
 rand.workspace = true
 tempfile.workspace = true
+mimalloc.workspace = true
 
 [[bench]]
 name = "map_benchmarks"

--- a/application/apps/indexer/processor/benches/map_benchmarks.rs
+++ b/application/apps/indexer/processor/benches/map_benchmarks.rs
@@ -4,6 +4,9 @@ extern crate processor;
 use criterion::{Criterion, *};
 use processor::map::{FilterMatch, SearchMap};
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn scaled_benchmark(c: &mut Criterion) {
     let mut example_map: SearchMap = SearchMap::new();
     let mut v = vec![];

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -28,6 +28,7 @@ shellexpand = "3.0.0"
 [dev-dependencies]
 env_logger.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
+mimalloc.workspace = true
 
 [[bench]]
 name = "mocks_once_producer"

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -29,9 +29,18 @@ shellexpand = "3.0.0"
 env_logger.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
 mimalloc.workspace = true
+tikv-jemallocator.workspace = true
 
 [[bench]]
 name = "mocks_once_producer"
+harness = false
+
+[[bench]]
+name = "mocks_once_producer_jemalloc"
+harness = false
+
+[[bench]]
+name = "mocks_once_producer_sysalloc"
 harness = false
 
 [[bench]]

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -48,6 +48,14 @@ name = "mocks_multi_producer"
 harness = false
 
 [[bench]]
+name = "mocks_multi_producer_jemalloc"
+harness = false
+
+[[bench]]
+name = "mocks_multi_producer_sysalloc"
+harness = false
+
+[[bench]]
 name = "dlt_producer"
 harness = false
 

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -29,14 +29,9 @@ shellexpand = "3.0.0"
 env_logger.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
 mimalloc.workspace = true
-tikv-jemallocator.workspace = true
 
 [[bench]]
 name = "mocks_once_producer"
-harness = false
-
-[[bench]]
-name = "mocks_once_producer_jemalloc"
 harness = false
 
 [[bench]]
@@ -45,10 +40,6 @@ harness = false
 
 [[bench]]
 name = "mocks_multi_producer"
-harness = false
-
-[[bench]]
-name = "mocks_multi_producer_jemalloc"
 harness = false
 
 [[bench]]

--- a/application/apps/indexer/sources/benches/dlt_producer.rs
+++ b/application/apps/indexer/sources/benches/dlt_producer.rs
@@ -9,6 +9,10 @@ use sources::producer::MessageProducer;
 
 mod bench_utls;
 
+// The MiMalloc allocator is currently used in the Chipmunk app.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// This benchmark covers parsing from DLT file and supports providing the path for a fibex file as
 /// additional configuration.
 fn dlt_producer(c: &mut Criterion) {

--- a/application/apps/indexer/sources/benches/macros/mock_producer_multi.rs
+++ b/application/apps/indexer/sources/benches/macros/mock_producer_multi.rs
@@ -1,0 +1,79 @@
+//! Provides macro to generate benchmarks with mock parser returning multiple value at a time using
+//! various memory allocators
+
+/// Macro to generate benchmarks with mock parser and source for various memory allocators.
+/// The parser mock in this macro will return multiple items per call using a vector to replicate
+/// the behavior of the potential plugins in Chipmunk.
+///
+/// # Usage:
+/// The macro accepts the name of the benchmark function and the allocator, and generates a
+/// benchmark function with given name using the given allocator
+///
+/// # Example:
+/// ```
+/// mod macros;
+/// mocks_producer_multi!(mocks_multi_producer_stdalloc, std::alloc::System);
+/// ```
+#[macro_export]
+macro_rules! mocks_producer_multi {
+    ($name:ident, $allocator:path) => {
+        use ::criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+        use ::sources::producer::MessageProducer;
+        use ::std::hint::black_box;
+        use bench_utls::{bench_standrad_config, run_producer};
+        use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
+
+        mod bench_utls;
+        mod mocks;
+
+        #[global_allocator]
+        static GLOBAL: $allocator = $allocator;
+
+        /// Runs Benchmarks replicating the producer loop within Chipmunk sessions, using mocks for
+        /// [`parsers::Parser`] and [`sources::ByteSource`] to ensure that the measurements is for the
+        /// producer loop only.
+        ///
+        /// The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
+        /// behavior of the potential plugins in Chipmunk.
+        ///
+        /// NOTE: This benchmark suffers unfortunately from a lot of noise because we are running it with
+        /// asynchronous runtime. This test is configured to reduce this amount of noise as possible,
+        /// However it would be better to run it multiple time for double checking.
+        fn $name(c: &mut Criterion) {
+            let max_parse_calls = 10000;
+
+            c.bench_with_input(
+                BenchmarkId::new(std::stringify!($name), max_parse_calls),
+                &(max_parse_calls),
+                |bencher, &max| {
+                    bencher
+                        // It's important to spawn a new runtime on each run to ensure to reduce the
+                        // potential noise produced from one runtime created at the start of all benchmarks
+                        // only.
+                        .to_async(tokio::runtime::Runtime::new().unwrap())
+                        .iter_batched(
+                            || {
+                                // Exclude initiation time from benchmarks.
+                                let parser = MockParser::new_multi(max);
+                                let byte_source = MockByteSource::new();
+                                let producer =
+                                    MessageProducer::new(parser, byte_source, black_box(None));
+
+                                producer
+                            },
+                            |producer| run_producer(producer),
+                            criterion::BatchSize::SmallInput,
+                        )
+                },
+            );
+        }
+
+        criterion_group! {
+            name = benches;
+            config = bench_standrad_config();
+            targets = $name
+        }
+
+        criterion_main!(benches);
+    };
+}

--- a/application/apps/indexer/sources/benches/macros/mock_producer_once.rs
+++ b/application/apps/indexer/sources/benches/macros/mock_producer_once.rs
@@ -1,0 +1,79 @@
+//! Provides macro to generate benchmarks with mock parser returning one value at a time using
+//! various memory allocators
+
+/// Macro to generate benchmarks with mock parser and source for various memory allocators.
+/// The parser mock in this macro will return one item per call with `iter::once()` to replicate
+/// the case with built in parsers.
+///
+/// # Usage:
+/// The macro accepts the name of the benchmark function and the allocator, and generates a
+/// benchmark function with given name using the given allocator
+///
+/// # Example:
+/// ```
+/// mod macros;
+/// mocks_producer_once!(mocks_once_producer_stdalloc, std::alloc::System);
+/// ```
+#[macro_export]
+macro_rules! mocks_producer_once {
+    ($name:ident, $allocator:path) => {
+        use ::criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+        use ::sources::producer::MessageProducer;
+        use ::std::hint::black_box;
+        use bench_utls::{bench_standrad_config, run_producer};
+        use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
+
+        mod bench_utls;
+        mod mocks;
+
+        #[global_allocator]
+        static GLOBAL: $allocator = $allocator;
+
+        /// Runs Benchmarks replicating the producer loop within Chipmunk sessions, using mocks for
+        /// [`parsers::Parser`] and [`sources::ByteSource`] to ensure that the measurements is for the
+        /// producer loop only.
+        ///
+        /// The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
+        /// the current built-in parsers in Chipmunk.
+        ///
+        /// NOTE: This benchmark suffers unfortunately from a lot of noise because we are running it with
+        /// asynchronous runtime. This test is configured to reduce this amount of noise as possible,
+        /// However it would be better to run it multiple time for double checking.
+        fn $name(c: &mut Criterion) {
+            let max_parse_calls = 50000;
+
+            c.bench_with_input(
+                BenchmarkId::new(std::stringify!($name), max_parse_calls),
+                &(max_parse_calls),
+                |bencher, &max| {
+                    bencher
+                        // It's important to spawn a new runtime on each run to ensure to reduce the
+                        // potential noise produced from one runtime created at the start of all benchmarks
+                        // only.
+                        .to_async(tokio::runtime::Runtime::new().unwrap())
+                        .iter_batched(
+                            || {
+                                // Exclude initiation time from benchmarks.
+                                let parser = MockParser::new_once(max);
+                                let byte_source = MockByteSource::new();
+                                let producer =
+                                    MessageProducer::new(parser, byte_source, black_box(None));
+
+                                producer
+                            },
+                            |producer| run_producer(producer),
+                            criterion::BatchSize::SmallInput,
+                        )
+                },
+            );
+        }
+
+        criterion_group! {
+            name = benches;
+            config = bench_standrad_config();
+            targets = $name
+        }
+
+        criterion_main!(benches);
+    };
+}

--- a/application/apps/indexer/sources/benches/macros/mod.rs
+++ b/application/apps/indexer/sources/benches/macros/mod.rs
@@ -4,4 +4,5 @@
 // together yet.
 #![allow(unused)]
 
+pub mod mock_producer_multi;
 pub mod mock_producer_once;

--- a/application/apps/indexer/sources/benches/macros/mod.rs
+++ b/application/apps/indexer/sources/benches/macros/mod.rs
@@ -1,0 +1,7 @@
+//! Provides macros to generate benchmarks with different environments like memory allocators.
+
+// Macros here are used within benchmarks but rust checking isn't able to connect the module
+// together yet.
+#![allow(unused)]
+
+pub mod mock_producer_once;

--- a/application/apps/indexer/sources/benches/mocks_multi_producer_jemalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_multi_producer_jemalloc.rs
@@ -1,9 +1,0 @@
-//! Benchmarks for producer loop with mock parser and byte source using `jemalloc` memory allocator,
-//! which provides the best performance and is used in Chipmunk app currently.
-//!
-//! The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
-//! behavior of the potential plugins in Chipmunk.
-
-mod macros;
-
-mocks_producer_multi!(mocks_multi_producer_jemalloc, tikv_jemallocator::Jemalloc);

--- a/application/apps/indexer/sources/benches/mocks_multi_producer_jemalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_multi_producer_jemalloc.rs
@@ -1,4 +1,4 @@
-//! Benchmarks for producer loop with mock parser and byte source using `mimalloc` memory allocator,
+//! Benchmarks for producer loop with mock parser and byte source using `jemalloc` memory allocator,
 //! which provides the best performance and is used in Chipmunk app currently.
 //!
 //! The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
@@ -6,4 +6,4 @@
 
 mod macros;
 
-mocks_producer_multi!(mocks_multi_producer, mimalloc::MiMalloc);
+mocks_producer_multi!(mocks_multi_producer_jemalloc, tikv_jemallocator::Jemalloc);

--- a/application/apps/indexer/sources/benches/mocks_multi_producer_sysalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_multi_producer_sysalloc.rs
@@ -1,4 +1,4 @@
-//! Benchmarks for producer loop with mock parser and byte source using `mimalloc` memory allocator,
+//! Benchmarks for producer loop with mock parser and byte source using rust standard memory allocator,
 //! which provides the best performance and is used in Chipmunk app currently.
 //!
 //! The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
@@ -6,4 +6,4 @@
 
 mod macros;
 
-mocks_producer_multi!(mocks_multi_producer, mimalloc::MiMalloc);
+mocks_producer_multi!(mocks_multi_producer_sysalloc, std::alloc::System);

--- a/application/apps/indexer/sources/benches/mocks_once_producer.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_producer.rs
@@ -8,6 +8,10 @@ use sources::producer::MessageProducer;
 mod bench_utls;
 mod mocks;
 
+// The MiMalloc allocator is currently used in the Chipmunk app.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Runs Benchmarks replicating the producer loop within Chipmunk sessions, using mocks for
 /// [`parsers::Parser`] and [`sources::ByteSource`] to ensure that the measurements is for the
 /// producer loop only.

--- a/application/apps/indexer/sources/benches/mocks_once_producer.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_producer.rs
@@ -1,54 +1,9 @@
-use std::hint::black_box;
+//! Benchmarks for producer loop with mock parser and byte source using `mimalloc` memory allocator,
+//! which provides the best performance and is used in Chipmunk app currently.
+//!
+//! The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
+//! the current built-in parsers in Chipmunk.
 
-use bench_utls::{bench_standrad_config, run_producer};
-use criterion::{criterion_group, criterion_main, Criterion};
-use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
-use sources::producer::MessageProducer;
+mod macros;
 
-mod bench_utls;
-mod mocks;
-
-// The MiMalloc allocator is currently used in the Chipmunk app.
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
-/// Runs Benchmarks replicating the producer loop within Chipmunk sessions, using mocks for
-/// [`parsers::Parser`] and [`sources::ByteSource`] to ensure that the measurements is for the
-/// producer loop only.
-///
-/// The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
-/// the current built-in parsers in Chipmunk.
-///
-/// NOTE: This benchmark suffers unfortunately from a lot of noise because we are running it with
-/// asynchronous runtime. This test is configured to reduce this amount of noise as possible,
-/// However it would be better to run it multiple time for double checking.
-fn mocks_once_producer(c: &mut Criterion) {
-    c.bench_function("mocks_once_producer", |bencher| {
-        bencher
-            // It's important to spawn a new runtime on each run to ensure to reduce the
-            // potential noise produced from one runtime created at the start of all benchmarks
-            // only.
-            .to_async(tokio::runtime::Runtime::new().unwrap())
-            .iter_batched(
-                || {
-                    // Exclude initiation time from benchmarks.
-                    let max_parse_calls = black_box(50000);
-                    let parser = MockParser::new_once(max_parse_calls);
-                    let byte_source = MockByteSource::new();
-                    let producer = MessageProducer::new(parser, byte_source, black_box(None));
-
-                    producer
-                },
-                |producer| run_producer(producer),
-                criterion::BatchSize::SmallInput,
-            )
-    });
-}
-
-criterion_group! {
-    name = benches;
-    config = bench_standrad_config();
-    targets = mocks_once_producer
-}
-
-criterion_main!(benches);
+mocks_producer_once!(mocks_once_producer, mimalloc::MiMalloc);

--- a/application/apps/indexer/sources/benches/mocks_once_producer_jemalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_producer_jemalloc.rs
@@ -1,8 +1,0 @@
-//! Benchmarks for producer loop with mock parser and byte source using `jemalloc` memory allocator.
-//!
-//! The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
-//! the current built-in parsers in Chipmunk.
-
-mod macros;
-
-mocks_producer_once!(mocks_once_producer_jemalloc, tikv_jemallocator::Jemalloc);

--- a/application/apps/indexer/sources/benches/mocks_once_producer_jemalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_producer_jemalloc.rs
@@ -1,0 +1,8 @@
+//! Benchmarks for producer loop with mock parser and byte source using `jemalloc` memory allocator.
+//!
+//! The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
+//! the current built-in parsers in Chipmunk.
+
+mod macros;
+
+mocks_producer_once!(mocks_once_producer_jemalloc, tikv_jemallocator::Jemalloc);

--- a/application/apps/indexer/sources/benches/mocks_once_producer_sysalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_producer_sysalloc.rs
@@ -1,0 +1,8 @@
+//! Benchmarks for producer loop with mock parser and byte source using rust standard memory allocator.
+//!
+//! The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
+//! the current built-in parsers in Chipmunk.
+
+mod macros;
+
+mocks_producer_once!(mocks_once_producer_sysalloc, std::alloc::System);

--- a/application/apps/indexer/sources/benches/someip_legacy_producer.rs
+++ b/application/apps/indexer/sources/benches/someip_legacy_producer.rs
@@ -7,6 +7,10 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use parsers::someip::SomeipParser;
 use sources::{binary::pcap::legacy::PcapLegacyByteSource, producer::MessageProducer};
 
+// The MiMalloc allocator is currently used in the Chipmunk app.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// This benchmark covers parsing from SomeIP file using [`PcapLegacyByteSource`] byte source.
 /// It supports providing the path for a fibex file as additional configuration.
 fn someip_legacy_producer(c: &mut Criterion) {

--- a/application/apps/indexer/sources/benches/someip_producer.rs
+++ b/application/apps/indexer/sources/benches/someip_producer.rs
@@ -7,6 +7,10 @@ use sources::{binary::pcap::ng::PcapngByteSource, producer::MessageProducer};
 
 mod bench_utls;
 
+// The MiMalloc allocator is currently used in the Chipmunk app.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// This benchmark covers parsing from SomeIP file using [`PcapngByteSource`] byte source.
 /// It supports providing the path for a fibex file as additional configuration.
 fn someip_producer(c: &mut Criterion) {

--- a/application/apps/indexer/sources/benches/text_producer.rs
+++ b/application/apps/indexer/sources/benches/text_producer.rs
@@ -8,6 +8,10 @@ use sources::producer::MessageProducer;
 
 mod bench_utls;
 
+// The MiMalloc allocator is currently used in the Chipmunk app.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// This benchmark covers parsing from text file file using [`BinaryByteSource`].
 /// This benchmark doesn't support any additional configurations.
 fn text_producer(c: &mut Criterion) {

--- a/application/apps/rustcore/rs-bindings/Cargo.lock
+++ b/application/apps/rustcore/rs-bindings/Cargo.lock
@@ -1179,6 +1179,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,6 +1337,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1492,6 +1511,7 @@ dependencies = [
  "log",
  "log4rs",
  "merging",
+ "mimalloc",
  "node-bindgen",
  "processor",
  "serde",

--- a/application/apps/rustcore/rs-bindings/Cargo.toml
+++ b/application/apps/rustcore/rs-bindings/Cargo.toml
@@ -35,3 +35,4 @@ thiserror = "1.0"
 tokio = { version = "1.24", features = ["full"] }
 tokio-util = "0.7"
 uuid = { version = "1.3", features = ["serde", "v4"] }
+mimalloc = "0.1"

--- a/application/apps/rustcore/rs-bindings/src/lib.rs
+++ b/application/apps/rustcore/rs-bindings/src/lib.rs
@@ -1,2 +1,9 @@
 mod js;
 mod logging;
+
+// Using the mimalloc allocator resulted in an 8% performance improvement.
+// NOTE: In a Rust project, the memory allocator can only be set once,
+// and it applies to the entire project, including all dependencies.
+// We chose to configure the allocator in the highest-level library where the runtime is also set.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;

--- a/cli/config/bench_core.toml
+++ b/cli/config/bench_core.toml
@@ -15,6 +15,14 @@ name = "mocks_multi_producer"
 library = "sources"
 
 [[bench]]
+name = "mocks_multi_producer_jemalloc"
+library = "sources"
+
+[[bench]]
+name = "mocks_multi_producer_sysalloc"
+library = "sources"
+
+[[bench]]
 name = "dlt_producer"
 library = "sources"
 

--- a/cli/config/bench_core.toml
+++ b/cli/config/bench_core.toml
@@ -3,19 +3,11 @@ name = "mocks_once_producer"
 library = "sources"
 
 [[bench]]
-name = "mocks_once_producer_jemalloc"
-library = "sources"
-
-[[bench]]
 name = "mocks_once_producer_sysalloc"
 library = "sources"
 
 [[bench]]
 name = "mocks_multi_producer"
-library = "sources"
-
-[[bench]]
-name = "mocks_multi_producer_jemalloc"
 library = "sources"
 
 [[bench]]

--- a/cli/config/bench_core.toml
+++ b/cli/config/bench_core.toml
@@ -3,6 +3,14 @@ name = "mocks_once_producer"
 library = "sources"
 
 [[bench]]
+name = "mocks_once_producer_jemalloc"
+library = "sources"
+
+[[bench]]
+name = "mocks_once_producer_sysalloc"
+library = "sources"
+
+[[bench]]
 name = "mocks_multi_producer"
 library = "sources"
 


### PR DESCRIPTION
This PR closes #2117 

This PR changes the used memory allocator in Rust to [mimalloc](https://crates.io/crates/mimalloc) memory allocator because it's provided performance gain about 9% in the producer loop.

* The allocator is set in `rs-bindings` crates + in each existing benchmarks.
* I've extended the benchmarks with mock structs to one benchmark for each well-known memory allocator (standard system memory allocator, [~~jemalloc~~](https://docs.rs/jemallocator/latest/jemallocator/) and `mimalloc`).
* To achieve these extensions, I've created macros to generate the same benchmarks for the given memory allocator.
* Benchmarks have been extended in the Build CLI Tool configuration as well.

**Update:**
`jemalloc` allocator support on Windows is still unstable, which makes it unrelevant for our use-case.

Currently we still need to test the changes on variety of environment to make sure that we are not getting regression on any of them. 
Platforms to test:
- [x] Linux x86
- [x] Windows x86
- [x] MacOs x86
- [x] MacOs Arm64
- [x] ~~Linux Arm64~~
- [x] ~~Windows Arm64~~

# Benchmarks Results:

## Linux x86:
```md
# Mimalloc:

## App with DLT:
File Read Took: 10606
File Read Took: 10295
File Read Took: 10402

## Benchmarks single item in parse return:
time:   [4.0199 ms 4.0246 ms 4.0299 ms]
time:   [4.0604 ms 4.0651 ms 4.0707 ms]
time:   [4.0112 ms 4.0170 ms 4.0234 ms]

## Benchmarks multiple items in parse return:
time:   [5.8757 ms 5.8791 ms 5.8830 ms]
time:   [5.9564 ms 5.9604 ms 5.9653 ms]
time:   [5.9736 ms 5.9773 ms 5.9818 ms]
--------------------------------------------------

# System Allocator:

## App with DLT:
File Read Took: 11586
File Read Took: 11429
File Read Took: 11397

## Benchmarks single item in parse return:
time:   [4.5073 ms 4.5173 ms 4.5277 ms]
time:   [4.5555 ms 4.5648 ms 4.5744 ms]
time:   [4.4404 ms 4.4516 ms 4.4636 ms]

## Benchmarks multiple items in parse return:
time:   [8.5335 ms 8.5537 ms 8.5741 ms]
time:   [8.4373 ms 8.4573 ms 8.4777 ms]
time:   [8.4468 ms 8.4690 ms 8.4913 ms]
-------------------------------------------------

```

## Windows x86:
```md
# Mimalloc

## App with DLT:
File Read Took: 18878
File Read Took: 17322
File Read Took: 18876

## Benchmarks single item in parse return:
time:   [6.3784 ms 6.3877 ms 6.3972 ms]
time:   [6.3674 ms 6.3756 ms 6.3839 ms]
time:   [6.3769 ms 6.3865 ms 6.3961 ms]

## Benchmarks multiple items in parse return:
time:   [7.7845 ms 7.8004 ms 7.8174 ms]
time:   [7.7006 ms 7.7140 ms 7.7282 ms]
time:   [7.6867 ms 7.6994 ms 7.7125 ms]

--------------------------------------------------

# System Allocator:

## App with DLT:
File Read Took: 24033
File Read Took: 22460
File Read Took: 22047

## Benchmarks single item in parse return:
time:   [13.752 ms 13.773 ms 13.793 ms]
time:   [13.741 ms 13.767 ms 13.795 ms]
time:   [13.763 ms 13.787 ms 13.813 ms]

## Benchmarks multiple items in parse return:
time:   [17.503 ms 17.528 ms 17.554 ms]
time:   [17.558 ms 17.589 ms 17.620 ms]
time:   [17.484 ms 17.511 ms 17.540 ms]

---------------------------------------------------

# Jemalloc: *NOT SUPPORTED ON WINDOWS!!!!*
```

## MacOS M1 Arch64:
```md
On M1 MacOS

# Mimalloc

## App with DLT:
File Read Took: 8241
File Read Took: 8079
File Read Took: 8156

## Benchmarks single item in parse return:
time:   [4.5663 ms 4.5745 ms 4.5831 ms]
time:   [4.5557 ms 4.5634 ms 4.5714 ms]
time:   [4.5464 ms 4.5529 ms 4.5599 ms]

## Benchmarks multiple items in parse return:
time:   [5.1218 ms 5.1295 ms 5.1373 ms]
time:   [5.1200 ms 5.1252 ms 5.1304 ms]
time:   [5.1403 ms 5.1477 ms 5.1550 ms]

--------------------------------------------------

# System Allocator:

## App with DLT:
File Read Took: 8656
File Read Took: 8573
File Read Took: 8987

## Benchmarks single item in parse return:
time:   [5.6709 ms 5.6787 ms 5.6876 ms]
time:   [5.7947 ms 5.8025 ms 5.8105 ms]
time:   [5.6819 ms 5.6881 ms 5.6949 ms]

## Benchmarks multiple items in parse return:
time:   [8.5934 ms 8.6080 ms 8.6248 ms]
time:   [8.5257 ms 8.5358 ms 8.5456 ms]
time:   [8.5058 ms 8.5153 ms 8.5247 ms]

---------------------------------------------------
``` 

## MacOS x86 intel i7
```md
# Mimalloc
## Benchmarks single item in parse return:
time: [6.8651 ms 6.9743 ms 7.1159 ms]
time: [6.6676 ms 6.7202 ms 6.7828 ms]
time: [6.6338 ms 6.6772 ms 6.7217 ms]
time: [6.6216 ms 6.6621 ms 6.7042 ms]

## Benchmarks multiple items in parse return:
time: [8.6619 ms 8.7040 ms 8.7494 ms]
time: [8.7765 ms 8.8262 ms 8.8787 ms]
time: [8.7044 ms 8.7551 ms 8.8090 ms]
time: [9.1320 ms 9.2537 ms 9.3865 ms]
time: [9.1289 ms 9.1816 ms 9.2413 ms]

# System allocator
## Benchmarks single item in parse return:
time: [11.301 ms 11.361 ms 11.423 ms]
time: [11.390 ms 11.452 ms 11.518 ms]
time: [11.456 ms 11.574 ms 11.709 ms]
time: [11.259 ms 11.321 ms 11.385 ms]
time: [11.273 ms 11.349 ms 11.439 ms]

## Benchmarks multiple items in parse return:
time: [14.597 ms 14.641 ms 14.691 ms]
time: [14.704 ms 14.747 ms 14.792 ms]
time: [14.616 ms 14.662 ms 14.713 ms]
time: [15.429 ms 15.686 ms 15.967 ms]
time: [14.644 ms 14.693 ms 14.747 ms]
```

## MacOS x86 intel i9 (With Custom image):
Parsing 500 MB dlt file via Chipmunk App
```md
# mimalloc::MiMalloc:
File Read Took: 28160
File Read Took: 29780
File Read Took: 25214

# Standard Allocator:
  File Read Took: 26157
  File Read Took: 27445
  File Read Took: 25844
```