### PR TITLE
Benchmarks: Replace Criterion `black_box` with the Standard Library Function

### DIFF
--- a/application/apps/indexer/sources/benches/dlt_producer.rs
+++ b/application/apps/indexer/sources/benches/dlt_producer.rs
@@ -1,5 +1,5 @@
-use criterion::{Criterion, *};
-use std::path::PathBuf;
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use std::{hint::black_box, path::PathBuf};
 
 use bench_utls::{
     bench_standrad_config, create_binary_bytesource, get_config, read_binary, run_producer,

--- a/application/apps/indexer/sources/benches/mocks/mock_parser.rs
+++ b/application/apps/indexer/sources/benches/mocks/mock_parser.rs
@@ -1,8 +1,8 @@
 use std::{fmt::Display, iter, marker::PhantomData};
 
-use criterion::black_box;
 use parsers::{Attachment, LogMessage, Parser};
 use serde::Serialize;
+use std::hint::black_box;
 
 /// Empty type used as phantom data with mock parser to indicate that its [`Parser::parse()`]
 /// implementation will always return [`iter::once()`].
@@ -93,7 +93,7 @@ impl<T> MockParser<T> {
         if counter >= max_count {
             const ERR: parsers::Error = parsers::Error::Eof;
 
-            return Err(criterion::black_box(ERR));
+            return Err(black_box(ERR));
         }
 
         // Unnecessary check to convince the compiler that we are using the input.

--- a/application/apps/indexer/sources/benches/mocks/mock_source.rs
+++ b/application/apps/indexer/sources/benches/mocks/mock_source.rs
@@ -1,5 +1,5 @@
-use criterion::black_box;
 use sources::ByteSource;
+use std::hint::black_box;
 
 #[derive(Debug, Clone)]
 pub struct MockByteSource {}

--- a/application/apps/indexer/sources/benches/mocks_multi_producer.rs
+++ b/application/apps/indexer/sources/benches/mocks_multi_producer.rs
@@ -1,5 +1,7 @@
+use std::hint::black_box;
+
 use bench_utls::{bench_standrad_config, run_producer};
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
 use sources::producer::MessageProducer;
 
@@ -17,31 +19,26 @@ mod mocks;
 /// asynchronous runtime. This test is configured to reduce this amount of noise as possible,
 /// However it would be better to run it multiple time for double checking.
 fn mocks_multi_producer(c: &mut Criterion) {
-    let max_parse_calls = 10000;
+    c.bench_function("mocks_multi_producer", |bencher| {
+        bencher
+            // It's important to spawn a new runtime on each run to ensure to reduce the
+            // potential noise produced from one runtime created at the start of all benchmarks
+            // only.
+            .to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter_batched(
+                || {
+                    // Exclude initiation time from benchmarks.
+                    let max_parse_calls = black_box(10000);
+                    let parser = MockParser::new_multi(max_parse_calls);
+                    let byte_source = MockByteSource::new();
+                    let producer = MessageProducer::new(parser, byte_source, black_box(None));
 
-    c.bench_with_input(
-        BenchmarkId::new("mocks_multi_producer", max_parse_calls),
-        &(max_parse_calls),
-        |bencher, &max| {
-            bencher
-                // It's important to spawn a new runtime on each run to ensure to reduce the
-                // potential noise produced from one runtime created at the start of all benchmarks
-                // only.
-                .to_async(tokio::runtime::Runtime::new().unwrap())
-                .iter_batched(
-                    || {
-                        // Exclude initiation time from benchmarks.
-                        let parser = MockParser::new_multi(max);
-                        let byte_source = MockByteSource::new();
-                        let producer = MessageProducer::new(parser, byte_source, black_box(None));
-
-                        producer
-                    },
-                    |producer| run_producer(producer),
-                    criterion::BatchSize::SmallInput,
-                )
-        },
-    );
+                    producer
+                },
+                |producer| run_producer(producer),
+                criterion::BatchSize::SmallInput,
+            )
+    });
 }
 
 criterion_group! {

--- a/application/apps/indexer/sources/benches/mocks_once_producer.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_producer.rs
@@ -1,5 +1,7 @@
+use std::hint::black_box;
+
 use bench_utls::{bench_standrad_config, run_producer};
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
 use sources::producer::MessageProducer;
 
@@ -17,31 +19,26 @@ mod mocks;
 /// asynchronous runtime. This test is configured to reduce this amount of noise as possible,
 /// However it would be better to run it multiple time for double checking.
 fn mocks_once_producer(c: &mut Criterion) {
-    let max_parse_calls = 50000;
+    c.bench_function("mocks_once_producer", |bencher| {
+        bencher
+            // It's important to spawn a new runtime on each run to ensure to reduce the
+            // potential noise produced from one runtime created at the start of all benchmarks
+            // only.
+            .to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter_batched(
+                || {
+                    // Exclude initiation time from benchmarks.
+                    let max_parse_calls = black_box(50000);
+                    let parser = MockParser::new_once(max_parse_calls);
+                    let byte_source = MockByteSource::new();
+                    let producer = MessageProducer::new(parser, byte_source, black_box(None));
 
-    c.bench_with_input(
-        BenchmarkId::new("mocks_once_producer", max_parse_calls),
-        &(max_parse_calls),
-        |bencher, &max| {
-            bencher
-                // It's important to spawn a new runtime on each run to ensure to reduce the
-                // potential noise produced from one runtime created at the start of all benchmarks
-                // only.
-                .to_async(tokio::runtime::Runtime::new().unwrap())
-                .iter_batched(
-                    || {
-                        // Exclude initiation time from benchmarks.
-                        let parser = MockParser::new_once(max);
-                        let byte_source = MockByteSource::new();
-                        let producer = MessageProducer::new(parser, byte_source, black_box(None));
-
-                        producer
-                    },
-                    |producer| run_producer(producer),
-                    criterion::BatchSize::SmallInput,
-                )
-        },
-    );
+                    producer
+                },
+                |producer| run_producer(producer),
+                criterion::BatchSize::SmallInput,
+            )
+    });
 }
 
 criterion_group! {

--- a/application/apps/indexer/sources/benches/someip_legacy_producer.rs
+++ b/application/apps/indexer/sources/benches/someip_legacy_producer.rs
@@ -1,9 +1,9 @@
 mod bench_utls;
 
-use std::{io::Cursor, path::PathBuf};
+use std::{hint::black_box, io::Cursor, path::PathBuf};
 
 use bench_utls::{bench_standrad_config, get_config, read_binary, run_producer};
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use parsers::someip::SomeipParser;
 use sources::{binary::pcap::legacy::PcapLegacyByteSource, producer::MessageProducer};
 

--- a/application/apps/indexer/sources/benches/someip_producer.rs
+++ b/application/apps/indexer/sources/benches/someip_producer.rs
@@ -1,7 +1,7 @@
-use std::{io::Cursor, path::PathBuf};
+use std::{hint::black_box, io::Cursor, path::PathBuf};
 
 use bench_utls::{bench_standrad_config, get_config, read_binary, run_producer};
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use parsers::someip::SomeipParser;
 use sources::{binary::pcap::ng::PcapngByteSource, producer::MessageProducer};
 

--- a/application/apps/indexer/sources/benches/text_producer.rs
+++ b/application/apps/indexer/sources/benches/text_producer.rs
@@ -1,4 +1,6 @@
-use criterion::{Criterion, *};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 
 use bench_utls::{bench_standrad_config, create_binary_bytesource, read_binary, run_producer};
 use parsers::text::StringTokenizer;


### PR DESCRIPTION
This PR:
* Replaces `black_box()` function from criterion with the one from the standard library `std::hint::black_box()` after stabilizing it.
* Replaces `bench_with_input()` function with manual black boxing since they are still using `criterion::black_box` function under the hood.

The function from criterion is already marked as deprecated in their master branch and will be using the one from the standard library in their next release as well.