### PR TITLE
Resolve rust version update issues with self hosted runner

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -36,24 +36,24 @@ jobs:
           node-version: "lts/*"
 
       - name: Install Ruby and related tools
-        run: ./scripts/benchmarks/setup_dependencies.sh
+        run: ./scripts/benchmarks/setup_ruby.sh
 
       - name: Install cargo tools
         run: |
-          cargo install nj-cli wasm-pack --locked
+          cargo install nj-cli wasm-pack
           npm install -g tslib
 
       - name: Run Jasmine performance tests
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          export PATH="/root/.cargo/bin:$PATH"
-          source ~/.bashrc
-          if [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ github.event.inputs.pr_id }}" -eq 0 ]]; then
-            echo "Running manually"
-            ruby scripts/benchmarks/process.rb 1
+          rustup -V
+          if [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ github.event.inputs.pr_id }}" -le 10 ]]; then
+            echo "Running manually with a PR ID of 10 or less."
+            ruby scripts/benchmarks/process.rb ${{ github.event.inputs.pr_id }}
           elif [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ github.event.inputs.pr_id }}" =~ ^[0-9]+$ ]]; then
+            echo "Running manually with a valid numeric PR ID greater than 10."
             ruby scripts/benchmarks/process.rb PR~${{ github.event.inputs.pr_id }}
           elif [[ "${{ github.event_name }}" != 'workflow_dispatch' ]]; then
+            echo "Running on a non-workflow_dispatch event."
             ruby scripts/benchmarks/process.rb 1
           fi
 
@@ -78,7 +78,7 @@ jobs:
           git config user.name "esrlabs"
           git config user.email "esrlabs@gmail.com"
           git remote set-url origin "https://esrlabs:${{secrets.DOCS_PUSH_TOKEN}}@github.com/esrlabs/chipmunk-docs"
-          if [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ github.event.inputs.pr_id }}" -ne 0 ]]; then
+          if [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ github.event.inputs.pr_id }}" -gt 10 ]]; then
             cp /chipmunk/chipmunk_performance_results/Benchmark_PR_${{ github.event.inputs.pr_id }}.json ./jekyll/benchmarks/data/pull_request/
             git add ./jekyll/benchmarks/data/pull_request/Benchmark_PR_${{ github.event.inputs.pr_id }}.json
             git commit -m "Adding PR benchmark results for chipmunk PR #${{ github.event.inputs.pr_id }}"

--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -1129,6 +1129,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,6 +1240,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1595,6 +1614,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
+ "mimalloc",
  "parsers",
  "pretty_assertions",
  "rand",
