### PR TITLE
Max `proptest` optimizations to increase tests performance

### DIFF
--- a/application/apps/indexer/stypes/Cargo.toml
+++ b/application/apps/indexer/stypes/Cargo.toml
@@ -40,3 +40,11 @@ paste = "1.0"
 uuid = { workspace = true, features = ["serde", "v4"] }
 remove_dir_all = "1.0"
 ts-rs = { version = "10.1", features = ["uuid-impl"] }
+
+# Proptest and its random number generator can be CPU intensive, therefore setting their optimizations level 
+# to max will have significant performance improvement for the tests.
+[profile.test.package.proptest]
+opt-level = 3
+
+[profile.test.package.rand_chacha]
+opt-level = 3


### PR DESCRIPTION
This PR sets optimization level of `proptest` crate and its dependencies to max to optimize the performance of prop-tests, according to [The tips and tricks section in proptest book](https://proptest-rs.github.io/proptest/proptest/tips-and-best-practices.html#setting-opt-level)
