### PR TITLE
Build CLI: Fixes for resolving dependencies & Running jobs in parallel

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Changes:
 
+* List only build related jobs as dependencies allowing lint and test jobs to run in parallel.
 * Add rust core as dependency for protocol and rs-bindings to ensure they will be rebuilt on changes in rust core.
 * Skip build, test, lint job if any of the build related jobs of their all dependencies failed.
 * Build related jobs for linting and testing can be skipped if possible.

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add rust core as dependency for protocol and rs-bindings to ensure they will be rebuilt on changes in rust core.
 * Skip build, test, lint job if any of the build related jobs of their all dependencies failed.
 * Build related jobs for linting and testing can be skipped if possible.
+* Remove test and lint jobs from dependencies if the targets aren't included in the original targets.
 * Update dependencies
 
 # 0.3.0

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Skip build, test, lint job if any of the build related jobs of their all dependencies failed.
 * Build related jobs for linting and testing can be skipped if possible.
 * Remove test and lint jobs from dependencies if the targets aren't included in the original targets.
+* Differentiate between finished and skipped jobs in the UI and logs.
+* Stop release if any build jobs has failed + Enable fail fast on release by default.
+* Add UI-Mode argument to run command.
+* Always show message on mismatch build CLI versions.
 * Update dependencies
 
 # 0.3.0

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.3.1
+
+## Changes:
+
+* Add rust core as dependency for protocol and rs-bindings to ensure they will be rebuilt on changes in rust core.
+* Skip build, test, lint job if any of the build related jobs of their all dependencies failed.
+* Build related jobs for linting and testing can be skipped if possible.
+* Update dependencies
+
 # 0.3.0
 
 ## Changes:

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "tempdir",
- "thiserror",
+ "thiserror 2.0.10",
 ]
 
 [[package]]
@@ -503,9 +503,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git2"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
 dependencies = [
  "bitflags",
  "libc",
@@ -774,9 +774,9 @@ checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.17.0+1.8.1"
+version = "0.18.0+1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
 dependencies = [
  "cc",
  "libc",
@@ -1045,7 +1045,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1232,7 +1232,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ac7f54ca534db81081ef1c1e7f6ea8a3ef428d2fc069097c079443d24124d3"
+dependencies = [
+ "thiserror-impl 2.0.10",
 ]
 
 [[package]]
@@ -1240,6 +1249,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9465d30713b56a37ede7185763c3492a91be2f5fa68d958c44e41ab9248beb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -158,7 +158,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cargo-chipmunk"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -67,19 +67,20 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "arrayref"
@@ -111,14 +112,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "blake3"
@@ -136,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.0"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
  "serde",
@@ -183,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.2"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -200,9 +201,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -210,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -222,18 +223,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.38"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9647a559c112175f17cf724dc72d3645680a883c58481332779192b0d8e7a01"
+checksum = "33a7e468e750fa4b6be660e8b5651ad47372e8fb114030b594c2d75d48c5ffd0"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -243,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
@@ -255,15 +256,15 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console"
-version = "0.15.8"
+version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
- "unicode-width 0.1.14",
- "windows-sys 0.52.0",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -274,9 +275,9 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -293,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "diff"
@@ -315,28 +316,28 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "tempdir",
- "thiserror 2.0.10",
+ "thiserror",
 ]
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -364,9 +365,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -516,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "globset"
@@ -708,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -725,7 +726,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.0",
+ "unicode-width",
  "web-time",
 ]
 
