### PR TITLE
Resolve rust version update issues with self hosted runner

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,25 +35,25 @@ jobs:
         with:
           node-version: "lts/*"
 
-      - name: Install Ruby and related tools
-        run: ./scripts/benchmarks/setup_dependencies.sh
+      - name: Install Ruby and other dev tools
+        run: ./scripts/benchmarks/setup_dev_tools.sh
 
       - name: Install cargo tools
         run: |
-          cargo install nj-cli wasm-pack --locked
+          cargo install nj-cli wasm-pack
           npm install -g tslib
 
       - name: Run Jasmine performance tests
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          export PATH="/root/.cargo/bin:$PATH"
-          source ~/.bashrc
-          if [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ github.event.inputs.pr_id }}" -eq 0 ]]; then
-            echo "Running manually"
-            ruby scripts/benchmarks/process.rb 1
+          rustc --version
+          if [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ github.event.inputs.pr_id }}" -le 10 ]]; then
+            echo "Running manually with a PR ID of 10 or less."
+            ruby scripts/benchmarks/process.rb ${{ github.event.inputs.pr_id }}
           elif [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ github.event.inputs.pr_id }}" =~ ^[0-9]+$ ]]; then
+            echo "Running manually with a valid numeric PR ID greater than 10."
             ruby scripts/benchmarks/process.rb PR~${{ github.event.inputs.pr_id }}
           elif [[ "${{ github.event_name }}" != 'workflow_dispatch' ]]; then
+            echo "Running on a non-workflow_dispatch event."
             ruby scripts/benchmarks/process.rb 1
           fi
 
@@ -78,7 +78,7 @@ jobs:
           git config user.name "esrlabs"
           git config user.email "esrlabs@gmail.com"
           git remote set-url origin "https://esrlabs:${{secrets.DOCS_PUSH_TOKEN}}@github.com/esrlabs/chipmunk-docs"
-          if [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ github.event.inputs.pr_id }}" -ne 0 ]]; then
+          if [[ "${{ github.event_name }}" == 'workflow_dispatch' && "${{ github.event.inputs.pr_id }}" -gt 10 ]]; then
             cp /chipmunk/chipmunk_performance_results/Benchmark_PR_${{ github.event.inputs.pr_id }}.json ./jekyll/benchmarks/data/pull_request/
             git add ./jekyll/benchmarks/data/pull_request/Benchmark_PR_${{ github.event.inputs.pr_id }}.json
             git commit -m "Adding PR benchmark results for chipmunk PR #${{ github.event.inputs.pr_id }}"

--- a/scripts/benchmarks/process.rb
+++ b/scripts/benchmarks/process.rb
@@ -113,7 +113,7 @@ def process_release_or_pr(branch_or_tag_name, identifier, env_vars)
         puts "Benchmark results:"
         system("cat #{result_path}")
       else
-        puts "Benchmark results not found at #{result_path}."
+        raise "Benchmark results not found at #{result_path}."
       end
     rescue => e
       puts "An error occurred while processing #{identifier}: #{e.message}"

--- a/scripts/benchmarks/setup_dev_tools.sh
+++ b/scripts/benchmarks/setup_dev_tools.sh
@@ -16,3 +16,8 @@ sudo chown -R $(whoami) /usr/local
 rvm use 3.1.2 --default
 export PATH="/usr/share/rvm:$PATH"
 gem install dotenv json octokit tmpdir fileutils
+curl https://sh.rustup.rs -sSf | RUSTUP_INIT_SKIP_PATH_CHECK=yes sh -s -- -y
+rustup default stable
+rustup update stable
+export PATH="/root/.cargo/bin:$PATH"
+source ~/.bashrc


### PR DESCRIPTION
This resolves the issue where self hosted runner did not get update the rust version and was locked on an older version of nj-cli(due to local dependencies on the self hosted runner).