@@ -2029,6 +2049,7 @@ dependencies = [
  "indexer_base",
  "lazy_static",
  "log",
+ "mimalloc",
  "parsers",
  "pcap-parser",
  "regex",

--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -2056,7 +2056,6 @@ dependencies = [
  "serde",
  "shellexpand",
  "thiserror",
- "tikv-jemallocator",
  "tokio",
  "tokio-serial",
  "tokio-stream",
@@ -2203,26 +2202,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.85",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -2056,6 +2056,7 @@ dependencies = [
  "serde",
  "shellexpand",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "tokio-serial",
  "tokio-stream",
@@ -2202,6 +2203,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.85",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -40,7 +40,6 @@ env_logger = "0.10"
 # Support for `html_reports` needs running the benchmarks via `cargo-criterion` tool.
 criterion = { version = "0.5", features = ["html_reports"] }
 mimalloc = "0.1"
-tikv-jemallocator = "0.6"
 
 # only uncomment when profiling
 # [profile.release]

--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -37,6 +37,7 @@ tempfile = "3.10.0"
 env_logger = "0.10"
 # Support for `html_reports` needs running the benchmarks via `cargo-criterion` tool.
 criterion = { version = "0.5", features = ["html_reports"] }
+mimalloc = "0.1"
 
 # only uncomment when profiling
 # [profile.release]

--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -35,9 +35,12 @@ uuid = "1.3"
 grep-searcher = "0.1"
 tempfile = "3.10.0"
 env_logger = "0.10"
+
+## Development Dependencies ##
 # Support for `html_reports` needs running the benchmarks via `cargo-criterion` tool.
 criterion = { version = "0.5", features = ["html_reports"] }
 mimalloc = "0.1"
+tikv-jemallocator = "0.6"
 
 # only uncomment when profiling
 # [profile.release]

--- a/application/apps/indexer/processor/Cargo.toml
+++ b/application/apps/indexer/processor/Cargo.toml
@@ -28,6 +28,7 @@ criterion.workspace = true
 pretty_assertions = "1.3"
 rand.workspace = true
 tempfile.workspace = true
+mimalloc.workspace = true
 
 [[bench]]
 name = "map_benchmarks"

--- a/application/apps/indexer/processor/benches/map_benchmarks.rs
+++ b/application/apps/indexer/processor/benches/map_benchmarks.rs
@@ -4,6 +4,9 @@ extern crate processor;
 use criterion::{Criterion, *};
 use processor::map::{FilterMatch, SearchMap};
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn scaled_benchmark(c: &mut Criterion) {
     let mut example_map: SearchMap = SearchMap::new();
     let mut v = vec![];

--- a/application/apps/indexer/session/src/handlers/observing/mod.rs
+++ b/application/apps/indexer/session/src/handlers/observing/mod.rs
@@ -124,6 +124,8 @@ async fn run_producer<T: LogMessage, P: Parser<T>, S: ByteSource>(
     let stream = producer.as_stream();
     futures::pin_mut!(stream);
     let cancel_on_tail = cancel.clone();
+    //TODO AAZ: Remove this timer after benchmarking on all machines is done.
+    let timer = std::time::Instant::now();
     while let Some(next) = select! {
         next_from_stream = async {
             match timeout(Duration::from_millis(FLUSH_TIMEOUT_IN_MS as u64), stream.next()).await {
@@ -162,6 +164,14 @@ async fn run_producer<T: LogMessage, P: Parser<T>, S: ByteSource>(
                         }
                         MessageStreamItem::Done => {
                             trace!("observe, message stream is done");
+                            let elapsed = timer.elapsed();
+                            println!("---------------------------------------------------------");
+                            println!("---------------------------------------------------------");
+                            println!("---------------------------------------------------------");
+                            println!("File Read Took: {}", elapsed.as_millis());
+                            println!("---------------------------------------------------------");
+                            println!("---------------------------------------------------------");
+                            println!("---------------------------------------------------------");
                             state.flush_session_file().await?;
                             state.file_read().await?;
                         }

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -28,6 +28,7 @@ shellexpand = "3.0.0"
 [dev-dependencies]
 env_logger.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
+mimalloc.workspace = true
 
 [[bench]]
 name = "mocks_once_producer"

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -29,9 +29,18 @@ shellexpand = "3.0.0"
 env_logger.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
 mimalloc.workspace = true
+tikv-jemallocator.workspace = true
 
 [[bench]]
 name = "mocks_once_producer"
+harness = false
+
+[[bench]]
+name = "mocks_once_producer_jemalloc"
+harness = false
+
+[[bench]]
+name = "mocks_once_producer_sysalloc"
 harness = false
 
 [[bench]]

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -48,6 +48,14 @@ name = "mocks_multi_producer"
 harness = false
 
 [[bench]]
+name = "mocks_multi_producer_jemalloc"
+harness = false
+
+[[bench]]
+name = "mocks_multi_producer_sysalloc"
+harness = false
+
+[[bench]]
 name = "dlt_producer"
 harness = false
 

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -29,14 +29,9 @@ shellexpand = "3.0.0"
 env_logger.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
 mimalloc.workspace = true
-tikv-jemallocator.workspace = true
 
 [[bench]]
 name = "mocks_once_producer"
-harness = false
-
-[[bench]]
-name = "mocks_once_producer_jemalloc"
 harness = false
 
 [[bench]]
@@ -45,10 +40,6 @@ harness = false
 
 [[bench]]
 name = "mocks_multi_producer"
-harness = false
-
-[[bench]]
-name = "mocks_multi_producer_jemalloc"
 harness = false
 
 [[bench]]

--- a/application/apps/indexer/sources/benches/dlt_producer.rs
+++ b/application/apps/indexer/sources/benches/dlt_producer.rs
@@ -9,6 +9,10 @@ use sources::producer::MessageProducer;
 
 mod bench_utls;
 
+// The MiMalloc allocator is currently used in the Chipmunk app.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// This benchmark covers parsing from DLT file and supports providing the path for a fibex file as
 /// additional configuration.
 fn dlt_producer(c: &mut Criterion) {

--- a/application/apps/indexer/sources/benches/macros/mock_producer_multi.rs
+++ b/application/apps/indexer/sources/benches/macros/mock_producer_multi.rs
@@ -1,0 +1,79 @@
+//! Provides macro to generate benchmarks with mock parser returning multiple value at a time using
+//! various memory allocators
+
+/// Macro to generate benchmarks with mock parser and source for various memory allocators.
+/// The parser mock in this macro will return multiple items per call using a vector to replicate
+/// the behavior of the potential plugins in Chipmunk.
+///
+/// # Usage:
+/// The macro accepts the name of the benchmark function and the allocator, and generates a
+/// benchmark function with given name using the given allocator
+///
+/// # Example:
+/// ```
+/// mod macros;
+/// mocks_producer_multi!(mocks_multi_producer_stdalloc, std::alloc::System);
+/// ```
+#[macro_export]
+macro_rules! mocks_producer_multi {
+    ($name:ident, $allocator:path) => {
+        use ::criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+        use ::sources::producer::MessageProducer;
+        use ::std::hint::black_box;
+        use bench_utls::{bench_standrad_config, run_producer};
+        use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
+
+        mod bench_utls;
+        mod mocks;
+
+        #[global_allocator]
+        static GLOBAL: $allocator = $allocator;
+
+        /// Runs Benchmarks replicating the producer loop within Chipmunk sessions, using mocks for
+        /// [`parsers::Parser`] and [`sources::ByteSource`] to ensure that the measurements is for the
+        /// producer loop only.
+        ///
+        /// The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
+        /// behavior of the potential plugins in Chipmunk.
+        ///
+        /// NOTE: This benchmark suffers unfortunately from a lot of noise because we are running it with
+        /// asynchronous runtime. This test is configured to reduce this amount of noise as possible,
+        /// However it would be better to run it multiple time for double checking.
+        fn $name(c: &mut Criterion) {
+            let max_parse_calls = 10000;
+
+            c.bench_with_input(
+                BenchmarkId::new(std::stringify!($name), max_parse_calls),
+                &(max_parse_calls),
+                |bencher, &max| {
+                    bencher
+                        // It's important to spawn a new runtime on each run to ensure to reduce the
+                        // potential noise produced from one runtime created at the start of all benchmarks
+                        // only.
+                        .to_async(tokio::runtime::Runtime::new().unwrap())
+                        .iter_batched(
+                            || {
+                                // Exclude initiation time from benchmarks.
+                                let parser = MockParser::new_multi(max);
+                                let byte_source = MockByteSource::new();
+                                let producer =
+                                    MessageProducer::new(parser, byte_source, black_box(None));
+
+                                producer
+                            },
+                            |producer| run_producer(producer),
+                            criterion::BatchSize::SmallInput,
+                        )
+                },
+            );
+        }
+
+        criterion_group! {
+            name = benches;
+            config = bench_standrad_config();
+            targets = $name
+        }
+
+        criterion_main!(benches);
+    };
+}

--- a/application/apps/indexer/sources/benches/macros/mock_producer_once.rs
+++ b/application/apps/indexer/sources/benches/macros/mock_producer_once.rs
@@ -1,0 +1,79 @@
+//! Provides macro to generate benchmarks with mock parser returning one value at a time using
+//! various memory allocators
+
+/// Macro to generate benchmarks with mock parser and source for various memory allocators.
+/// The parser mock in this macro will return one item per call with `iter::once()` to replicate
+/// the case with built in parsers.
+///
+/// # Usage:
+/// The macro accepts the name of the benchmark function and the allocator, and generates a
+/// benchmark function with given name using the given allocator
+///
+/// # Example:
+/// ```
+/// mod macros;
+/// mocks_producer_once!(mocks_once_producer_stdalloc, std::alloc::System);
+/// ```
+#[macro_export]
+macro_rules! mocks_producer_once {
+    ($name:ident, $allocator:path) => {
+        use ::criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+        use ::sources::producer::MessageProducer;
+        use ::std::hint::black_box;
+        use bench_utls::{bench_standrad_config, run_producer};
+        use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
+
+        mod bench_utls;
+        mod mocks;
+
+        #[global_allocator]
+        static GLOBAL: $allocator = $allocator;
+
+        /// Runs Benchmarks replicating the producer loop within Chipmunk sessions, using mocks for
+        /// [`parsers::Parser`] and [`sources::ByteSource`] to ensure that the measurements is for the
+        /// producer loop only.
+        ///
+        /// The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
+        /// the current built-in parsers in Chipmunk.
+        ///
+        /// NOTE: This benchmark suffers unfortunately from a lot of noise because we are running it with
+        /// asynchronous runtime. This test is configured to reduce this amount of noise as possible,
+        /// However it would be better to run it multiple time for double checking.
+        fn $name(c: &mut Criterion) {
+            let max_parse_calls = 50000;
+
+            c.bench_with_input(
+                BenchmarkId::new(std::stringify!($name), max_parse_calls),
+                &(max_parse_calls),
+                |bencher, &max| {
+                    bencher
+                        // It's important to spawn a new runtime on each run to ensure to reduce the
+                        // potential noise produced from one runtime created at the start of all benchmarks
+                        // only.
+                        .to_async(tokio::runtime::Runtime::new().unwrap())
+                        .iter_batched(
+                            || {
+                                // Exclude initiation time from benchmarks.
+                                let parser = MockParser::new_once(max);
+                                let byte_source = MockByteSource::new();
+                                let producer =
+                                    MessageProducer::new(parser, byte_source, black_box(None));
+
+                                producer
+                            },
+                            |producer| run_producer(producer),
+                            criterion::BatchSize::SmallInput,
+                        )
+                },
+            );
+        }
+
+        criterion_group! {
+            name = benches;
+            config = bench_standrad_config();
+            targets = $name
+        }
+
+        criterion_main!(benches);
+    };
+}

--- a/application/apps/indexer/sources/benches/macros/mod.rs
+++ b/application/apps/indexer/sources/benches/macros/mod.rs
@@ -4,4 +4,5 @@
 // together yet.
 #![allow(unused)]
 
+pub mod mock_producer_multi;
 pub mod mock_producer_once;

--- a/application/apps/indexer/sources/benches/macros/mod.rs
+++ b/application/apps/indexer/sources/benches/macros/mod.rs
@@ -1,0 +1,7 @@
+//! Provides macros to generate benchmarks with different environments like memory allocators.
+
+// Macros here are used within benchmarks but rust checking isn't able to connect the module
+// together yet.
+#![allow(unused)]
+
+pub mod mock_producer_once;

--- a/application/apps/indexer/sources/benches/mocks_multi_producer_jemalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_multi_producer_jemalloc.rs
@@ -1,9 +1,0 @@
-//! Benchmarks for producer loop with mock parser and byte source using `jemalloc` memory allocator,
-//! which provides the best performance and is used in Chipmunk app currently.
-//!
-//! The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
-//! behavior of the potential plugins in Chipmunk.
-
-mod macros;
-
-mocks_producer_multi!(mocks_multi_producer_jemalloc, tikv_jemallocator::Jemalloc);

--- a/application/apps/indexer/sources/benches/mocks_multi_producer_jemalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_multi_producer_jemalloc.rs
@@ -1,4 +1,4 @@
-//! Benchmarks for producer loop with mock parser and byte source using `mimalloc` memory allocator,
+//! Benchmarks for producer loop with mock parser and byte source using `jemalloc` memory allocator,
 //! which provides the best performance and is used in Chipmunk app currently.
 //!
 //! The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
@@ -6,4 +6,4 @@
 
 mod macros;
 
-mocks_producer_multi!(mocks_multi_producer, mimalloc::MiMalloc);
+mocks_producer_multi!(mocks_multi_producer_jemalloc, tikv_jemallocator::Jemalloc);

--- a/application/apps/indexer/sources/benches/mocks_multi_producer_sysalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_multi_producer_sysalloc.rs
@@ -1,4 +1,4 @@
-//! Benchmarks for producer loop with mock parser and byte source using `mimalloc` memory allocator,
+//! Benchmarks for producer loop with mock parser and byte source using rust standard memory allocator,
 //! which provides the best performance and is used in Chipmunk app currently.
 //!
 //! The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
@@ -6,4 +6,4 @@
 
 mod macros;
 
-mocks_producer_multi!(mocks_multi_producer, mimalloc::MiMalloc);
+mocks_producer_multi!(mocks_multi_producer_sysalloc, std::alloc::System);

--- a/application/apps/indexer/sources/benches/mocks_once_producer.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_producer.rs
@@ -8,6 +8,10 @@ use sources::producer::MessageProducer;
 mod bench_utls;
 mod mocks;
 
+// The MiMalloc allocator is currently used in the Chipmunk app.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Runs Benchmarks replicating the producer loop within Chipmunk sessions, using mocks for
 /// [`parsers::Parser`] and [`sources::ByteSource`] to ensure that the measurements is for the
 /// producer loop only.

--- a/application/apps/indexer/sources/benches/mocks_once_producer.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_producer.rs
@@ -1,54 +1,9 @@
-use std::hint::black_box;
+//! Benchmarks for producer loop with mock parser and byte source using `mimalloc` memory allocator,
+//! which provides the best performance and is used in Chipmunk app currently.
+//!
+//! The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
+//! the current built-in parsers in Chipmunk.
 
-use bench_utls::{bench_standrad_config, run_producer};
-use criterion::{criterion_group, criterion_main, Criterion};
-use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
-use sources::producer::MessageProducer;
+mod macros;
 
-mod bench_utls;
-mod mocks;
-
-// The MiMalloc allocator is currently used in the Chipmunk app.
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
-/// Runs Benchmarks replicating the producer loop within Chipmunk sessions, using mocks for
-/// [`parsers::Parser`] and [`sources::ByteSource`] to ensure that the measurements is for the
-/// producer loop only.
-///
-/// The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
-/// the current built-in parsers in Chipmunk.
-///
-/// NOTE: This benchmark suffers unfortunately from a lot of noise because we are running it with
-/// asynchronous runtime. This test is configured to reduce this amount of noise as possible,
-/// However it would be better to run it multiple time for double checking.
-fn mocks_once_producer(c: &mut Criterion) {
-    c.bench_function("mocks_once_producer", |bencher| {
-        bencher
-            // It's important to spawn a new runtime on each run to ensure to reduce the
-            // potential noise produced from one runtime created at the start of all benchmarks
-            // only.
-            .to_async(tokio::runtime::Runtime::new().unwrap())
-            .iter_batched(
-                || {
-                    // Exclude initiation time from benchmarks.
-                    let max_parse_calls = black_box(50000);
-                    let parser = MockParser::new_once(max_parse_calls);
-                    let byte_source = MockByteSource::new();
-                    let producer = MessageProducer::new(parser, byte_source, black_box(None));
-
-                    producer
-                },
-                |producer| run_producer(producer),
-                criterion::BatchSize::SmallInput,
-            )
-    });
-}
-
-criterion_group! {
-    name = benches;
-    config = bench_standrad_config();
-    targets = mocks_once_producer
-}
-
-criterion_main!(benches);
+mocks_producer_once!(mocks_once_producer, mimalloc::MiMalloc);

--- a/application/apps/indexer/sources/benches/mocks_once_producer_jemalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_producer_jemalloc.rs
@@ -1,8 +1,0 @@
-//! Benchmarks for producer loop with mock parser and byte source using `jemalloc` memory allocator.
-//!
-//! The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
-//! the current built-in parsers in Chipmunk.
-
-mod macros;
-
-mocks_producer_once!(mocks_once_producer_jemalloc, tikv_jemallocator::Jemalloc);

--- a/application/apps/indexer/sources/benches/mocks_once_producer_jemalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_producer_jemalloc.rs
@@ -1,0 +1,8 @@
+//! Benchmarks for producer loop with mock parser and byte source using `jemalloc` memory allocator.
+//!
+//! The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
+//! the current built-in parsers in Chipmunk.
+
+mod macros;
+
+mocks_producer_once!(mocks_once_producer_jemalloc, tikv_jemallocator::Jemalloc);

--- a/application/apps/indexer/sources/benches/mocks_once_producer_sysalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_producer_sysalloc.rs
@@ -1,0 +1,8 @@
+//! Benchmarks for producer loop with mock parser and byte source using rust standard memory allocator.
+//!
+//! The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
+//! the current built-in parsers in Chipmunk.
+
+mod macros;
+
+mocks_producer_once!(mocks_once_producer_sysalloc, std::alloc::System);

--- a/application/apps/indexer/sources/benches/someip_legacy_producer.rs
+++ b/application/apps/indexer/sources/benches/someip_legacy_producer.rs
@@ -7,6 +7,10 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use parsers::someip::SomeipParser;
 use sources::{binary::pcap::legacy::PcapLegacyByteSource, producer::MessageProducer};
 
+// The MiMalloc allocator is currently used in the Chipmunk app.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// This benchmark covers parsing from SomeIP file using [`PcapLegacyByteSource`] byte source.
 /// It supports providing the path for a fibex file as additional configuration.
 fn someip_legacy_producer(c: &mut Criterion) {

--- a/application/apps/indexer/sources/benches/someip_producer.rs
+++ b/application/apps/indexer/sources/benches/someip_producer.rs
@@ -7,6 +7,10 @@ use sources::{binary::pcap::ng::PcapngByteSource, producer::MessageProducer};
 
 mod bench_utls;
 
+// The MiMalloc allocator is currently used in the Chipmunk app.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// This benchmark covers parsing from SomeIP file using [`PcapngByteSource`] byte source.
 /// It supports providing the path for a fibex file as additional configuration.
 fn someip_producer(c: &mut Criterion) {

--- a/application/apps/indexer/sources/benches/text_producer.rs
+++ b/application/apps/indexer/sources/benches/text_producer.rs
@@ -8,6 +8,10 @@ use sources::producer::MessageProducer;
 
 mod bench_utls;
 
+// The MiMalloc allocator is currently used in the Chipmunk app.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// This benchmark covers parsing from text file file using [`BinaryByteSource`].
 /// This benchmark doesn't support any additional configurations.
 fn text_producer(c: &mut Criterion) {

--- a/application/apps/rustcore/rs-bindings/Cargo.lock
+++ b/application/apps/rustcore/rs-bindings/Cargo.lock
@@ -1179,6 +1179,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,6 +1337,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1492,6 +1511,7 @@ dependencies = [
  "log",
  "log4rs",
  "merging",
+ "mimalloc",
  "node-bindgen",
  "processor",
  "serde",

--- a/application/apps/rustcore/rs-bindings/Cargo.toml
+++ b/application/apps/rustcore/rs-bindings/Cargo.toml
@@ -35,3 +35,4 @@ thiserror = "1.0"
 tokio = { version = "1.24", features = ["full"] }
 tokio-util = "0.7"
 uuid = { version = "1.3", features = ["serde", "v4"] }
+mimalloc = "0.1"

--- a/application/apps/rustcore/rs-bindings/src/lib.rs
+++ b/application/apps/rustcore/rs-bindings/src/lib.rs
@@ -1,2 +1,9 @@
 mod js;
 mod logging;
+
+// Using the mimalloc allocator resulted in an 8% performance improvement.
+// NOTE: In a Rust project, the memory allocator can only be set once,
+// and it applies to the entire project, including all dependencies.
+// We chose to configure the allocator in the highest-level library where the runtime is also set.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;

--- a/cli/config/bench_core.toml
+++ b/cli/config/bench_core.toml
@@ -15,6 +15,14 @@ name = "mocks_multi_producer"
 library = "sources"
 
 [[bench]]
+name = "mocks_multi_producer_jemalloc"
+library = "sources"
+
+[[bench]]
+name = "mocks_multi_producer_sysalloc"
+library = "sources"
+
+[[bench]]
 name = "dlt_producer"
 library = "sources"
 

--- a/cli/config/bench_core.toml
+++ b/cli/config/bench_core.toml
@@ -3,19 +3,11 @@ name = "mocks_once_producer"
 library = "sources"
 
 [[bench]]
-name = "mocks_once_producer_jemalloc"
-library = "sources"
-
-[[bench]]
 name = "mocks_once_producer_sysalloc"
 library = "sources"
 
 [[bench]]
 name = "mocks_multi_producer"
-library = "sources"
-
-[[bench]]
-name = "mocks_multi_producer_jemalloc"
 library = "sources"
 
 [[bench]]

--- a/cli/config/bench_core.toml
+++ b/cli/config/bench_core.toml
@@ -3,6 +3,14 @@ name = "mocks_once_producer"
 library = "sources"
 
 [[bench]]
+name = "mocks_once_producer_jemalloc"
+library = "sources"
+
+[[bench]]
+name = "mocks_once_producer_sysalloc"
+library = "sources"
+
+[[bench]]
 name = "mocks_multi_producer"
 library = "sources"
 

--- a/scripts/benchmarks/process.rb
+++ b/scripts/benchmarks/process.rb
@@ -113,7 +113,7 @@ def process_release_or_pr(branch_or_tag_name, identifier, env_vars)
         puts "Benchmark results:"
         system("cat #{result_path}")
       else
-        puts "Benchmark results not found at #{result_path}."
+        raise "Benchmark results not found at #{result_path}."
       end
     rescue => e
       puts "An error occurred while processing #{identifier}: #{e.message}"

--- a/scripts/benchmarks/setup_ruby.sh
+++ b/scripts/benchmarks/setup_ruby.sh
@@ -16,3 +16,8 @@ sudo chown -R $(whoami) /usr/local
 rvm use 3.1.2 --default
 export PATH="/usr/share/rvm:$PATH"
 gem install dotenv json octokit tmpdir fileutils
+curl https://sh.rustup.rs -sSf | RUSTUP_INIT_SKIP_PATH_CHECK=yes sh -s -- -y
+rustup default stable
+rustup update
+export PATH="/root/.cargo/bin:$PATH"
+source ~/.bashrc


### PR DESCRIPTION
This resolves the issue where self hosted runner did not get update the rust version and was locked on an older version of nj-cli(due to local dependencies on the self hosted runner).