### PR TITLE
Parsers returns multiple items & Reuse Items buffer instead of streams 

### DIFF
--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -930,13 +930,11 @@ name = "dlt-tools"
 version = "0.1.0"
 dependencies = [
  "dlt-core",
- "futures",
  "indexer_base",
  "log",
  "parsers",
  "sources",
  "tokio",
- "tokio-stream",
  "tokio-util",
 ]
 
@@ -1424,7 +1422,6 @@ dependencies = [
  "dlt-core",
  "dlt-tools",
  "env_logger",
- "futures",
  "indexer_base",
  "indicatif",
  "lazy_static",
@@ -1445,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.9"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
  "console",
  "number_prefix",
@@ -2198,6 +2195,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sources",
  "stypes",
  "tempfile",
  "thiserror 2.0.11",

--- a/application/apps/indexer/addons/dlt-tools/Cargo.toml
+++ b/application/apps/indexer/addons/dlt-tools/Cargo.toml
@@ -5,13 +5,11 @@ edition = "2021"
 
 [dependencies]
 dlt-core.workspace = true
-futures.workspace = true
 indexer_base = { path = "../../indexer_base" }
 log.workspace = true
 parsers = { path = "../../parsers" }
 sources = { path = "../../sources" }
 tokio = { workspace = true , features = ["full"] }
 tokio-util = { workspace = true, features = ["codec", "net"] }
-tokio-stream.workspace = true
 
 [dev-dependencies]

--- a/application/apps/indexer/addons/dlt-tools/src/lib.rs
+++ b/application/apps/indexer/addons/dlt-tools/src/lib.rs
@@ -49,6 +49,9 @@ pub async fn scan_dlt_ft(
             let mut attachments = vec![];
             loop {
                 tokio::select! {
+                    // Check on events in current order ensuring cancel will be checked at first
+                    // as it's defined in the current unit tests.
+                    biased;
                     _ = cancel.cancelled() => {
                         debug!("scan canceled");
                         canceled = true;

--- a/application/apps/indexer/indexer_cli/Cargo.toml
+++ b/application/apps/indexer/indexer_cli/Cargo.toml
@@ -10,7 +10,6 @@ chrono = "0.4"
 dirs.workspace = true
 dlt-core.workspace = true
 env_logger.workspace = true
-futures.workspace = true
 indexer_base = { path = "../indexer_base" }
 indicatif = "0.17"
 lazy_static.workspace = true

--- a/application/apps/indexer/parsers/src/lib.rs
+++ b/application/apps/indexer/parsers/src/lib.rs
@@ -3,7 +3,7 @@ pub mod dlt;
 pub mod someip;
 pub mod text;
 use serde::Serialize;
-use std::{fmt::Display, io::Write};
+use std::{fmt::Display, io::Write, iter};
 use thiserror::Error;
 
 extern crate log;
@@ -98,4 +98,57 @@ pub enum MessageStreamItem<T: LogMessage> {
     Incomplete,
     Empty,
     Done,
+}
+
+/// Continuously applies the [`parse_fn`] function to the given [`input`] bytes,
+/// extracting all possible items until no more can be parsed.
+///
+/// This function serves as a helper for parsing methods that return only the first
+/// successfully parsed item. It repeatedly invokes [`parse_fn`] as long as there
+/// are enough bytes remaining in [`input`] to parse another message.
+///
+/// # Behavior
+///
+/// - If the first invocation of [`parse_fn`] fails, the function returns an error immediately.
+/// - If the first invocation succeeds, parsing continues until either:
+///   - There are not enough remaining bytes to parse another message.
+///   - [`parse_fn`] returns an error, which will be ignored after the first success.
+///
+/// # Arguments
+///
+/// * `input`: A slice of bytes to be parsed.
+/// * `timestamp`: An optional timestamp associated with the message.
+/// * `min_bytes_count`: The minimum number of bytes likely required to parse a message.
+/// * `parse_fn`: A function that attempts to parse a message from a byte slice.
+///   - It takes a byte slice and an optional timestamp.
+///   - It returns a result containing:
+///     - The number of bytes consumed.
+///     - An optional parsed item [`ParseYield<T>`].
+///   - If parsing fails, it returns an [`Error`].
+fn parse_all<F, T>(
+    input: &[u8],
+    timestamp: Option<u64>,
+    min_bytes_count: usize,
+    mut parse_fn: F,
+) -> Result<impl Iterator<Item = (usize, Option<ParseYield<T>>)> + use<'_, F, T>, Error>
+where
+    F: FnMut(&[u8], Option<u64>) -> Result<(usize, Option<ParseYield<T>>), Error>,
+{
+    let mut slice = input;
+
+    // return early if function errors on first parse call.
+    let first_res = parse_fn(slice, timestamp)?;
+
+    // Otherwise keep parsing and stop on first error, returning the parsed items at the end.
+    let iter = iter::successors(Some(first_res), move |(consumed, _res)| {
+        slice = &slice[*consumed..];
+
+        if slice.len() < min_bytes_count {
+            return None;
+        }
+
+        parse_fn(slice, timestamp).ok()
+    });
+
+    Ok(iter)
 }

--- a/application/apps/indexer/processor/Cargo.toml
+++ b/application/apps/indexer/processor/Cargo.toml
@@ -16,6 +16,7 @@ itertools = "0.13"
 lazy_static.workspace = true
 log.workspace = true
 parsers = { path = "../parsers" }
+sources = { path = "../sources" }
 regex.workspace = true
 serde = { workspace = true , features = ["derive"] }
 serde_json.workspace = true

--- a/application/apps/indexer/session/src/handlers/export_raw.rs
+++ b/application/apps/indexer/session/src/handlers/export_raw.rs
@@ -5,7 +5,7 @@ use parsers::{
     dlt::{fmt::FormatOptions, DltParser},
     someip::SomeipParser,
     text::StringTokenizer,
-    LogMessage, MessageStreamItem,
+    LogMessage, Parser,
 };
 use processor::export::{export_raw, ExportError};
 use sources::{
@@ -138,16 +138,8 @@ async fn export<S: ByteSource>(
             } else {
                 SomeipParser::new()
             };
-            let mut producer = MessageProducer::new(parser, source, None);
-            export_runner(
-                Box::pin(producer.as_stream()),
-                dest,
-                sections,
-                read_to_end,
-                false,
-                cancel,
-            )
-            .await
+            let producer = MessageProducer::new(parser, source, None);
+            export_runner(producer, dest, sections, read_to_end, false, cancel).await
         }
         stypes::ParserType::Dlt(settings) => {
             let fmt_options = Some(FormatOptions::from(settings.tz.as_ref()));
@@ -158,34 +150,18 @@ async fn export<S: ByteSource>(
                 None,
                 settings.with_storage_header,
             );
-            let mut producer = MessageProducer::new(parser, source, None);
-            export_runner(
-                Box::pin(producer.as_stream()),
-                dest,
-                sections,
-                read_to_end,
-                false,
-                cancel,
-            )
-            .await
+            let producer = MessageProducer::new(parser, source, None);
+            export_runner(producer, dest, sections, read_to_end, false, cancel).await
         }
         stypes::ParserType::Text(()) => {
-            let mut producer = MessageProducer::new(StringTokenizer {}, source, None);
-            export_runner(
-                Box::pin(producer.as_stream()),
-                dest,
-                sections,
-                read_to_end,
-                true,
-                cancel,
-            )
-            .await
+            let producer = MessageProducer::new(StringTokenizer {}, source, None);
+            export_runner(producer, dest, sections, read_to_end, true, cancel).await
         }
     }
 }
 
-pub async fn export_runner<S, T>(
-    s: S,
+pub async fn export_runner<P, D, T>(
+    producer: MessageProducer<T, P, D>,
     dest: &Path,
     sections: &Vec<IndexSection>,
     read_to_end: bool,
@@ -194,9 +170,10 @@ pub async fn export_runner<S, T>(
 ) -> Result<Option<usize>, stypes::NativeError>
 where
     T: LogMessage + Sized,
-    S: futures::Stream<Item = Box<[(usize, MessageStreamItem<T>)]>> + Unpin,
+    P: Parser<T>,
+    D: ByteSource,
 {
-    export_raw(s, dest, sections, read_to_end, text_file, cancel)
+    export_raw(producer, dest, sections, read_to_end, text_file, cancel)
         .await
         .map_or_else(
             |err| match err {

--- a/application/apps/indexer/session/src/handlers/observing/mod.rs
+++ b/application/apps/indexer/session/src/handlers/observing/mod.rs
@@ -21,10 +21,9 @@ use tokio::{
     sync::mpsc::Receiver,
     time::{timeout, Duration},
 };
-use tokio_stream::StreamExt;
 
-enum Next<T: LogMessage> {
-    Items(Box<[(usize, MessageStreamItem<T>)]>),
+enum Next<'a, T: LogMessage> {
+    Items(&'a mut Vec<(usize, MessageStreamItem<T>)>),
     Timeout,
     Waiting,
 }
@@ -120,12 +119,10 @@ async fn run_producer<T: LogMessage, P: Parser<T>, S: ByteSource>(
     state.set_session_file(None).await?;
     operation_api.processing();
     let cancel = operation_api.cancellation_token();
-    let stream = producer.as_stream();
-    futures::pin_mut!(stream);
     let cancel_on_tail = cancel.clone();
     while let Some(next) = select! {
         next_from_stream = async {
-            match timeout(Duration::from_millis(FLUSH_TIMEOUT_IN_MS as u64), stream.next()).await {
+            match timeout(Duration::from_millis(FLUSH_TIMEOUT_IN_MS as u64), producer.read_next_segment()).await {
                 Ok(items) => {
                     if let Some(items) = items {
                         Some(Next::Items(items))
@@ -140,6 +137,10 @@ async fn run_producer<T: LogMessage, P: Parser<T>, S: ByteSource>(
     } {
         match next {
             Next::Items(items) => {
+                // Iterating over references is more efficient than using `drain(..)`, even though
+                // we clone the attachments below. With ownership, `mem_copy()` would still be called
+                // to move the item into the attachment vector. Cloning avoids the overhead of
+                // `drain(..)`, especially since `items` is cleared on each iteration anyway.
                 for (_, item) in items {
                     match item {
                         MessageStreamItem::Item(ParseYield::Message(item)) => {
@@ -154,10 +155,10 @@ async fn run_producer<T: LogMessage, P: Parser<T>, S: ByteSource>(
                             state
                                 .write_session_file(source_id, format!("{item}\n"))
                                 .await?;
-                            state.add_attachment(attachment)?;
+                            state.add_attachment(attachment.to_owned())?;
                         }
                         MessageStreamItem::Item(ParseYield::Attachment(attachment)) => {
-                            state.add_attachment(attachment)?;
+                            state.add_attachment(attachment.to_owned())?;
                         }
                         MessageStreamItem::Done => {
                             trace!("observe, message stream is done");

--- a/application/apps/indexer/sources/benches/bench_utls.rs
+++ b/application/apps/indexer/sources/benches/bench_utls.rs
@@ -82,10 +82,7 @@ where
 {
     let mut counter = ProducerCounter::default();
 
-    let s = producer.as_stream();
-    tokio::pin!(s);
-
-    while let Some(items) = s.next().await {
+    while let Some(items) = producer.read_next_segment().await {
         for (_, i) in items {
             match i {
                 MessageStreamItem::Item(item) => match item {

--- a/application/apps/indexer/sources/benches/mocks/mock_parser.rs
+++ b/application/apps/indexer/sources/benches/mocks/mock_parser.rs
@@ -184,13 +184,23 @@ impl Parser<MockMessage> for MockParser<IterMany> {
     > {
         self.counter += 1;
 
-        const REPEAT: usize = 10;
-        let mut res = Vec::with_capacity(black_box(REPEAT));
-        for _ in 0..black_box(REPEAT) {
-            let item = Self::inner_parse(self.counter, self.max_count, input, timestamp)?;
-            res.push(item)
+        if self.counter >= self.max_count {
+            const ERR: parsers::Error = parsers::Error::Eof;
+
+            return Err(black_box(ERR));
         }
 
-        Ok(res.into_iter())
+        const REPEAT: usize = 10;
+        let mut counter = 0;
+        let res = iter::from_fn(move || {
+            counter += 1;
+            if counter < black_box(REPEAT) {
+                Self::inner_parse(self.counter, self.max_count, input, timestamp).ok()
+            } else {
+                None
+            }
+        });
+
+        black_box(Ok(res))
     }
 }

--- a/application/apps/indexer/sources/src/command/process.rs
+++ b/application/apps/indexer/sources/src/command/process.rs
@@ -38,8 +38,11 @@ pub struct ProcessSource {
 
 impl Drop for ProcessSource {
     fn drop(&mut self) {
-        if let Err(err) = self.process.start_kill() {
-            error!("Fail to kill child process: {err}");
+        let is_process_alive = self.process.try_wait().is_ok_and(|state| state.is_none());
+        if is_process_alive {
+            if let Err(err) = self.process.start_kill() {
+                warn!("Fail to kill child process: {err}");
+            }
         }
     }
 }

--- a/application/apps/indexer/sources/src/socket/udp.rs
+++ b/application/apps/indexer/sources/src/socket/udp.rs
@@ -132,6 +132,8 @@ impl ByteSource for UdpSource {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use tokio::task::yield_now;
 
     use super::*;
@@ -213,6 +215,8 @@ mod tests {
         tokio::spawn(async move {
             let msg = [b'a'; SENT_LEN];
             let mut total_sent = 0;
+            // Give the receiver some start up time.
+            tokio::time::sleep(Duration::from_millis(100)).await;
             while total_sent < MAX_BUFF_SIZE * 2 {
                 send_socket
                     .send_to(&msg, RECEIVER)

--- a/application/apps/indexer/stypes/src/lib.rs
+++ b/application/apps/indexer/stypes/src/lib.rs
@@ -114,7 +114,7 @@ pub use progress::*;
 
 pub(crate) use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub(crate) use std::{collections::HashMap, path::PathBuf};
-#[cfg(test)]
+#[cfg(all(test, feature = "test_and_gen"))]
 pub(crate) use ts_rs::TS;
 pub(crate) use uuid::Uuid;
 
@@ -126,7 +126,7 @@ pub(crate) use node_bindgen::{
 
 #[cfg(test)]
 pub(crate) use proptest::prelude::*;
-#[cfg(test)]
+#[cfg(all(test, feature = "test_and_gen"))]
 pub(crate) use tests::*;
 
 #[cfg(feature = "rustcore")]

--- a/application/apps/indexer/stypes/src/tests.rs
+++ b/application/apps/indexer/stypes/src/tests.rs
@@ -1,14 +1,18 @@
+#[cfg(feature = "test_and_gen")]
 use std::path::PathBuf;
 /// The number of test cases to generate for use in test scenarios.
+#[cfg(feature = "test_and_gen")]
 pub const TESTS_USECASE_COUNT: usize = 100;
 
 /// The name of the environment variable that specifies the path for storing test data.
 /// If this variable is not set, the default path will be used.
+#[cfg(feature = "test_and_gen")]
 pub const OUTPUT_PATH_ENVVAR: &str = "CHIPMUNK_PROTOCOL_TEST_OUTPUT";
 
 /// This function returns the path for writing test data (for testing in a different context).
 /// The function checks the value of the `CHIPMUNK_PROTOCOL_TEST_OUTPUT` environment variable.
 /// If the variable is defined, its value will be used as the path for writing test data.
+#[cfg(feature = "test_and_gen")]
 pub fn get_output_path() -> Result<PathBuf, String> {
     std::env::var(OUTPUT_PATH_ENVVAR)
         .map_err(|err| err.to_string())

--- a/application/apps/rustcore/rs-bindings/Cargo.lock
+++ b/application/apps/rustcore/rs-bindings/Cargo.lock
@@ -1838,6 +1838,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sources",
  "stypes",
  "thiserror 2.0.3",
  "tokio-util",

--- a/cli/chipmunk-cli/src/main.rs
+++ b/cli/chipmunk-cli/src/main.rs
@@ -1,3 +1,5 @@
+#![warn(unused_extern_crates)]
+
 use tokio::signal;
 use tokio_util::sync::CancellationToken;
 

--- a/cli/chipmunk-cli/src/session/format/binary.rs
+++ b/cli/chipmunk-cli/src/session/format/binary.rs
@@ -10,11 +10,10 @@ use super::MessageFormatter;
 pub struct MsgBinaryFormatter {}
 
 impl MessageFormatter for MsgBinaryFormatter {
-    fn write_msg(
-        &mut self,
-        mut writer: impl std::io::Write,
-        msg: impl LogMessage,
-    ) -> anyhow::Result<()> {
+    fn write_msg<M>(&mut self, mut writer: impl std::io::Write, msg: &M) -> anyhow::Result<()>
+    where
+        M: LogMessage,
+    {
         msg.to_writer(&mut writer)
             .context("Error while writing binary message")?;
         Ok(())

--- a/cli/chipmunk-cli/src/session/format/mod.rs
+++ b/cli/chipmunk-cli/src/session/format/mod.rs
@@ -9,9 +9,7 @@ pub mod text;
 /// the provided [`std::io::Write`].
 pub trait MessageFormatter {
     /// Format the message and then write it to the provided [`writer`]
-    fn write_msg(
-        &mut self,
-        writer: impl std::io::Write,
-        msg: impl LogMessage,
-    ) -> anyhow::Result<()>;
+    fn write_msg<M>(&mut self, writer: impl std::io::Write, msg: &M) -> anyhow::Result<()>
+    where
+        M: LogMessage;
 }

--- a/cli/chipmunk-cli/src/session/format/text.rs
+++ b/cli/chipmunk-cli/src/session/format/text.rs
@@ -71,11 +71,10 @@ impl MsgTextFormatter {
 impl MessageFormatter for MsgTextFormatter {
     /// Format the given message by running the original formatting in chipmunk and then
     /// replace the special separator from chipmunk with the configured ones in the CLI tool.
-    fn write_msg(
-        &mut self,
-        mut writer: impl std::io::Write,
-        msg: impl LogMessage,
-    ) -> anyhow::Result<()> {
+    fn write_msg<M>(&mut self, mut writer: impl std::io::Write, msg: &M) -> anyhow::Result<()>
+    where
+        M: LogMessage,
+    {
         self.origin_msg_buffer.clear();
         self.replaced_msg_buffer.clear();
 


### PR DESCRIPTION
This PR introduces the following changes:

### Producer:
* Parsed items will be saved in an internal buffer reusing the memory to avoid costly memory allocation calls especially with parsers returning multiple items at one.
* Change producer API removing the stream interface and making `load_next_segment()` function returns a mutable reference of the newly loaded items, giving the caller the freedom to consume the items with `drain(..)` or iterate over their references.
* Unused field `index` is removed.
* Cancel safety if `load_next_segment()` is described in the comments in code and tested manually.
* Unit tests has been adjusted for the new producer API, and they all pass without any change in their core functionality. 

### Parsers:
* Make all parsers try to parse all possible items from the provided bytes instead of returning the first item only. If the first call of parse fails, then the error will be returned, however any errors after having a successful parse call will be ignored in the current call because parse will be called again with more data. If the error persists on the next call, then it will be returned directly since it will occur on the first parse call.
* Unit tests for all parsers adjusted to ensure the count of the parsed items on each call + New tests has been added.

**Note**: The checks on TCP & UDP byte sources introduced in #2230 aren't needed anymore for the built-in parser. However, I kept them to support plugin parser that can parse one item at a time only.

### Fixes:
* Mock parser for benchmarks avoids allocating memory by using `iter::repeate_n()` instead.
* Chipmunk CLI: Add warning for external dependencies.

----

## Performance Changes:
The changes led to slightly increasing in performance in spite of the parser returning multiple values. This improvement is thanks to reusing the memory with the internal buffer in producer loop. Here is a comparison between master and current PR.
```md
# Chipmunk App: Parsing DLT file 500MB:

### Current PR:
File Read Took: 12058 ms
File Read Took: 11972 ms
File Read Took: 12103 ms

### Master: 
File Read Took: 12648 ms
File Read Took: 12639 ms
File Read Took: 12680 ms

--------------------------------------------------

# Chipmunk App: Parsing DLT With attachments 150MB:

### Current PR:
File Read Took: 3509 ms
File Read Took: 3461 ms
File Read Took: 3538 ms

### Master: 
File Read Took: 3518 ms
File Read Took: 3485 ms
File Read Took: 3507 ms

--------------------------------------------------

# Rust Core Benchmarks: Mock parser returning 10 values on each call:

### Current PR:
time:   [5.9618 ms 5.9758 ms 5.9899 ms]
time:   [5.9676 ms 5.9816 ms 5.9954 ms]

### Master: 
time:   [8.3135 ms 8.3412 ms 8.3692 ms]
time:   [8.2700 ms 8.2920 ms 8.3141 ms]
```    