### PR TITLE
Make Custom allocators Opt-in & Parallel Benchmarks & Jemalloc on Unix

### DIFF
--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -1614,7 +1614,6 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
- "mimalloc",
  "parsers",
  "pretty_assertions",
  "rand",
@@ -2056,6 +2055,7 @@ dependencies = [
  "serde",
  "shellexpand",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "tokio-serial",
  "tokio-stream",
@@ -2202,6 +2202,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.85",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -39,7 +39,6 @@ env_logger = "0.10"
 ## Development Dependencies ##
 # Support for `html_reports` needs running the benchmarks via `cargo-criterion` tool.
 criterion = { version = "0.5", features = ["html_reports"] }
-mimalloc = "0.1"
 
 # only uncomment when profiling
 # [profile.release]

--- a/application/apps/indexer/processor/Cargo.toml
+++ b/application/apps/indexer/processor/Cargo.toml
@@ -28,7 +28,6 @@ criterion.workspace = true
 pretty_assertions = "1.3"
 rand.workspace = true
 tempfile.workspace = true
-mimalloc.workspace = true
 
 [[bench]]
 name = "map_benchmarks"

--- a/application/apps/indexer/processor/benches/map_benchmarks.rs
+++ b/application/apps/indexer/processor/benches/map_benchmarks.rs
@@ -4,9 +4,6 @@ extern crate processor;
 use criterion::{Criterion, *};
 use processor::map::{FilterMatch, SearchMap};
 
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 fn scaled_benchmark(c: &mut Criterion) {
     let mut example_map: SearchMap = SearchMap::new();
     let mut v = vec![];

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -28,14 +28,19 @@ shellexpand = "3.0.0"
 [dev-dependencies]
 env_logger.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
-mimalloc.workspace = true
+mimalloc = "0.1"
+tikv-jemallocator = "0.6"
 
 [[bench]]
 name = "mocks_once_producer"
 harness = false
 
 [[bench]]
-name = "mocks_once_producer_sysalloc"
+name = "mocks_once_producer_jemalloc"
+harness = false
+
+[[bench]]
+name = "mocks_once_producer_mimalloc"
 harness = false
 
 [[bench]]
@@ -43,7 +48,11 @@ name = "mocks_multi_producer"
 harness = false
 
 [[bench]]
-name = "mocks_multi_producer_sysalloc"
+name = "mocks_multi_producer_jemalloc"
+harness = false
+
+[[bench]]
+name = "mocks_multi_producer_mimalloc"
 harness = false
 
 [[bench]]

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -32,11 +32,39 @@ mimalloc = "0.1"
 tikv-jemallocator = "0.6"
 
 [[bench]]
+name = "dlt_producer"
+harness = false
+
+[[bench]]
+name = "someip_producer"
+harness = false
+
+[[bench]]
+name = "someip_legacy_producer"
+harness = false
+
+[[bench]]
+name = "text_producer"
+harness = false
+
+[[bench]]
 name = "mocks_once_producer"
 harness = false
 
 [[bench]]
 name = "mocks_once_producer_jemalloc"
+harness = false
+
+[[bench]]
+name = "mocks_once_parallel"
+harness = false
+
+[[bench]]
+name = "mocks_once_parallel_jemalloc"
+harness = false
+
+[[bench]]
+name = "mocks_once_parallel_mimalloc"
 harness = false
 
 [[bench]]
@@ -56,17 +84,13 @@ name = "mocks_multi_producer_mimalloc"
 harness = false
 
 [[bench]]
-name = "dlt_producer"
+name = "mocks_multi_parallel"
 harness = false
 
 [[bench]]
-name = "someip_producer"
+name = "mocks_multi_parallel_jemalloc"
 harness = false
 
 [[bench]]
-name = "someip_legacy_producer"
-harness = false
-
-[[bench]]
-name = "text_producer"
+name = "mocks_multi_parallel_mimalloc"
 harness = false

--- a/application/apps/indexer/sources/benches/dlt_producer.rs
+++ b/application/apps/indexer/sources/benches/dlt_producer.rs
@@ -9,11 +9,6 @@ use sources::producer::MessageProducer;
 
 mod bench_utls;
 
-// The MiMalloc allocator is currently used in the Chipmunk app on Windows.
-#[cfg(windows)]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 /// This benchmark covers parsing from DLT file and supports providing the path for a fibex file as
 /// additional configuration.
 fn dlt_producer(c: &mut Criterion) {

--- a/application/apps/indexer/sources/benches/dlt_producer.rs
+++ b/application/apps/indexer/sources/benches/dlt_producer.rs
@@ -9,7 +9,8 @@ use sources::producer::MessageProducer;
 
 mod bench_utls;
 
-// The MiMalloc allocator is currently used in the Chipmunk app.
+// The MiMalloc allocator is currently used in the Chipmunk app on Windows.
+#[cfg(windows)]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/application/apps/indexer/sources/benches/macros/mock_producer_multi_parallel.rs
+++ b/application/apps/indexer/sources/benches/macros/mock_producer_multi_parallel.rs
@@ -1,0 +1,94 @@
+//!Provides macro to generate benchmarks for multiple producer sessions running in parallel
+//!with mock parser returning multiple value at a time using various memory allocators
+
+/// Macro to generate benchmarks for multiple producer sessions with mock parser and source
+/// for various memory allocators.
+/// The parser mock in this macro will return multiple items per call using a vector to replicate
+/// the behavior of the potential plugins in Chipmunk.
+///
+/// # Usage:
+/// The macro accepts the name of the benchmark function and the allocator, and generates a
+/// benchmark function with given name using the given allocator
+///
+/// # Example:
+/// ```
+/// mod macros;
+/// mocks_producer_multi_parallel!(mocks_multi_producer_stdalloc, std::alloc::System);
+/// ```
+#[macro_export]
+macro_rules! mocks_producer_multi_parallel {
+    ($name:ident, $allocator:path) => {
+        use ::criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+        use ::sources::producer::MessageProducer;
+        use ::std::hint::black_box;
+        use bench_utls::{bench_standrad_config, run_producer};
+        use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
+
+        mod bench_utls;
+        mod mocks;
+
+        #[global_allocator]
+        static GLOBAL: $allocator = $allocator;
+
+        /// Runs Benchmarks replicating the producer loop within Chipmunk for multiple sessions
+        /// using mocks for [`parsers::Parser`] and [`sources::ByteSource`] to ensure that the
+        /// measurements is for the producer loop only.
+        ///
+        /// The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
+        /// behavior of the potential plugins in Chipmunk.
+        ///
+        /// NOTE: This benchmark suffers unfortunately from a lot of noise because we are running it with
+        /// asynchronous runtime. This test is configured to reduce this amount of noise as possible,
+        /// However it would be better to run it multiple time for double checking.
+        fn $name(c: &mut Criterion) {
+            let max_parse_calls = ::std::hint::black_box(10000);
+            let tasks_count = ::std::hint::black_box(10);
+
+            c.bench_with_input(
+                BenchmarkId::new(std::stringify!($name), max_parse_calls),
+                &(max_parse_calls),
+                |bencher, &max| {
+                    bencher
+                        // It's important to spawn a new runtime on each run to ensure to reduce the
+                        // potential noise produced from one runtime created at the start of all benchmarks
+                        // only.
+                        .to_async(tokio::runtime::Runtime::new().unwrap())
+                        .iter_batched(
+                            || {
+                                // Exclude initiation time from benchmarks.
+                                let mut producers = Vec::with_capacity(tasks_count);
+                                for _ in 0..tasks_count {
+                                    let parser = MockParser::new_multi(max);
+                                    let byte_source = MockByteSource::new();
+                                    let producer =
+                                        MessageProducer::new(parser, byte_source, black_box(None));
+
+                                    producers.push(producer);
+                                }
+
+                                producers
+                            },
+                            |producers| async {
+                                let mut set = ::tokio::task::JoinSet::new();
+                                for producer in producers {
+                                    set.spawn(run_producer(producer));
+                                }
+                                while let Some(res) = set.join_next().await {
+                                    ::std::hint::black_box(&res);
+                                }
+                            },
+                            criterion::BatchSize::SmallInput,
+                        )
+                },
+            );
+        }
+
+        criterion_group! {
+            name = benches;
+            config = bench_standrad_config();
+            targets = $name
+        }
+
+        criterion_main!(benches);
+    };
+}

--- a/application/apps/indexer/sources/benches/macros/mock_producer_once_parallel.rs
+++ b/application/apps/indexer/sources/benches/macros/mock_producer_once_parallel.rs
@@ -1,0 +1,94 @@
+//!Provides macro to generate benchmarks for multiple producer sessions running in parallel
+//!with mock parser returning one value at a time using various memory allocators
+
+/// Macro to generate benchmarks for multiple producer sessions with mock parser and source
+/// for various memory allocators.
+/// The parser mock in this macro will return one item per call with `iter::once()` to replicate
+/// the case with built in parsers.
+///
+/// # Usage:
+/// The macro accepts the name of the benchmark function and the allocator, and generates a
+/// benchmark function with given name using the given allocator
+///
+/// # Example:
+/// ```
+/// mod macros;
+/// mocks_producer_once_parallel!(mocks_once_producer_stdalloc, std::alloc::System);
+/// ```
+#[macro_export]
+macro_rules! mocks_producer_once_parallel {
+    ($name:ident, $allocator:path) => {
+        use ::criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+        use ::sources::producer::MessageProducer;
+        use ::std::hint::black_box;
+        use bench_utls::{bench_standrad_config, run_producer};
+        use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
+
+        mod bench_utls;
+        mod mocks;
+
+        #[global_allocator]
+        static GLOBAL: $allocator = $allocator;
+
+        /// Runs Benchmarks replicating the producer loop within Chipmunk sessions for multiple sessions
+        /// ins parallel, using mocks for [`parsers::Parser`] and [`sources::ByteSource`] to ensure
+        /// that the measurements is for the producer loop only.
+        ///
+        /// The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
+        /// the current built-in parsers in Chipmunk.
+        ///
+        /// NOTE: This benchmark suffers unfortunately from a lot of noise because we are running it with
+        /// asynchronous runtime. This test is configured to reduce this amount of noise as possible,
+        /// However it would be better to run it multiple time for double checking.
+        fn $name(c: &mut Criterion) {
+            let max_parse_calls = ::std::hint::black_box(50000);
+            let tasks_count = ::std::hint::black_box(10);
+
+            c.bench_with_input(
+                BenchmarkId::new(std::stringify!($name), max_parse_calls),
+                &(max_parse_calls),
+                |bencher, &max| {
+                    bencher
+                        // It's important to spawn a new runtime on each run to ensure to reduce the
+                        // potential noise produced from one runtime created at the start of all benchmarks
+                        // only.
+                        .to_async(tokio::runtime::Runtime::new().unwrap())
+                        .iter_batched(
+                            || {
+                                // Exclude initiation time from benchmarks.
+                                let mut producers = Vec::with_capacity(tasks_count);
+                                for _ in 0..tasks_count {
+                                    let parser = MockParser::new_once(max);
+                                    let byte_source = MockByteSource::new();
+                                    let producer =
+                                        MessageProducer::new(parser, byte_source, black_box(None));
+
+                                    producers.push(producer);
+                                }
+
+                                producers
+                            },
+                            |producers| async {
+                                let mut set = ::tokio::task::JoinSet::new();
+                                for producer in producers {
+                                    set.spawn(run_producer(producer));
+                                }
+                                while let Some(res) = set.join_next().await {
+                                    ::std::hint::black_box(&res);
+                                }
+                            },
+                            criterion::BatchSize::SmallInput,
+                        )
+                },
+            );
+        }
+
+        criterion_group! {
+            name = benches;
+            config = bench_standrad_config();
+            targets = $name
+        }
+
+        criterion_main!(benches);
+    };
+}

--- a/application/apps/indexer/sources/benches/macros/mod.rs
+++ b/application/apps/indexer/sources/benches/macros/mod.rs
@@ -5,4 +5,6 @@
 #![allow(unused)]
 
 pub mod mock_producer_multi;
+pub mod mock_producer_multi_parallel;
 pub mod mock_producer_once;
+pub mod mock_producer_once_parallel;

--- a/application/apps/indexer/sources/benches/mocks_multi_parallel.rs
+++ b/application/apps/indexer/sources/benches/mocks_multi_parallel.rs
@@ -1,0 +1,9 @@
+//!Benchmarks for producer loop running multiple times in parallel with mock
+//!parser and byte source using rust standard memory allocator.
+//!
+//!The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
+//!behavior of the potential plugins in Chipmunk.
+
+mod macros;
+
+mocks_producer_multi_parallel!(mocks_multi_parallel, std::alloc::System);

--- a/application/apps/indexer/sources/benches/mocks_multi_parallel_jemalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_multi_parallel_jemalloc.rs
@@ -1,0 +1,9 @@
+//!Benchmarks for producer loop running multiple times in parallel with mock
+//!parser and byte source using 'jemalloc' memory allocator.
+//!
+//!The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
+//!behavior of the potential plugins in Chipmunk.
+
+mod macros;
+
+mocks_producer_multi_parallel!(mocks_multi_parallel_jemalloc, tikv_jemallocator::Jemalloc);

--- a/application/apps/indexer/sources/benches/mocks_multi_parallel_mimalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_multi_parallel_mimalloc.rs
@@ -1,0 +1,9 @@
+//!Benchmarks for producer loop running multiple times in parallel with mock
+//!parser and byte source using 'mimalloc' memory allocator.
+//!
+//!The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
+//!behavior of the potential plugins in Chipmunk.
+
+mod macros;
+
+mocks_producer_multi_parallel!(mocks_multi_parallel_mimalloc, mimalloc::MiMalloc);

--- a/application/apps/indexer/sources/benches/mocks_multi_producer.rs
+++ b/application/apps/indexer/sources/benches/mocks_multi_producer.rs
@@ -1,9 +1,8 @@
-//! Benchmarks for producer loop with mock parser and byte source using `mimalloc` memory allocator,
-//! which provides the best performance and is used in Chipmunk app currently.
+//! Benchmarks for producer loop with mock parser and byte source using rust standard memory allocator,
 //!
 //! The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
 //! behavior of the potential plugins in Chipmunk.
 
 mod macros;
 
-mocks_producer_multi!(mocks_multi_producer, mimalloc::MiMalloc);
+mocks_producer_multi!(mocks_multi_producer, std::alloc::System);

--- a/application/apps/indexer/sources/benches/mocks_multi_producer_jemalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_multi_producer_jemalloc.rs
@@ -1,0 +1,8 @@
+//! Benchmarks for producer loop with mock parser and byte source using `jemalloc` memory allocator,
+//!
+//! The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
+//! behavior of the potential plugins in Chipmunk.
+
+mod macros;
+
+mocks_producer_multi!(mocks_multi_producer_jemalloc, tikv_jemallocator::Jemalloc);

--- a/application/apps/indexer/sources/benches/mocks_multi_producer_mimalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_multi_producer_mimalloc.rs
@@ -1,0 +1,8 @@
+//! Benchmarks for producer loop with mock parser and byte source using `mimalloc` memory allocator,
+//!
+//! The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
+//! behavior of the potential plugins in Chipmunk.
+
+mod macros;
+
+mocks_producer_multi!(mocks_multi_producer_mimalloc, mimalloc::MiMalloc);

--- a/application/apps/indexer/sources/benches/mocks_multi_producer_sysalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_multi_producer_sysalloc.rs
@@ -1,9 +1,0 @@
-//! Benchmarks for producer loop with mock parser and byte source using rust standard memory allocator,
-//! which provides the best performance and is used in Chipmunk app currently.
-//!
-//! The mock of [`parsers::Parser`] will return iterator with multiple value replicating the
-//! behavior of the potential plugins in Chipmunk.
-
-mod macros;
-
-mocks_producer_multi!(mocks_multi_producer_sysalloc, std::alloc::System);

--- a/application/apps/indexer/sources/benches/mocks_once_parallel.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_parallel.rs
@@ -1,0 +1,9 @@
+//!Benchmarks for producer loop running multiple times in parallel with mock
+//!parser and byte source using rust standard memory allocator.
+//!
+//!The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
+//!the current built-in parsers in Chipmunk.
+
+mod macros;
+
+mocks_producer_once_parallel!(mocks_once_parallel, std::alloc::System);

--- a/application/apps/indexer/sources/benches/mocks_once_parallel_jemalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_parallel_jemalloc.rs
@@ -1,0 +1,9 @@
+//!Benchmarks for producer loop running multiple times in parallel with mock
+//!parser and byte source using 'jemalloc' memory allocator.
+//!
+//!The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
+//!the current built-in parsers in Chipmunk.
+
+mod macros;
+
+mocks_producer_once_parallel!(mocks_once_parallel_jemalloc, tikv_jemallocator::Jemalloc);

--- a/application/apps/indexer/sources/benches/mocks_once_parallel_mimalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_parallel_mimalloc.rs
@@ -1,0 +1,9 @@
+//!Benchmarks for producer loop running 10 times in parallel with mock
+//!parser and byte source using 'mimalloc' memory allocator.
+//!
+//!The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
+//!the current built-in parsers in Chipmunk.
+
+mod macros;
+
+mocks_producer_once_parallel!(mocks_once_parallel_mimalloc, mimalloc::MiMalloc);

--- a/application/apps/indexer/sources/benches/mocks_once_producer.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_producer.rs
@@ -1,9 +1,8 @@
-//! Benchmarks for producer loop with mock parser and byte source using `mimalloc` memory allocator,
-//! which provides the best performance and is used in Chipmunk app currently.
+//! Benchmarks for producer loop with mock parser and byte source using rust standard memory allocator.
 //!
 //! The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
 //! the current built-in parsers in Chipmunk.
 
 mod macros;
 
-mocks_producer_once!(mocks_once_producer, mimalloc::MiMalloc);
+mocks_producer_once!(mocks_once_producer, std::alloc::System);

--- a/application/apps/indexer/sources/benches/mocks_once_producer_jemalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_producer_jemalloc.rs
@@ -1,0 +1,8 @@
+//! Benchmarks for producer loop with mock parser and byte source using `jemalloc` memory allocator,
+//!
+//! The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
+//! the current built-in parsers in Chipmunk.
+
+mod macros;
+
+mocks_producer_once!(mocks_once_producer_jemalloc, tikv_jemallocator::Jemalloc);

--- a/application/apps/indexer/sources/benches/mocks_once_producer_mimalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_producer_mimalloc.rs
@@ -1,0 +1,8 @@
+//! Benchmarks for producer loop with mock parser and byte source using `mimalloc` memory allocator,
+//!
+//! The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
+//! the current built-in parsers in Chipmunk.
+
+mod macros;
+
+mocks_producer_once!(mocks_once_producer_mimalloc, mimalloc::MiMalloc);

--- a/application/apps/indexer/sources/benches/mocks_once_producer_sysalloc.rs
+++ b/application/apps/indexer/sources/benches/mocks_once_producer_sysalloc.rs
@@ -1,8 +1,0 @@
-//! Benchmarks for producer loop with mock parser and byte source using rust standard memory allocator.
-//!
-//! The mock of [`parsers::Parser`] will return [`std::iter::once()`] replicating the behavior of
-//! the current built-in parsers in Chipmunk.
-
-mod macros;
-
-mocks_producer_once!(mocks_once_producer_sysalloc, std::alloc::System);

--- a/application/apps/indexer/sources/benches/someip_legacy_producer.rs
+++ b/application/apps/indexer/sources/benches/someip_legacy_producer.rs
@@ -7,11 +7,6 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use parsers::someip::SomeipParser;
 use sources::{binary::pcap::legacy::PcapLegacyByteSource, producer::MessageProducer};
 
-// The MiMalloc allocator is currently used in the Chipmunk app on Windows.
-#[cfg(windows)]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 /// This benchmark covers parsing from SomeIP file using [`PcapLegacyByteSource`] byte source.
 /// It supports providing the path for a fibex file as additional configuration.
 fn someip_legacy_producer(c: &mut Criterion) {

--- a/application/apps/indexer/sources/benches/someip_legacy_producer.rs
+++ b/application/apps/indexer/sources/benches/someip_legacy_producer.rs
@@ -7,7 +7,8 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use parsers::someip::SomeipParser;
 use sources::{binary::pcap::legacy::PcapLegacyByteSource, producer::MessageProducer};
 
-// The MiMalloc allocator is currently used in the Chipmunk app.
+// The MiMalloc allocator is currently used in the Chipmunk app on Windows.
+#[cfg(windows)]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/application/apps/indexer/sources/benches/someip_producer.rs
+++ b/application/apps/indexer/sources/benches/someip_producer.rs
@@ -7,7 +7,8 @@ use sources::{binary::pcap::ng::PcapngByteSource, producer::MessageProducer};
 
 mod bench_utls;
 
-// The MiMalloc allocator is currently used in the Chipmunk app.
+// The MiMalloc allocator is currently used in the Chipmunk app on Windows.
+#[cfg(windows)]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/application/apps/indexer/sources/benches/someip_producer.rs
+++ b/application/apps/indexer/sources/benches/someip_producer.rs
@@ -7,11 +7,6 @@ use sources::{binary::pcap::ng::PcapngByteSource, producer::MessageProducer};
 
 mod bench_utls;
 
-// The MiMalloc allocator is currently used in the Chipmunk app on Windows.
-#[cfg(windows)]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 /// This benchmark covers parsing from SomeIP file using [`PcapngByteSource`] byte source.
 /// It supports providing the path for a fibex file as additional configuration.
 fn someip_producer(c: &mut Criterion) {

--- a/application/apps/indexer/sources/benches/text_producer.rs
+++ b/application/apps/indexer/sources/benches/text_producer.rs
@@ -8,11 +8,6 @@ use sources::producer::MessageProducer;
 
 mod bench_utls;
 
-// The MiMalloc allocator is currently used in the Chipmunk app on Windows.
-#[cfg(windows)]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 /// This benchmark covers parsing from text file file using [`BinaryByteSource`].
 /// This benchmark doesn't support any additional configurations.
 fn text_producer(c: &mut Criterion) {

--- a/application/apps/indexer/sources/benches/text_producer.rs
+++ b/application/apps/indexer/sources/benches/text_producer.rs
@@ -8,7 +8,8 @@ use sources::producer::MessageProducer;
 
 mod bench_utls;
 
-// The MiMalloc allocator is currently used in the Chipmunk app.
+// The MiMalloc allocator is currently used in the Chipmunk app on Windows.
+#[cfg(windows)]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/application/apps/rustcore/rs-bindings/Cargo.lock
+++ b/application/apps/rustcore/rs-bindings/Cargo.lock
@@ -1519,6 +1519,7 @@ dependencies = [
  "session",
  "sources",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "uuid",
@@ -2387,6 +2388,26 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/application/apps/rustcore/rs-bindings/Cargo.toml
+++ b/application/apps/rustcore/rs-bindings/Cargo.toml
@@ -35,4 +35,6 @@ thiserror = "1.0"
 tokio = { version = "1.24", features = ["full"] }
 tokio-util = "0.7"
 uuid = { version = "1.3", features = ["serde", "v4"] }
+
+[target.'cfg(windows)'.dependencies]
 mimalloc = "0.1"

--- a/application/apps/rustcore/rs-bindings/Cargo.toml
+++ b/application/apps/rustcore/rs-bindings/Cargo.toml
@@ -36,5 +36,15 @@ tokio = { version = "1.24", features = ["full"] }
 tokio-util = "0.7"
 uuid = { version = "1.3", features = ["serde", "v4"] }
 
+[target.'cfg(unix)'.dependencies]
+tikv-jemallocator = {version = "0.6" , optional = true }
+
 [target.'cfg(windows)'.dependencies]
-mimalloc = "0.1"
+mimalloc = {version = "0.1" , optional = true }
+
+[features]
+default = []
+# Feature to use optimized memory allocators per platform.
+# Uses `jemalloc` on Unix-based targets and `mimalloc` on Windows.
+# This feature won't be enabled by default since these allocators aren't well tested as the defaults.
+custom-alloc = ['dep:mimalloc', 'dep:tikv-jemallocator']

--- a/application/apps/rustcore/rs-bindings/src/lib.rs
+++ b/application/apps/rustcore/rs-bindings/src/lib.rs
@@ -1,9 +1,10 @@
 mod js;
 mod logging;
 
-// Using the mimalloc allocator resulted in an 8% performance improvement.
+// Using the mimalloc allocator resulted in an 20% performance improvement on windows.
 // NOTE: In a Rust project, the memory allocator can only be set once,
 // and it applies to the entire project, including all dependencies.
 // We chose to configure the allocator in the highest-level library where the runtime is also set.
+#[cfg(windows)]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;

--- a/application/apps/rustcore/rs-bindings/src/lib.rs
+++ b/application/apps/rustcore/rs-bindings/src/lib.rs
@@ -1,10 +1,21 @@
 mod js;
 mod logging;
 
-// Using the mimalloc allocator resulted in an 20% performance improvement on windows.
+// ****************************************
+// *** Memory Allocators Configurations ***
+// ****************************************
+
 // NOTE: In a Rust project, the memory allocator can only be set once,
 // and it applies to the entire project, including all dependencies.
 // We chose to configure the allocator in the highest-level library where the runtime is also set.
-#[cfg(windows)]
+
+// Using the mimalloc allocator resulted in an 20% performance improvement on windows
+// But there are report of memory leaks and big difference in memory consumption using it.
+#[cfg(all(feature = "custom-alloc", windows))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+// Jemalloc currently supports UNIX based operating systems only and provides better performance.
+#[cfg(all(feature = "custom-alloc", unix))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.10
+
+## Features:
+
+* Add `additional features` to both CLI arguments and user configuration to enable additional features in the build process.
+* Add `custom-alloc` additional feature to enable using custom memory allocators in rs-bindings.
+
 # 0.2.9
 
 ## Fixes:

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,11 @@
 * Add `additional features` to both CLI arguments and user configuration to enable additional features in the build process.
 * Add `custom-alloc` additional feature to enable using custom memory allocators in rs-bindings.
 
+## Fixes:
+
+* Fix UI bars unintended up movements and clearing up the messages once done.
+* Keep logs indentation when printing them.
+
 # 0.2.9
 
 ## Fixes:

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cargo-chipmunk"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chipmunk"
-version = "0.2.9"
+version = "0.2.10"
 authors = ["Ammar Abou Zor <ammar.abou.zor@accenture.com>"]
 edition = "2021"
 description = "CLI Tool for chipmunk application development"

--- a/cli/README.md
+++ b/cli/README.md
@@ -86,13 +86,17 @@ Options:
   -u, --ui-mode <UI_MODE>
           Specifies the UI options for displaying command logs and progress in the terminal
 
-          [default: bars]
-
           Possible values:
           - bars:      Displays progress bars, showing the current line of the output of each command. [aliases: 'b']
           - report:    Displays progress bars and prints a summary of all command logs to stdout after all jobs have finished. [aliases: 'r']
           - print:     Outputs each job's result to stdout once the job finishes. No progress bars are displayed. [aliases: 'p']
           - immediate: Outputs logs immediately as they are produced, which may cause overlapping logs for parallel jobs. No progress bars are displayed. [aliases: 'i']
+
+  -a, --additional-features <ADDITIONAL_FEATURES>
+          Specifies additional features to be enabled in the build process
+
+          Possible values:
+          - custom-alloc: Activate `custom-alloc` feature in rs-binding to use custom memory allocator instead of the default one.
 
   -h, --help
           Print help (see a summary with '-h')
@@ -129,6 +133,11 @@ shell = "sh"
 #   - `print`: Outputs each job's result to stdout once the job finishes. No progress bars are displayed.
 #   - `immediate`: Outputs logs immediately as they are produced, which may cause overlapping logs for parallel jobs. No progress bars are displayed.
 ui_mode = "bars"
+
+# Specifies additional features to enable during the build process.
+# Options:
+#  - "custom-alloc": Activate `custom-alloc` feature in rs-binding to use custom memory allocator instead of the default one.
+additional_features = []
 ```
 
 ## Benchmarks via Build CLI Tool

--- a/cli/config/bench_core.toml
+++ b/cli/config/bench_core.toml
@@ -1,26 +1,6 @@
 [[bench]]
-name = "mocks_once_producer"
-library = "sources"
-
-[[bench]]
-name = "mocks_once_producer_jemalloc"
-library = "sources"
-
-[[bench]]
-name = "mocks_once_producer_mimalloc"
-library = "sources"
-
-[[bench]]
-name = "mocks_multi_producer"
-library = "sources"
-
-[[bench]]
-name = "mocks_multi_producer_jemalloc"
-library = "sources"
-
-[[bench]]
-name = "mocks_multi_producer_mimalloc"
-library = "sources"
+name = "map_benchmarks"
+library = "processor"
 
 [[bench]]
 name = "dlt_producer"
@@ -39,6 +19,50 @@ name = "text_producer"
 library = "sources"
 
 [[bench]]
-name = "map_benchmarks"
-library = "processor"
+name = "mocks_once_producer"
+library = "sources"
+
+[[bench]]
+name = "mocks_once_producer_jemalloc"
+library = "sources"
+
+[[bench]]
+name = "mocks_once_producer_mimalloc"
+library = "sources"
+
+[[bench]]
+name = "mocks_once_parallel"
+library = "sources"
+
+[[bench]]
+name = "mocks_once_parallel_jemalloc"
+library = "sources"
+
+[[bench]]
+name = "mocks_once_parallel_mimalloc"
+library = "sources"
+
+[[bench]]
+name = "mocks_multi_producer"
+library = "sources"
+
+[[bench]]
+name = "mocks_multi_producer_jemalloc"
+library = "sources"
+
+[[bench]]
+name = "mocks_multi_producer_mimalloc"
+library = "sources"
+
+[[bench]]
+name = "mocks_multi_parallel"
+library = "sources"
+
+[[bench]]
+name = "mocks_multi_parallel_jemalloc"
+library = "sources"
+
+[[bench]]
+name = "mocks_multi_parallel_mimalloc"
+library = "sources"
 

--- a/cli/config/bench_core.toml
+++ b/cli/config/bench_core.toml
@@ -3,7 +3,11 @@ name = "mocks_once_producer"
 library = "sources"
 
 [[bench]]
-name = "mocks_once_producer_sysalloc"
+name = "mocks_once_producer_jemalloc"
+library = "sources"
+
+[[bench]]
+name = "mocks_once_producer_mimalloc"
 library = "sources"
 
 [[bench]]
@@ -11,7 +15,11 @@ name = "mocks_multi_producer"
 library = "sources"
 
 [[bench]]
-name = "mocks_multi_producer_sysalloc"
+name = "mocks_multi_producer_jemalloc"
+library = "sources"
+
+[[bench]]
+name = "mocks_multi_producer_mimalloc"
 library = "sources"
 
 [[bench]]

--- a/cli/src/cli_args.rs
+++ b/cli/src/cli_args.rs
@@ -5,12 +5,15 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand};
 use serde::{Deserialize, Serialize};
 
-use crate::{benchmark::BenchTarget, target::Target};
+use crate::{benchmark::BenchTarget, jobs_runner::jobs_state::AdditionalFeatures, target::Target};
 
 const FAIL_FAST_HELP_TEXT: &str = "Stops execution immediately if any job fails.";
 const NO_FAIL_FAST_HELP_TEXT: &str = "Don't stops execution immediately if any job fails.";
 const UI_LOG_OPTION_HELP_TEXT: &str =
     "Specifies the UI options for displaying command logs and progress in the terminal";
+const ADDITIONAL_FEATURES_HELP_TEXT: &str =
+    "Specifies additional features to be enabled in the build process";
+
 const HELP_TEMPLATE: &str = "\
 {before-help}{about}
 version: {version}
@@ -107,6 +110,9 @@ pub enum Command {
 
         #[arg(short, long, help = UI_LOG_OPTION_HELP_TEXT, value_enum)]
         ui_mode: Option<UiMode>,
+
+        #[arg(short, long, help = ADDITIONAL_FEATURES_HELP_TEXT)]
+        additional_features: Option<Vec<AdditionalFeatures>>,
     },
     /// Clean all or the specified targets
     Clean {
@@ -146,6 +152,9 @@ pub enum Command {
 
         #[arg(short, long, help = NO_FAIL_FAST_HELP_TEXT)]
         no_fail_fast: bool,
+
+        #[arg(short, long, help = ADDITIONAL_FEATURES_HELP_TEXT)]
+        additional_features: Option<Vec<AdditionalFeatures>>,
     },
     /// Builds Chipmunk and generates a release (defaults to Release mode).
     Release {

--- a/cli/src/dev_environment.rs
+++ b/cli/src/dev_environment.rs
@@ -57,7 +57,7 @@ pub fn validate_dev_tools() -> anyhow::Result<()> {
     }
 
     match errors {
-        Some(err_text) => bail!("{}", err_text.trim()),
+        Some(err_text) => bail!("{}", err_text.trim_end()),
         None => Ok(()),
     }
 }

--- a/cli/src/jobs_runner/jobs_state.rs
+++ b/cli/src/jobs_runner/jobs_state.rs
@@ -3,6 +3,7 @@
 
 use std::{sync::OnceLock, time::Duration};
 
+use serde::{Deserialize, Serialize};
 use tokio::time::timeout;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
@@ -28,6 +29,16 @@ pub struct JobsState {
     configuration: JobsConfig,
 }
 
+/// Represents defined additional features that can activated on parts on build process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, Serialize, Deserialize)]
+pub enum AdditionalFeatures {
+    /// Activate `custom-alloc` feature in rs-binding to use custom memory allocator
+    /// instead of the default one.
+    #[serde(rename = "custom-alloc")]
+    #[value(name = "custom-alloc")]
+    CustomAllocator,
+}
+
 #[derive(Debug, Clone, Default)]
 /// Represents the configuration and specification for the jobs.
 pub struct JobsConfig {
@@ -35,6 +46,8 @@ pub struct JobsConfig {
     is_release_build: bool,
     // Custom specifications for the given jobs.
     custom_specs: Vec<String>,
+    // Additional features for the given jobs.
+    additional_features: Vec<AdditionalFeatures>,
 }
 
 impl JobsConfig {
@@ -54,6 +67,12 @@ impl JobsConfig {
     #[must_use]
     pub fn custom_specs(mut self, custom_specs: Vec<String>) -> Self {
         self.custom_specs = custom_specs;
+        self
+    }
+
+    #[must_use]
+    pub fn additional_features(mut self, additional_features: Vec<AdditionalFeatures>) -> Self {
+        self.additional_features = additional_features;
         self
     }
 }
@@ -153,5 +172,10 @@ impl JobsState {
     /// Gets the job custom specifications if specified.
     pub fn custom_specs(&self) -> &[String] {
         self.configuration.custom_specs.as_slice()
+    }
+
+    /// Gets the additional features for the running job.
+    pub fn additional_features(&self) -> &[AdditionalFeatures] {
+        self.configuration.additional_features.as_slice()
     }
 }

--- a/cli/src/log_print.rs
+++ b/cli/src/log_print.rs
@@ -35,7 +35,7 @@ pub fn print_report(spawn_result: &SpawnResult) {
     spawn_result
         .report
         .iter()
-        .for_each(|line| println!("{}", line.trim()))
+        .for_each(|line| println!("{}", line.trim_end()))
 }
 
 /// Prints a separator to be used between the jobs reports.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -137,8 +137,11 @@ async fn main_process(command: Command) -> Result<(), Error> {
             production,
             fail_fast,
             ui_mode,
+            additional_features,
         } => {
-            JobsState::init(JobsConfig::new(fail_fast));
+            let features = additional_features
+                .unwrap_or_else(|| UserConfiguration::get().additional_features.clone());
+            JobsState::init(JobsConfig::new(fail_fast).additional_features(features));
             init_tracker(ui_mode);
             validate_dev_tools()?;
             let targets = get_targets_or_all(target);
@@ -170,8 +173,11 @@ async fn main_process(command: Command) -> Result<(), Error> {
         Command::Run {
             production,
             no_fail_fast,
+            additional_features,
         } => {
-            JobsState::init(JobsConfig::new(!no_fail_fast));
+            let features = additional_features
+                .unwrap_or_else(|| UserConfiguration::get().additional_features.clone());
+            JobsState::init(JobsConfig::new(!no_fail_fast).additional_features(features));
             init_tracker(Default::default());
             validate_dev_tools()?;
             let results = jobs_runner::run(&[Target::App], JobType::Build { production }).await?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -252,7 +252,7 @@ async fn main_process(command: Command) -> Result<(), Error> {
                         status
                             .report
                             .iter()
-                            .for_each(|line| eprintln!("{}", line.trim()));
+                            .for_each(|line| eprintln!("{}", line.trim_end()));
 
                         eprintln!(
                             "---------------------------------------------------------------------"

--- a/cli/src/target/binding.rs
+++ b/cli/src/target/binding.rs
@@ -2,7 +2,13 @@ use std::fs;
 
 use anyhow::{bail, Context};
 
-use crate::{fstools, jobs_runner::JobDefinition, spawner::SpawnResult, tracker::get_tracker};
+use crate::{
+    fstools,
+    jobs_runner::{jobs_state::AdditionalFeatures, JobDefinition},
+    spawner::SpawnResult,
+    tracker::get_tracker,
+    JobsState,
+};
 
 use super::{ProcessCommand, Target};
 
@@ -18,6 +24,15 @@ pub fn get_build_cmd(prod: bool) -> anyhow::Result<ProcessCommand> {
     if prod {
         args.push("--release".into());
     }
+
+    if JobsState::get()
+        .additional_features()
+        .contains(&AdditionalFeatures::CustomAllocator)
+    {
+        args.push(String::from("--"));
+        args.push(String::from("--features custom-alloc"));
+    }
+
     Ok(ProcessCommand::new(
         path.to_string_lossy().to_string(),
         args,

--- a/cli/src/target/mod.rs
+++ b/cli/src/target/mod.rs
@@ -50,7 +50,7 @@ pub enum Target {
     Wasm,
     /// Represents the path `application/client`
     Client,
-    /// Represents the path `application/apps/precompiled/updater
+    /// Represents the path `application/apps/precompiled/updater`
     Updater,
     /// Represents the path `application/holder`
     App,

--- a/cli/src/user_config.rs
+++ b/cli/src/user_config.rs
@@ -7,18 +7,24 @@ use anyhow::{ensure, Context};
 use console::style;
 use serde::{Deserialize, Serialize};
 
-use crate::{cli_args::UiMode, location::build_cli_home_dir, shell::UserShell};
+use crate::{
+    cli_args::UiMode, jobs_runner::jobs_state::AdditionalFeatures, location::build_cli_home_dir,
+    shell::UserShell,
+};
 
 static USER_CONFIGURATION: OnceLock<UserConfiguration> = OnceLock::new();
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 /// Represents the configuration of this tool on the user level, providing settings like
-/// [`UserShell`] and [`UiMode`] besides methods to load this configurations from a file.
+/// [`UserShell`], [`UiMode`] and [`AdditionalFeatures`] besides methods to load this
+/// configurations from a file.
 pub struct UserConfiguration {
     #[serde(default)]
     pub shell: UserShell,
     #[serde(default)]
     pub ui_mode: UiMode,
+    #[serde(default)]
+    pub additional_features: Vec<AdditionalFeatures>,
 }
 
 impl UserConfiguration {


### PR DESCRIPTION
In this PR:
- [x] Custom allocators are disabled by default and are hidden behind feature flag `custom-alloc`
- [x] When `custom-alloc` is activated, `mimalloc` will be used on Windows and `jemalloc` will be used on unix based systems.
- [x] Build CLI: `additional_flags` add to both CLI arguments and user configuration to enable activating features in build process.
- [x] Build CLI: Add `custom-alloc` to `additional-features` to enable custom allocators feature in rs-bindings
- [x] Add benchmarks to replicate running producer sessions multiple times in parallel with various memory allocators to cover their performance on multi-threaded scenarios.  
- [x] Add jemalloc benchmarks to consider using it on Unix based systems.
- [x] Build CLI: Fixes & Improvements in UI bars and printing logs regarding trimming and empty lines
- [x] Build CLI: Increase Version & Update README and CHANGELOG
