### PR TITLE
Build CLI: Remove Core from dependencies & Keep state on involved targets in last build only

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.14
+
+## Changes:
+
+* Remove rust core target from build dependencies, because it's not being build directly, instead it'll be build from rs-bindings.
+* Last build states keeps track of the targets involved in the last build only.
+
 # 0.2.13
 
 ## Changes:

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -172,6 +172,7 @@ dependencies = [
  "git2",
  "glob",
  "indicatif",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "tempdir",
@@ -297,6 +298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "dir_checksum"
 version = "0.1.0"
 dependencies = [
@@ -305,6 +312,7 @@ dependencies = [
  "ignore",
  "log",
  "memmap2",
+ "pretty_assertions",
  "rayon",
  "tempdir",
  "thiserror",
@@ -934,6 +942,16 @@ name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1649,6 +1667,12 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -158,7 +158,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cargo-chipmunk"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chipmunk"
-version = "0.2.13"
+version = "0.2.14"
 authors = ["Ammar Abou Zor <ammar.abou.zor@accenture.com>"]
 edition = "2021"
 description = "CLI Tool for chipmunk application development"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,6 +15,7 @@ members = ["dir_checksum"]
 [workspace.dependencies]
 tempdir = "0.3"
 anyhow = "1"
+pretty_assertions = "1.4"
 
 [dependencies]
 anyhow.workspace = true
@@ -37,6 +38,7 @@ dirs = "5"
 
 [dev-dependencies]
 tempdir.workspace = true
+pretty_assertions.workspace = true
 
 [[test]]
 name = "dir_checksum"

--- a/cli/dir_checksum/Cargo.toml
+++ b/cli/dir_checksum/Cargo.toml
@@ -16,3 +16,4 @@ log = "0.4"
 [dev-dependencies]
 tempdir.workspace = true
 anyhow.workspace = true
+pretty_assertions.workspace = true

--- a/cli/dir_checksum/tests/integration_tests.rs
+++ b/cli/dir_checksum/tests/integration_tests.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use dir_checksum::*;
+use pretty_assertions::{assert_eq, assert_ne};
 use tempdir::TempDir;
 
 fn create_tmp_dir_with_file(dir_name: &'static str) -> anyhow::Result<(TempDir, PathBuf)> {

--- a/cli/integration_tests/build.py
+++ b/cli/integration_tests/build.py
@@ -50,8 +50,10 @@ BUILD_COMMAND = [
     "--",
     "chipmunk",
     "build",
-    # Provide app target only and it should pull all other targets expect for build CLI, which isn't
-    # possible to build on Windows because it's not allowed to replace a binary while it's running.
+    # Provide app and core targets only and it should pull all other targets expect for build CLI,
+    # which isn't possible to build on Windows because it's not allowed to replace a binary while
+    # it's running.
+    "core",
     "app",
 ]
 

--- a/cli/src/jobs_runner/jobs_resolver.rs
+++ b/cli/src/jobs_runner/jobs_resolver.rs
@@ -218,6 +218,7 @@ fn is_job_involved(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn flatten_clean_job() {

--- a/cli/src/jobs_runner/jobs_resolver.rs
+++ b/cli/src/jobs_runner/jobs_resolver.rs
@@ -29,7 +29,7 @@ pub fn resolve(
     for target in involved_targets {
         for job in involved_jobs
             .iter()
-            .filter(|&&j| is_job_involved(target, j, &main_job, targets))
+            .filter(|&&j| is_job_involved(target, j, &main_job))
         {
             // Start with dependencies from other targets (Applies for Build & Install jobs only)
             let mut dep_jobs = match job {
@@ -125,33 +125,17 @@ fn flatten_targets_for_build(targets: &[Target]) -> BTreeSet<Target> {
 /// * `target`: Job Target
 /// * `current_job`: Current job type to check if it has job for the given target
 /// * `main_job`: Main job type, which is used for the additional filter
-/// * `original_targets`: original targets associated with the main job
-fn is_job_involved(
-    target: Target,
-    current_job: JobType,
-    main_job: &JobType,
-    original_targets: &[Target],
-) -> bool {
+fn is_job_involved(target: Target, current_job: JobType, main_job: &JobType) -> bool {
     // This filter handle the special cases of adding build steps for TS and WASM lints and tests
     // and remove those jobs from the not involved targets
     let additional_filter = || {
         match main_job {
             // Linting for TS and WASM targets inquire that those targets are built
             JobType::Lint => match target {
-                // * Linting for Rust core doesn't need any build and must be excluded in the
-                //   additional filter.
-                Target::Core => match current_job {
-                    // When the current job matches the main job we need to check if the target is
-                    // included in the original targets
-                    JobType::Lint => original_targets.contains(&target),
-                    // Otherwise we need to check if the targets have core in their dependencies to
-                    // build the core since it's needed for their linting jobs.
-                    _ => original_targets
-                        .iter()
-                        .any(|t| t.deps().contains(&Target::Core)),
-                },
                 // These targets aren't involved in the dependencies tree.
-                Target::Cli | Target::Updater => matches!(current_job, JobType::Lint),
+                Target::Core | Target::Cli | Target::Updater => {
+                    matches!(current_job, JobType::Lint)
+                }
                 // TS and Bindings targets need to be built with all their dependencies to perform the
                 // needed type checks on TypeScript
                 Target::Shared
@@ -164,22 +148,10 @@ fn is_job_involved(
 
             // Tests for TS and WASM targets inquire that those targets are built
             JobType::Test { .. } => match target {
-                // * Running tests for rust core doesn't inquire running build on it.
-                // * It should excluded in the filter if it's not included in the original targets
-                //   dependencies before being flatted. This is to avoid running test on core if we
-                //   want to run test on Binding or Wrapper.
-                Target::Core => match current_job {
-                    // When the current job matches the main job we need to check if the target is
-                    // included in the original targets
-                    JobType::Test { .. } => original_targets.contains(&target),
-                    // Otherwise we need to check if the targets have core in their dependencies to
-                    // build the core since it's needed for their testing jobs.
-                    _ => original_targets
-                        .iter()
-                        .any(|t| t.deps().contains(&Target::Core)),
-                },
                 // These targets aren't involved in the dependencies tree.
-                Target::Cli | Target::Updater => matches!(current_job, JobType::Test { .. }),
+                Target::Core | Target::Cli | Target::Updater => {
+                    matches!(current_job, JobType::Test { .. })
+                }
                 // Only TS and WASM Bindings have tests that inquire running build on them and their dependencies
                 // before running the actual tests.
                 Target::Wrapper | Target::Wasm => true,
@@ -279,19 +251,13 @@ mod tests {
 
     #[test]
     fn flatten_wrapper_target() {
-        let expected = BTreeSet::from([
-            Target::Shared,
-            Target::Core,
-            Target::Binding,
-            Target::Wrapper,
-        ]);
+        let expected = BTreeSet::from([Target::Shared, Target::Binding, Target::Wrapper]);
         assert_eq!(flatten_targets_for_build(&[Target::Wrapper]), expected);
     }
 
     #[test]
     fn flatten_app_target() {
         let expected = BTreeSet::from([
-            Target::Core,
             Target::Shared,
             Target::Binding,
             Target::Wrapper,
@@ -351,10 +317,6 @@ mod tests {
         let production = false;
         let expected = BTreeMap::from([
             (
-                JobDefinition::new(Target::Core, JobType::Build { production }),
-                vec![],
-            ),
-            (
                 JobDefinition::new(Target::Shared, JobType::Install { production }),
                 vec![],
             ),
@@ -368,7 +330,6 @@ mod tests {
             (
                 JobDefinition::new(Target::Binding, JobType::Install { production }),
                 vec![
-                    JobDefinition::new(Target::Core, JobType::Build { production }),
                     JobDefinition::new(Target::Shared, JobType::Install { production }),
                     JobDefinition::new(Target::Shared, JobType::Build { production }),
                 ],
@@ -376,7 +337,6 @@ mod tests {
             (
                 JobDefinition::new(Target::Binding, JobType::Build { production }),
                 vec![
-                    JobDefinition::new(Target::Core, JobType::Build { production }),
                     JobDefinition::new(Target::Shared, JobType::Install { production }),
                     JobDefinition::new(Target::Shared, JobType::Build { production }),
                     JobDefinition::new(Target::Binding, JobType::Install { production }),

--- a/cli/src/target/mod.rs
+++ b/cli/src/target/mod.rs
@@ -235,15 +235,10 @@ impl Target {
             Target::Core | Target::Cli | Target::Shared | Target::Wasm | Target::Updater => {
                 Vec::new()
             }
-            Target::Binding => vec![Target::Core, Target::Shared],
-            Target::Wrapper => vec![Target::Core, Target::Binding, Target::Shared],
+            Target::Binding => vec![Target::Shared],
+            Target::Wrapper => vec![Target::Binding, Target::Shared],
             Target::Client => vec![Target::Shared, Target::Wasm],
-            Target::App => vec![
-                Target::Wrapper,
-                Target::Client,
-                Target::Core,
-                Target::Updater,
-            ],
+            Target::App => vec![Target::Wrapper, Target::Client, Target::Updater],
         }
     }
 

--- a/cli/src/version.rs
+++ b/cli/src/version.rs
@@ -117,6 +117,7 @@ fn version_in_repo() -> anyhow::Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
     use Version as V;
 
     #[test]


### PR DESCRIPTION
This PR provides the following changes to the build CLI tool:

* Removes Rust Core from the build dependencies to run the app, since it's not involved in build process, instead it'll be built form rs-bindings directly
* Keep track on the state of involved targets in last build only. Avoiding false positives in skipping builds when saved targets states belongs to different build runs.
* Added pretty assertion for unit tests in Build CLI tool 
