### PR TITLE
Socket sources: Improvements for internal buffers

### DIFF
--- a/application/apps/indexer/sources/src/socket/mod.rs
+++ b/application/apps/indexer/sources/src/socket/mod.rs
@@ -4,6 +4,12 @@ use tokio::sync::watch::Sender;
 pub mod tcp;
 pub mod udp;
 
+/// Maximum packet size for the internal temp buffer of socket byte-sources.
+const MAX_DATAGRAM_SIZE: usize = 65_507;
+
+/// Maximum capacity for the buffer of socket byte-sources.
+const MAX_BUFF_SIZE: usize = 1024 * 1024;
+
 /// Defines methods on sockets to make them able to reconnect to server in case the
 /// connection is lost.
 trait ReconnectToServer {

--- a/application/apps/indexer/sources/src/socket/udp.rs
+++ b/application/apps/indexer/sources/src/socket/udp.rs
@@ -1,9 +1,11 @@
-use crate::{ByteSource, Error as SourceError, ReloadInfo, SourceFilter};
 use bufread::DeqBuffer;
 use log::trace;
 use std::net::{IpAddr, Ipv4Addr};
 use thiserror::Error;
 use tokio::net::{ToSocketAddrs, UdpSocket};
+
+use super::{MAX_BUFF_SIZE, MAX_DATAGRAM_SIZE};
+use crate::{ByteSource, Error as SourceError, ReloadInfo, SourceFilter};
 
 #[derive(Error, Debug)]
 pub enum UdpSourceError {
@@ -24,8 +26,6 @@ pub struct UdpSource {
     socket: UdpSocket,
     tmp_buffer: Vec<u8>,
 }
-
-const MAX_DATAGRAM_SIZE: usize = 65_507;
 
 impl UdpSource {
     pub async fn new<A: ToSocketAddrs>(
@@ -66,7 +66,7 @@ impl UdpSource {
         }
 
         Ok(Self {
-            buffer: DeqBuffer::new(8192),
+            buffer: DeqBuffer::new(MAX_BUFF_SIZE),
             socket,
             tmp_buffer: vec![0u8; MAX_DATAGRAM_SIZE],
         })
@@ -78,6 +78,14 @@ impl ByteSource for UdpSource {
         &mut self,
         _filter: Option<&SourceFilter>,
     ) -> Result<Option<ReloadInfo>, SourceError> {
+        // If buffer is almost full then skip loading and return the available bytes.
+        // This can happen because some parsers will parse the first item of the provided slice
+        // while the producer will call load on each iteration making data accumulate.
+        if self.buffer.write_available() < MAX_DATAGRAM_SIZE {
+            let available_bytes = self.len();
+            return Ok(Some(ReloadInfo::new(0, available_bytes, 0, None)));
+        }
+
         // TODO use filter
         let (len, remote_addr) = self
             .socket
@@ -91,8 +99,14 @@ impl ByteSource for UdpSource {
             String::from_utf8_lossy(&self.tmp_buffer[..len])
         );
         if len > 0 {
-            self.buffer.write_from(&self.tmp_buffer[..len]);
+            let added = self.buffer.write_from(&self.tmp_buffer[..len]);
+            if added < len {
+                return Err(SourceError::Unrecoverable(
+                    "Internal buffer maximum capcity reached.".into(),
+                ));
+            }
         }
+
         let available_bytes = self.buffer.read_available();
 
         Ok(Some(ReloadInfo::new(len, available_bytes, 0, None)))
@@ -104,6 +118,11 @@ impl ByteSource for UdpSource {
 
     fn consume(&mut self, offset: usize) {
         self.buffer.read_done(offset);
+        // Calling read_done() won't make free up writable memory.
+        // Therefore we need to call flush manually.
+        if self.buffer.write_available() < MAX_DATAGRAM_SIZE {
+            self.buffer.flush();
+        }
     }
 
     fn len(&self) -> usize {
@@ -113,6 +132,8 @@ impl ByteSource for UdpSource {
 
 #[cfg(test)]
 mod tests {
+    use tokio::task::yield_now;
+
     use super::*;
     use crate::tests::general_source_reload_test;
 
@@ -166,5 +187,54 @@ mod tests {
         let mut udp_source = UdpSource::new(RECEIVER, vec![]).await.unwrap();
 
         general_source_reload_test(&mut udp_source).await;
+    }
+
+    /// Tests will send packets with fixed lengths while consuming
+    /// half of the sent length, ensuring the source won't break.
+    ///
+    /// TODO:
+    /// This test demonstrate that parsers which consume the bytes of one result at a
+    /// time while miss parsing the whole bytes when the server isn't sending more data
+    /// even that the buffer has bytes in it.
+    #[tokio::test]
+    async fn test_source_buffer_overflow() {
+        const SENDER: &str = "127.0.0.1:4002";
+        const RECEIVER: &str = "127.0.0.1:5002";
+
+        const SENT_LEN: usize = MAX_DATAGRAM_SIZE;
+        const CONSUME_LEN: usize = MAX_DATAGRAM_SIZE / 2;
+
+        let send_socket = UdpSocket::bind(SENDER)
+            .await
+            .map_err(UdpSourceError::Io)
+            .unwrap();
+
+        // Spawn server in background.
+        tokio::spawn(async move {
+            let msg = [b'a'; SENT_LEN];
+            let mut total_sent = 0;
+            while total_sent < MAX_BUFF_SIZE * 2 {
+                send_socket
+                    .send_to(&msg, RECEIVER)
+                    .await
+                    .expect("could not send on socket");
+                yield_now().await;
+                total_sent += msg.len();
+            }
+        });
+
+        let mut udp_source = UdpSource::new(RECEIVER, vec![]).await.unwrap();
+
+        while let Ok(Some(info)) = udp_source.load(None).await {
+            if info.newly_loaded_bytes == 0 {
+                println!(
+                    "Availbe bytes count that won't be parsed: {}",
+                    info.available_bytes
+                );
+
+                break;
+            }
+            udp_source.consume(info.available_bytes.min(CONSUME_LEN));
+        }
     }
 }

--- a/cli/chipmunk-cli/Cargo.lock
+++ b/cli/chipmunk-cli/Cargo.lock
@@ -198,6 +198,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bufread"
+version = "0.1.1"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,7 +1382,7 @@ name = "sources"
 version = "0.1.0"
 dependencies = [
  "async-stream",
- "buf_redux",
+ "bufread",
  "bytes",
  "etherparse",
  "futures",


### PR DESCRIPTION
This PR includes:
* Increase the capacity of the internal buffer in socket byte sources to 1MB instead of the default value 8KB.
* Add Checks for socket byte source to avoid filling the internal buffer if the server is sending the data with high frequency because the producer loop will call load on each iteration while some parsers will parse one item only on each iteration.
* Call flush on consume when there is not enough writable memory.
* Another check if the buffer is filled and return an error if we can't add all the incoming bytes into the buffer.