@@ -752,25 +753,19 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.74"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libgit2-sys"
@@ -796,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.20"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
+checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
 dependencies = [
  "cc",
  "libc",
@@ -824,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "memchr"
@@ -845,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -871,9 +866,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -910,7 +905,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -921,9 +916,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -955,18 +950,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1030,22 +1025,22 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -1103,18 +1098,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1123,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -1196,9 +1191,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1228,38 +1223,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ac7f54ca534db81081ef1c1e7f6ea8a3ef428d2fc069097c079443d24124d3"
-dependencies = [
- "thiserror-impl 2.0.10",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9465d30713b56a37ede7185763c3492a91be2f5fa68d958c44e41ab9248beb"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1278,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1296,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1307,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1359,12 +1334,6 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -1425,9 +1394,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1436,13 +1405,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1451,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1461,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1474,9 +1442,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-time"
@@ -1521,20 +1492,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1543,22 +1505,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1567,21 +1514,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1591,21 +1532,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1621,21 +1550,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1645,21 +1562,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1669,9 +1574,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chipmunk"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Ammar Abou Zor <ammar.abou.zor@accenture.com>"]
 edition = "2021"
 description = "CLI Tool for chipmunk application development"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -34,7 +34,7 @@ serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 glob = "0.3"
 toml = "0.8"
-dirs = "5"
+dirs = "6"
 
 [dev-dependencies]
 tempdir.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,7 @@ clap = { version = "4.5", features = ["derive"] }
 console = "0.15"
 fs_extra = "1.3"
 futures = "0.3"
-git2 = { version = "0.19", default-features = false }
+git2 = { version = "0.20", default-features = false }
 indicatif = "0.17"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }

--- a/cli/dir_checksum/Cargo.toml
+++ b/cli/dir_checksum/Cargo.toml
@@ -10,7 +10,7 @@ blake3 = { version = "1", features = ["rayon"] }
 ignore = "0.4"
 memmap2 = "0.9"
 rayon = "1"
-thiserror = "1"
+thiserror = "2"
 log = "0.4"
 
 [dev-dependencies]

--- a/cli/integration_tests/build.py
+++ b/cli/integration_tests/build.py
@@ -50,10 +50,9 @@ BUILD_COMMAND = [
     "--",
     "chipmunk",
     "build",
-    # Provide app and core targets only and it should pull all other targets expect for build CLI,
+    # Provide app target only and it should pull all other targets expect for build CLI,
     # which isn't possible to build on Windows because it's not allowed to replace a binary while
     # it's running.
-    "core",
     "app",
 ]
 

