### PR TITLE
Development CLI: Remove targets record file on Clean.

### DIFF
--- a/cli/development-cli/CHANGELOG.md
+++ b/cli/development-cli/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.4.1
+
+## Changes:
+
+* Clean command removes checksum records entirely, making it more reliable.
+
 # 0.4.0
 
 ## Changes:

--- a/cli/development-cli/Cargo.lock
+++ b/cli/development-cli/Cargo.lock
@@ -159,7 +159,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cargo-chipmunk"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/development-cli/Cargo.toml
+++ b/cli/development-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chipmunk"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Ammar Abou Zor <ammar.abou.zor@accenture.com>"]
 edition = "2021"
 description = "CLI Tool for chipmunk application development"

--- a/cli/development-cli/src/build_state_records.rs
+++ b/cli/development-cli/src/build_state_records.rs
@@ -259,15 +259,6 @@ impl BuildStateRecords {
             })
     }
 
-    /// Remove the target from the states records
-    pub fn remove_state_if_exist(&mut self, target: Target) -> anyhow::Result<()> {
-        self.involved_targets.insert(target);
-
-        self.states.remove(&target);
-
-        Ok(())
-    }
-
     /// Clears the states from previous build then calculates the states for the involved targets.
     fn update_records(&mut self) -> anyhow::Result<()> {
         self.states.clear();

--- a/cli/development-cli/src/main.rs
+++ b/cli/development-cli/src/main.rs
@@ -152,6 +152,8 @@ async fn main_process(command: Command) -> Result<(), Error> {
             JobsState::init(JobsConfig::new(false));
             init_tracker(ui_mode);
             validate_dev_tools()?;
+
+            BuildStateRecords::remove_records_file()?;
             let targets = get_targets_or_all(target);
             let results = jobs_runner::run(&targets, JobType::Clean).await?;
             (JobType::Clean, results)

--- a/cli/development-cli/src/target/mod.rs
+++ b/cli/development-cli/src/target/mod.rs
@@ -9,7 +9,6 @@ use std::{borrow::Cow, collections::BTreeSet, fmt::Display, iter, path::PathBuf,
 use tokio::fs;
 
 use crate::{
-    build_state_records::BuildStateRecords,
     dev_tools::DevTool,
     fstools,
     job_type::JobType,
@@ -514,15 +513,6 @@ impl Target {
     /// Clean the given target, removing it from the checksum tracker as well.
     pub async fn reset(&self) -> anyhow::Result<SpawnResult> {
         let job_def = JobDefinition::new(*self, JobType::Clean);
-
-        {
-            // Clean doesn't differentiate between development and production, and both of them will be
-            // cleaned from the files when the data are persisted.
-            let mut checksum = BuildStateRecords::get(false)?.lock().map_err(|err| {
-                anyhow::anyhow!("Error while acquiring items jobs mutex: Error {err}")
-            })?;
-            checksum.remove_state_if_exist(*self)?;
-        }
 
         let mut paths_to_remove = vec![self.cwd().join("dist")];
         let path = match self.kind() {


### PR DESCRIPTION
This PR closes #2227 

It provides Removing record file entirely on the start of any clean job instead of trying to update the record file, making clean command more reliable because updating the record file may fail more often than removing it.