### PR TITLE
Core: Improve Cleanup Temporary Files in Chipmunk Home Directory 

### DIFF
--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -1916,6 +1916,7 @@ dependencies = [
  "serde_json",
  "serialport",
  "sources",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/application/apps/indexer/session/Cargo.toml
+++ b/application/apps/indexer/session/Cargo.toml
@@ -33,3 +33,4 @@ walkdir = "2.3"
 
 [dev-dependencies]
 lazy_static.workspace = true
+tempfile.workspace = true

--- a/application/apps/indexer/session/src/state/mod.rs
+++ b/application/apps/indexer/session/src/state/mod.rs
@@ -771,7 +771,6 @@ pub async fn run(
             }
             Api::ShutdownWithError => {
                 debug!("shutdown state loop with error for testing");
-                state.session_file.cleanup()?;
                 return Err(NativeError {
                     severity: Severity::ERROR,
                     kind: NativeErrorKind::Io,
@@ -780,7 +779,15 @@ pub async fn run(
             }
         }
     }
-    state.session_file.cleanup()?;
     debug!("task is finished");
     Ok(())
+}
+
+impl Drop for SessionState {
+    fn drop(&mut self) {
+        // Ensure session files are cleaned up by calling the cleanup function on drop.
+        if let Err(err) = self.session_file.cleanup() {
+            log::error!("Cleaning up session files failed. Error: {err:#?}");
+        }
+    }
 }

--- a/application/apps/indexer/session/src/unbound/cleanup.rs
+++ b/application/apps/indexer/session/src/unbound/cleanup.rs
@@ -1,0 +1,106 @@
+use std::{
+    fs, io,
+    path::Path,
+    time::{Duration, SystemTime},
+};
+
+use crate::{
+    events::{NativeError, NativeErrorKind},
+    paths::get_streams_dir,
+    progress::Severity,
+};
+
+/// Iterates through chipmunk temporary directory and remove the entries which is older
+/// than two months.
+pub fn cleanup_temp_dir() -> Result<(), NativeError> {
+    let tmp_dir = get_streams_dir()?;
+
+    const TWO_MONTHS_SECONDS: u64 = 60 * 60 * 24 * 60;
+    let modified_limit = SystemTime::now()
+        .checked_sub(Duration::from_secs(TWO_MONTHS_SECONDS))
+        .ok_or_else(|| NativeError {
+            severity: Severity::ERROR,
+            kind: NativeErrorKind::Io,
+            message: Some(String::from(
+                "Error while calculating modification time limit",
+            )),
+        })?;
+
+    cleanup_dir(&tmp_dir, modified_limit)?;
+
+    Ok(())
+}
+
+// Clean files and directory within the given path that have a modified time older than
+// the given modified date limit
+fn cleanup_dir(path: &Path, modified_date_limit: SystemTime) -> io::Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    fs::read_dir(path)?
+        .flat_map(Result::ok)
+        .filter(|p| {
+            p.metadata()
+                .is_ok_and(|meta| meta.modified().is_ok_and(|date| date < modified_date_limit))
+        })
+        .map(|entry| entry.path())
+        .try_for_each(|path| {
+            if path.is_dir() {
+                fs::remove_dir_all(path)
+            } else if path.is_file() {
+                fs::remove_file(path)
+            } else {
+                Ok(())
+            }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs::{self, File},
+        thread,
+        time::{Duration, SystemTime},
+    };
+
+    use super::cleanup_dir;
+
+    #[test]
+    fn test_cleanup_dir() {
+        // Create temporary directory with some entries
+        let tempdir = tempfile::tempdir().unwrap();
+        let temp_path = tempdir.path();
+
+        let dir = temp_path.join("dir");
+        fs::create_dir(&dir).unwrap();
+        let sub_file = dir.join("sub_file");
+        _ = File::create(&sub_file).unwrap();
+        let file = temp_path.join("file");
+        _ = File::create(&file).unwrap();
+
+        let entries = [dir, sub_file, file];
+
+        // Make sure there differences in modification time and current time.
+        thread::sleep(Duration::from_millis(50));
+
+        // Cleaning up with time stamp one day ago must not remove anything.
+        let past = SystemTime::now()
+            .checked_sub(Duration::from_secs(3600))
+            .unwrap();
+        cleanup_dir(&temp_path, past).unwrap();
+        for entry in &entries {
+            assert!(entry.exists());
+        }
+
+        // Cleaning up with now must remove all files and directories.
+        cleanup_dir(&temp_path, SystemTime::now()).unwrap();
+
+        // Temp directory itself shouldn't be removed.
+        assert!(temp_path.exists());
+
+        for entry in entries {
+            assert!(!entry.exists());
+        }
+    }
+}


### PR DESCRIPTION
This PR closes #2137 

It improves cleaning up the temporary files (Logs and attachments) generated by an observe session with the following changes:
* Cleanup function for individual sessions is called when the session is dropped instead of calling it explicitly, ensuring that it will be called even on panics or in integration tests.
* Extend cleanup function for individual sessions to remove the attachments besides removing the main log file.
* A general cleaning up function to scan the temporary directory in Chipmunk and remove all files and directories that are older than two months. This function will be called on start of Chipmunk and will run on a separate thread to avoid blocking the initialization of the app on cleaning up huge temporary directory