### PR TITLE
Up to 3.13.4

### DIFF
--- a/application/apps/indexer/session/src/state/mod.rs
+++ b/application/apps/indexer/session/src/state/mod.rs
@@ -709,7 +709,12 @@ pub async fn run(
                 state.cancelling_operations.remove(&uuid);
             }
             Api::AddAttachment(attachment) => {
-                state.handle_add_attachment(attachment, tx_callback_events.clone())?;
+                let at_name = attachment.name.clone();
+                if let Err(err) =
+                    state.handle_add_attachment(attachment, tx_callback_events.clone())
+                {
+                    error!("Fail to process attachment {at_name:?}; error: {err:?}");
+                }
             }
             Api::GetAttachments(tx_response) => {
                 tx_response.send(state.attachments.get()).map_err(|_| {

--- a/application/client/package.json
+++ b/application/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chipmunk",
-  "version": "3.13.3",
+  "version": "3.13.4",
   "description": "Logs analyzer tool",
   "author": "Dmitry Astafyev",
   "scripts": {

--- a/application/holder/package.json
+++ b/application/holder/package.json
@@ -1,6 +1,6 @@
 {
     "name": "chipmunk",
-    "version": "3.13.3",
+    "version": "3.13.4",
     "chipmunk": {
         "versions": {}
     },

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+# 3.13.4 (21.10.2024)
+
+## Fixes
+- sanitize the attachment path before saving
+- prevent closing session on invalid attachment
+
+## Changes
+- add support for multiple values/messages on the producer level
+
 # 3.13.3 (18.10.2024)
 
 ## Fixes


### PR DESCRIPTION
# 3.13.4 (21.10.2024)

## Fixes
- sanitize the attachment path before saving
- prevent closing session on invalid attachment

## Changes
- add support for multiple values/messages on the producer level