### PR TITLE
Build CLI Release: Fix MacOS notarize logs

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.9
+
+## Fixes:
+
+* Show notarize command logs before checking its status to ensure that logs will be always printed.
+* Hide credentials when printing notarize command.
+
 # 0.2.8
 
 ## Features:

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cargo-chipmunk"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chipmunk"
-version = "0.2.8"
+version = "0.2.9"
 authors = ["Ammar Abou Zor <ammar.abou.zor@accenture.com>"]
 edition = "2021"
 description = "CLI Tool for chipmunk application development"

--- a/cli/src/release/codesign/macos.rs
+++ b/cli/src/release/codesign/macos.rs
@@ -219,11 +219,6 @@ pub fn notarize(config: &MacOsConfig) -> anyhow::Result<()> {
         .output()
         .context("Error while running notarize command.")?;
 
-    ensure!(
-        cmd_output.status.success(),
-        "Code notarize failed. Command : '{cmd}'"
-    );
-
     let mut accepted = false;
 
     println!("Notarize commnad output on stdout:");
@@ -243,6 +238,14 @@ pub fn notarize(config: &MacOsConfig) -> anyhow::Result<()> {
             accepted = true;
         }
     }
+
+    ensure!(
+        cmd_output.status.success(),
+        "Code notarize failed. Command : '{}'",
+        cmd.replace(&apple_id, "***")
+            .replace(&team_id, "***")
+            .replace(&password, "***")
+    );
 
     ensure!(
         accepted,


### PR DESCRIPTION
This PR provides the following fixes and improvements to notarizing process while releasing to MacOS:

* Print logs before checking the status of the notarize command to ensure that logs will be shown on command errors.
* Hide credentials from output logs.
* Update tool version & Add changes to change log