### PR TITLE
Plugins: Set constrains for plugin filenames.

### DIFF
--- a/application/client/src/app/service/actions/folder.plugins.ts
+++ b/application/client/src/app/service/actions/folder.plugins.ts
@@ -47,7 +47,11 @@ export class Action extends Base {
             session
                 .initialize()
                 .observe(
-                    new Factory.File().type(files[0].type).file(files[0].filename).asPlugin().get(),
+                    new Factory.File()
+                        .type(files[0].type)
+                        .file(files[0].filename)
+                        .asParserPlugin()
+                        .get(),
                 );
         }
 

--- a/cli/chipmunk-cli/Cargo.lock
+++ b/cli/chipmunk-cli/Cargo.lock
@@ -1415,6 +1415,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 name = "stypes"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bincode",
  "dlt-core",
  "envvars",

--- a/plugin_examples/README.md
+++ b/plugin_examples/README.md
@@ -94,7 +94,8 @@ The build process will generate a WASM file named after your plugin. To integrat
    Create a directory within the appropriate plugin type folder (for example, `<HOME>/.chipmunk/plugins/parser/` for parser plugins or `<HOME>/.chipmunk/plugins/bytesource/` for byte-source plugins) using the plugin name.
 
 2. **Copy Artifacts:**  
-   Place the compiled WASM file in the directory. You may also include an optional TOML file containing plugin metadata (such as the plugin name and description).
+Place the compiled WASM file inside the plugin directory. Optionally, you can include a TOML file to provide metadata such as the plugin’s name and description.
+Ensure that both the `.wasm` binary and the `.toml` metadata file (if present) have names that match the plugin directory name.
 
 ---
 


### PR DESCRIPTION
This PR closes #2200 

It includes:
* File names for plugin binary and metadata files must match the directory name of the plugin, making the naming conventions clear for plugin developers.
* Update plugins README with the changes as well.