### PR TITLE
Up to 3.14.2

### DIFF
--- a/application/client/package.json
+++ b/application/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chipmunk",
-  "version": "3.14.1",
+  "version": "3.14.2",
   "description": "Logs analyzer tool",
   "author": "Dmitry Astafyev",
   "scripts": {

--- a/application/holder/package.json
+++ b/application/holder/package.json
@@ -1,6 +1,6 @@
 {
     "name": "chipmunk",
-    "version": "3.14.1",
+    "version": "3.14.2",
     "chipmunk": {
         "versions": {}
     },

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# 3.14.2 (08.11.2024)
+
+## Corrections
+- better parsing Some/IP in the scope of DLT Network Trace
+
 # 3.14.1 (28.10.2024)
 
 ## Corrections

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Corrections
 - better parsing Some/IP in the scope of DLT Network Trace
+- cleanup temporary session files
 
 # 3.14.1 (28.10.2024)
 


### PR DESCRIPTION
# 3.14.2 (08.11.2024)

## Corrections
- better parsing Some/IP in the scope of DLT Network Trace
- cleanup temporary session files