### PR TITLE
Up to 3.14.4

### DIFF
--- a/application/client/package.json
+++ b/application/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chipmunk",
-  "version": "3.14.3",
+  "version": "3.14.4",
   "description": "Logs analyzer tool",
   "author": "Dmitry Astafyev",
   "scripts": {

--- a/application/holder/package.json
+++ b/application/holder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chipmunk",
-  "version": "3.14.3",
+  "version": "3.14.4",
   "chipmunk": {
     "versions": {}
   },

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# 3.14.4 (08.01.2025)
+
+## Changes
+- Using binary format for messaging instead of JSON strings
+
 # 3.14.3 (15.11.2024)
 
 ## Corrections


### PR DESCRIPTION
# 3.14.4 (08.01.2025)

## Changes
- Using binary format for messaging instead of JSON strings