--- a/cli/integration_tests/build.py
+++ b/cli/integration_tests/build.py
@@ -77,7 +77,7 @@ APP_PATHS_FOR_BUILD_CHECK = [
     "apps/rustcore/wasm-bindings/pkg",
     "apps/rustcore/wasm-bindings/node_modules",
     # Client
-    "client/dist",
+    "client/dist/debug",
     "client/node_modules",
     # Updater
     "apps/precompiled/updater/target",
@@ -170,7 +170,7 @@ INVOLVED_PATHS_BUILD_RECORDS_CHECK = [
     # Wrapper
     "apps/rustcore/ts-bindings/dist/index.js",
     # Client
-    "client/dist",
+    "client/dist/debug",
     # App
     "holder/dist/app.js",
 ]

--- a/cli/src/cli_args.rs
+++ b/cli/src/cli_args.rs
@@ -167,8 +167,8 @@ pub enum Command {
         /// Verbose logging
         #[arg(short, long, default_value_t = false)]
         verbose: bool,
-        #[arg(short, long, help = FAIL_FAST_HELP_TEXT)]
-        fail_fast: bool,
+        #[arg(short, long, help = NO_FAIL_FAST_HELP_TEXT)]
+        no_fail_fast: bool,
         /// Build chipmunk in development mode
         #[arg(short, long, default_value_t = false)]
         development: bool,

--- a/cli/src/cli_args.rs
+++ b/cli/src/cli_args.rs
@@ -159,6 +159,9 @@ pub enum Command {
         #[arg(short, long, help = NO_FAIL_FAST_HELP_TEXT)]
         no_fail_fast: bool,
 
+        #[arg(short, long, help = UI_LOG_OPTION_HELP_TEXT, value_enum)]
+        ui_mode: Option<UiMode>,
+
         #[arg(short, long, help = ADDITIONAL_FEATURES_HELP_TEXT)]
         additional_features: Option<Vec<AdditionalFeatures>>,
     },

--- a/cli/src/job_type.rs
+++ b/cli/src/job_type.rs
@@ -65,9 +65,8 @@ impl JobType {
         }
     }
 
-    /// Returns if the job type can be skipped as it is part of the build process
-    /// (install, build, or after build)
-    pub fn can_be_skipped(&self) -> bool {
+    /// Returns if the job type is related to the build process. (install, build, or after build)
+    pub fn is_build_related(&self) -> bool {
         match self {
             JobType::Install { .. } | JobType::Build { .. } | JobType::AfterBuild { .. } => true,
             JobType::Clean | JobType::Lint | JobType::Test { .. } | JobType::Run { .. } => false,

--- a/cli/src/jobs_runner/job_definition.rs
+++ b/cli/src/jobs_runner/job_definition.rs
@@ -35,7 +35,7 @@ impl JobDefinition {
             Some(Ok(res)) => {
                 if res.status.success() {
                     if res.skipped {
-                        tracker.success(self, "skipped".into());
+                        tracker.skipped(self, String::default());
                     } else {
                         tracker.success(self, String::default());
                     }

--- a/cli/src/jobs_runner/job_definition.rs
+++ b/cli/src/jobs_runner/job_definition.rs
@@ -34,7 +34,7 @@ impl JobDefinition {
         match res.as_ref() {
             Some(Ok(res)) => {
                 if res.status.success() {
-                    if res.skipped.is_some_and(|skipped| skipped) {
+                    if res.skipped {
                         tracker.success(self, "skipped".into());
                     } else {
                         tracker.success(self, String::default());
@@ -69,7 +69,7 @@ impl JobDefinition {
                 return self.target.after_build(production, skip).await
             }
             JobType::Clean => self.target.reset().await,
-            JobType::Test { production } => return self.target.test(production).await,
+            JobType::Test { production } => return self.target.test(production, skip).await,
             JobType::Run { .. } => return None,
         };
 

--- a/cli/src/jobs_runner/mod.rs
+++ b/cli/src/jobs_runner/mod.rs
@@ -180,7 +180,6 @@ fn spawn_jobs(
         // Skip on dependencies failing, no matter what the job is.
         let skip = if deps_fail {
             true
-            // Skip
         } else if job_def.job_type.is_build_related() && !jobs_state.is_release_build() {
             // Check if target is already registered and checked
             if let Some(&chksm_compare) = checksum_compare_map.get(&job_def.target) {

--- a/cli/src/jobs_runner/mod.rs
+++ b/cli/src/jobs_runner/mod.rs
@@ -169,8 +169,14 @@ fn spawn_jobs(
         }
 
         let skip = if job_def.job_type.can_be_skipped() && !jobs_state.is_release_build() {
-            // Skip if any prequel job of this target has failed
-            if failed_jobs.contains(&job_def.target) {
+            // Skip if any prequel job of this target and its dependencies has failed
+            if job_def
+                .target
+                .deps()
+                .into_iter()
+                .chain(std::iter::once(job_def.target))
+                .any(|t| failed_jobs.contains(&t))
+            {
                 true
             }
             // Check if target is already registered and checked

--- a/cli/src/jobs_runner/mod.rs
+++ b/cli/src/jobs_runner/mod.rs
@@ -55,14 +55,14 @@ pub async fn run(targets: &[Target], main_job: JobType) -> Result<SpawnResultsCo
     let (tx, mut rx) = unbounded_channel::<(JobDefinition, Result<SpawnResult>)>();
 
     let mut checksum_compare_map = BTreeMap::new();
-    let mut failed_jobs = Vec::new();
+    let mut failed_build_jobs = Vec::new();
 
     // Spawn free job at first
     spawn_jobs(
         tx.clone(),
         &mut jobs_status,
         &mut checksum_compare_map,
-        &failed_jobs,
+        &failed_build_jobs,
     )?;
 
     let mut results = Vec::new();
@@ -96,7 +96,9 @@ pub async fn run(targets: &[Target], main_job: JobType) -> Result<SpawnResultsCo
         let jobs_state = JobsState::get();
 
         if failed {
-            failed_jobs.push(job_def.target);
+            if job_def.job_type.is_build_related() {
+                failed_build_jobs.push(job_def.target);
+            }
 
             if jobs_state.fail_fast() {
                 jobs_state.cancellation_token().cancel();
@@ -143,7 +145,7 @@ pub async fn run(targets: &[Target], main_job: JobType) -> Result<SpawnResultsCo
             tx.clone(),
             &mut jobs_status,
             &mut checksum_compare_map,
-            &failed_jobs,
+            &failed_build_jobs,
         )?;
     }
 
@@ -155,7 +157,7 @@ fn spawn_jobs(
     sender: UnboundedSender<(JobDefinition, Result<SpawnResult>)>,
     jobs_status: &mut BTreeMap<JobDefinition, JobPhase>,
     checksum_compare_map: &mut BTreeMap<Target, ChecksumCompareResult>,
-    failed_jobs: &[Target],
+    failed_build_jobs: &[Target],
 ) -> Result<()> {
     let jobs_state = JobsState::get();
     let task_tracker = jobs_state.task_tracker();
@@ -168,19 +170,20 @@ fn spawn_jobs(
             continue;
         }
 
-        let skip = if job_def.job_type.can_be_skipped() && !jobs_state.is_release_build() {
-            // Skip if any prequel job of this target and its dependencies has failed
-            if job_def
-                .target
-                .deps()
-                .into_iter()
-                .chain(std::iter::once(job_def.target))
-                .any(|t| failed_jobs.contains(&t))
-            {
-                true
-            }
+        let deps_fail = job_def
+            .target
+            .flatten_deps()
+            .into_iter()
+            .chain(std::iter::once(job_def.target))
+            .any(|t| failed_build_jobs.contains(&t));
+
+        // Skip on dependencies failing, no matter what the job is.
+        let skip = if deps_fail {
+            true
+            // Skip
+        } else if job_def.job_type.is_build_related() && !jobs_state.is_release_build() {
             // Check if target is already registered and checked
-            else if let Some(&chksm_compare) = checksum_compare_map.get(&job_def.target) {
+            if let Some(&chksm_compare) = checksum_compare_map.get(&job_def.target) {
                 chksm_compare == ChecksumCompareResult::Same
             } else {
                 // Calculate target checksums and compare it the persisted one
@@ -191,7 +194,7 @@ fn spawn_jobs(
                 checksum_rec.register_job(job_def.target)?;
 
                 // Check if all dependent jobs are skipped, then do the checksum calculations
-                if job_def.target.deps().iter().all(|dep| {
+                if job_def.target.direct_deps().iter().all(|dep| {
                     checksum_compare_map
                         .get(dep)
                         .is_some_and(|&chksm| chksm == ChecksumCompareResult::Same)

--- a/cli/src/log_print.rs
+++ b/cli/src/log_print.rs
@@ -8,7 +8,7 @@ use crate::spawner::SpawnResult;
 pub fn print_report(spawn_result: &SpawnResult) {
     match (spawn_result.skipped, spawn_result.status.success()) {
         // Skipped
-        (Some(true), _) => {
+        (true, _) => {
             let msg = format!("Job '{}' has been skipped", spawn_result.job);
             println!("{}", style(msg).cyan().bold());
         }
@@ -26,7 +26,7 @@ pub fn print_report(spawn_result: &SpawnResult) {
     println!();
 
     println!("Command: {}", spawn_result.cmd);
-    if spawn_result.skipped.is_some_and(|skipped| skipped) {
+    if spawn_result.skipped {
         return;
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -199,11 +199,11 @@ async fn main_process(command: Command) -> Result<(), Error> {
         }
         Command::Release {
             verbose,
-            fail_fast,
+            no_fail_fast,
             development,
             code_sign,
         } => {
-            JobsState::init(JobsConfig::new(fail_fast).release_build(true));
+            JobsState::init(JobsConfig::new(!no_fail_fast).release_build(true));
             let ui_mode = if verbose {
                 UiMode::PrintImmediately
             } else {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -178,12 +178,13 @@ async fn main_process(command: Command) -> Result<(), Error> {
         Command::Run {
             production,
             no_fail_fast,
+            ui_mode,
             additional_features,
         } => {
             let features = additional_features
                 .unwrap_or_else(|| UserConfiguration::get().additional_features.clone());
             JobsState::init(JobsConfig::new(!no_fail_fast).additional_features(features));
-            init_tracker(Default::default());
+            init_tracker(ui_mode);
             validate_dev_tools()?;
             let results = jobs_runner::run(&[Target::App], JobType::Build { production }).await?;
             (JobType::Run { production }, results)

--- a/cli/src/print_dot.rs
+++ b/cli/src/print_dot.rs
@@ -12,7 +12,7 @@ pub fn print_dependencies_targets() {
     println!("digraph dependencies {{");
 
     for target in Target::all() {
-        for dep in target.deps() {
+        for dep in target.direct_deps() {
             println!(r#"  "{target}"  -> "{dep}""#);
         }
     }

--- a/cli/src/release/env_utls.rs
+++ b/cli/src/release/env_utls.rs
@@ -15,8 +15,8 @@ pub fn load_from_env_file() {
         }
         Err(err) => {
             println!(
-                "{} Error: {err}",
-                style("dotenv not found, not considering .env file.").cyan()
+                "{} Info: {err}",
+                style("dotenv for local environment not found, not considering .env file.").cyan()
             );
         }
     }

--- a/cli/src/spawner.rs
+++ b/cli/src/spawner.rs
@@ -10,7 +10,6 @@ use crate::{
     JobsState,
 };
 use anyhow::Context;
-use console::style;
 use core::panic;
 use std::{
     path::PathBuf,
@@ -218,12 +217,7 @@ pub async fn spawn_blocking(
 
 /// This spawns a new task and return immediately showing that the job has been skipped
 pub async fn spawn_skip(job_def: JobDefinition, command: String) -> anyhow::Result<SpawnResult> {
-    if get_tracker().print_immediately() {
-        let msg = format!("Job '{}' has been skipped", job_def.job_title());
-        println!("{}", style(msg).cyan().bold());
-    }
-    Ok(SpawnResult::create_for_skipped(
-        job_def.job_title(),
-        command,
-    ))
+    let skip_result = SpawnResult::create_for_skipped(job_def.job_title(), command);
+
+    Ok(skip_result)
 }

--- a/cli/src/target/mod.rs
+++ b/cli/src/target/mod.rs
@@ -244,13 +244,11 @@ impl Target {
     /// Provides the target which this target depend on
     pub fn deps(self) -> Vec<Target> {
         match self {
-            Target::Core
-            | Target::Cli
-            | Target::Shared
-            | Target::Wasm
-            | Target::Updater
-            | Target::Protocol => Vec::new(),
-            Target::Binding => vec![Target::Shared, Target::Protocol],
+            Target::Core | Target::Cli | Target::Shared | Target::Wasm | Target::Updater => {
+                Vec::new()
+            }
+            Target::Protocol => vec![Target::Core],
+            Target::Binding => vec![Target::Shared, Target::Core, Target::Protocol],
             Target::Wrapper => vec![Target::Binding, Target::Shared, Target::Protocol],
             Target::Client => vec![Target::Shared, Target::Wasm, Target::Protocol],
             Target::App => vec![Target::Wrapper, Target::Client, Target::Updater],

--- a/cli/src/target/mod.rs
+++ b/cli/src/target/mod.rs
@@ -267,7 +267,9 @@ impl Target {
         }
 
         let mut resolved_targets = BTreeSet::new();
-        flatten_rec(self, &mut resolved_targets);
+        for target in self.direct_deps() {
+            flatten_rec(target, &mut resolved_targets);
+        }
 
         resolved_targets
     }

--- a/cli/src/target/wasm.rs
+++ b/cli/src/target/wasm.rs
@@ -46,7 +46,6 @@ pub fn get_test_cmds() -> Vec<TestSpawnCommand> {
             Some(SpawnOptions {
                 // The output of this command causes a weird behavior on the progress bars.
                 suppress_ui: true,
-                ..Default::default()
             }),
         ),
     ]

--- a/cli/src/target/wrapper.rs
+++ b/cli/src/target/wrapper.rs
@@ -6,7 +6,7 @@ use crate::{
     fstools,
     job_type::JobType,
     jobs_runner::JobDefinition,
-    spawner::{spawn, spawn_blocking, SpawnResult},
+    spawner::{spawn, spawn_blocking, spawn_skip, SpawnResult},
     JobsState,
 };
 
@@ -29,8 +29,12 @@ const TEST_FILES_SUFFIXES: &[&str] = &[".spec.js", ".spec.ts"];
 // sequentially using `Stdio::inherit` to keep using the main shell, printing the results
 // of the test directly to standard out, then the progress bars will be shown again.
 
-pub async fn run_test(production: bool) -> Result<SpawnResult, anyhow::Error> {
+pub async fn run_test(production: bool, skip: bool) -> Result<SpawnResult, anyhow::Error> {
     let job_def = JobDefinition::new(Target::Wrapper, JobType::Test { production });
+
+    if skip {
+        return spawn_skip(job_def, "Various test wrapper commands".into()).await;
+    }
 
     let cwd = Target::Wrapper.cwd();
 

--- a/cli/src/tracker.rs
+++ b/cli/src/tracker.rs
@@ -349,7 +349,7 @@ impl Tracker {
                             JobBarPhase::Finished(_) => continue,
                         };
 
-                        job_bar.phase = JobBarPhase::Finished((OperationResult::Failed, time));
+                        job_bar.phase = JobBarPhase::Finished((OperationResult::Skipped, time));
                         max_time_len = max_time_len.max(Self::count_digits(time));
 
                         job_bar.bar.finish();

--- a/cli/src/version.rs
+++ b/cli/src/version.rs
@@ -1,7 +1,7 @@
 //! Manages Comparing the current version of the binary to the version of this CLI tool from the
 //! current local repository of the user, printing a message to the user on newer editions.
 
-use std::{fmt::Display, str::FromStr};
+use std::{cmp::Ordering, fmt::Display, str::FromStr};
 
 use anyhow::{ensure, Context};
 use console::style;
@@ -65,9 +65,22 @@ fn try_check_version() -> anyhow::Result<()> {
         format!("Parsing local repo version text failed. Version: {repo_version}")
     })?;
 
-    if repo_version > bin_version {
-        let warn_msg = format!("A newer version of the Build CLI Tool is available in your local repository\nInstalled Version: {bin_version}\nLatest Version: {repo_version}\n");
-        eprintln!("{}", style(warn_msg).yellow());
+    match repo_version.cmp(&bin_version) {
+        Ordering::Less => {
+            let info_msg = format!("The version of the installed Build CLI Tool is more recent than the current one in the local repository\n\
+                Installed Version: {bin_version}\n\
+                Local repo Version: {repo_version}\n");
+            eprintln!("{}", style(info_msg).cyan());
+        }
+        Ordering::Equal => {}
+        Ordering::Greater => {
+            let warn_msg = format!(
+                "A newer version of the Build CLI Tool is available in the local repository\n\
+                Installed Version: {bin_version}\n\
+                Local repo Version: {repo_version}\n"
+            );
+            eprintln!("{}", style(warn_msg).yellow());
+        }
     }
 
     Ok(())


### PR DESCRIPTION
This PR provides various fixes and improvement to the build CLI tool:

* It lists only build related jobs as dependencies allowing lint and test jobs to run in parallel, avoiding blocking jobs until the lint or test jobs of their dependencies are done (as in the current solution) 
* Add rust core as dependency for protocol and rs-bindings to ensure they will be rebuilt on changes in rust core.
* Skip build, test, lint job if any of the build related jobs of their all dependencies failed.
* Build related jobs for linting and testing can be skipped if possible.
* Fix to avoid running test and lint jobs on the dependencies of a job since only build jobs are needed
* Stop release on any failing build jobs + Active fail fast on release.
* Skipped jobs should be marked in the TUI with and without fail fast.
* Small blue note when build-cli version is greater than the current one in solution branch.
* Add missing UI mode CLI argument for run command.
* Update dependencies of the build CLI tool.
