### PR TITLE
TCP/UDP Sockets: Move flush to load method.

### DIFF
--- a/application/apps/indexer/sources/src/socket/mod.rs
+++ b/application/apps/indexer/sources/src/socket/mod.rs
@@ -1,3 +1,4 @@
+use bufread::DeqBuffer;
 use std::time::Duration;
 use tokio::sync::watch::Sender;
 
@@ -70,4 +71,35 @@ pub enum ReconnectStateMsg {
         attempts: usize,
         err_msg: Option<String>,
     },
+}
+
+/// Represents the capacity state of the buffer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BuffCapacityState {
+    /// Buffer can be loaded with more data.
+    CanLoad,
+    /// Buffer is almost full. Loading it may cause data loss.
+    AlmostFull,
+}
+
+/// Checks if the buffer can be loaded with more data, calling flush on it when necessary,
+/// and return the buffer capacity state.
+fn hanlde_buff_capacity(buffer: &mut DeqBuffer) -> BuffCapacityState {
+    // Check if buffer has enough capacity for the next load call.
+    if buffer.write_available() < MAX_DATAGRAM_SIZE {
+        // Capacity isn't enough -> Try flushing the buffer.
+        if buffer.flush() > 0 {
+            // Check buffer capacity again after flush
+            if buffer.write_available() < MAX_DATAGRAM_SIZE {
+                BuffCapacityState::AlmostFull
+            } else {
+                BuffCapacityState::CanLoad
+            }
+        } else {
+            // Flush didn't moved any bytes -> No capacity is freed up.
+            BuffCapacityState::AlmostFull
+        }
+    } else {
+        BuffCapacityState::CanLoad
+    }
 }

--- a/application/apps/indexer/sources/src/socket/tcp.rs
+++ b/application/apps/indexer/sources/src/socket/tcp.rs
@@ -4,7 +4,10 @@ use crate::{
 use bufread::DeqBuffer;
 use tokio::{net::TcpStream, task::yield_now};
 
-use super::{ReconnectInfo, ReconnectResult, ReconnectToServer, MAX_BUFF_SIZE, MAX_DATAGRAM_SIZE};
+use super::{
+    hanlde_buff_capacity, BuffCapacityState, ReconnectInfo, ReconnectResult, ReconnectToServer,
+    MAX_BUFF_SIZE, MAX_DATAGRAM_SIZE,
+};
 
 pub struct TcpSource {
     buffer: DeqBuffer,
@@ -93,9 +96,12 @@ impl ByteSource for TcpSource {
         // If buffer is almost full then skip loading and return the available bytes.
         // This can happen because some parsers will parse the first item of the provided slice
         // while the producer will call load on each iteration making data accumulate.
-        if self.buffer.write_available() < MAX_DATAGRAM_SIZE {
-            let available_bytes = self.len();
-            return Ok(Some(ReloadInfo::new(0, available_bytes, 0, None)));
+        match hanlde_buff_capacity(&mut self.buffer) {
+            BuffCapacityState::CanLoad => {}
+            BuffCapacityState::AlmostFull => {
+                let available_bytes = self.len();
+                return Ok(Some(ReloadInfo::new(0, available_bytes, 0, None)));
+            }
         }
 
         // TODO use filter
@@ -167,11 +173,6 @@ impl ByteSource for TcpSource {
 
     fn consume(&mut self, offset: usize) {
         self.buffer.read_done(offset);
-        // Calling read_done() won't make free up writable memory.
-        // Therefore we need to call flush manually.
-        if self.buffer.write_available() < MAX_DATAGRAM_SIZE {
-            self.buffer.flush();
-        }
     }
 
     fn len(&self) -> usize {

--- a/application/apps/indexer/sources/src/socket/udp.rs
+++ b/application/apps/indexer/sources/src/socket/udp.rs
@@ -5,7 +5,10 @@ use thiserror::Error;
 use tokio::net::{ToSocketAddrs, UdpSocket};
 
 use super::{MAX_BUFF_SIZE, MAX_DATAGRAM_SIZE};
-use crate::{ByteSource, Error as SourceError, ReloadInfo, SourceFilter};
+use crate::{
+    socket::{hanlde_buff_capacity, BuffCapacityState},
+    ByteSource, Error as SourceError, ReloadInfo, SourceFilter,
+};
 
 #[derive(Error, Debug)]
 pub enum UdpSourceError {
@@ -81,9 +84,12 @@ impl ByteSource for UdpSource {
         // If buffer is almost full then skip loading and return the available bytes.
         // This can happen because some parsers will parse the first item of the provided slice
         // while the producer will call load on each iteration making data accumulate.
-        if self.buffer.write_available() < MAX_DATAGRAM_SIZE {
-            let available_bytes = self.len();
-            return Ok(Some(ReloadInfo::new(0, available_bytes, 0, None)));
+        match hanlde_buff_capacity(&mut self.buffer) {
+            BuffCapacityState::CanLoad => {}
+            BuffCapacityState::AlmostFull => {
+                let available_bytes = self.len();
+                return Ok(Some(ReloadInfo::new(0, available_bytes, 0, None)));
+            }
         }
 
         // TODO use filter
@@ -118,11 +124,6 @@ impl ByteSource for UdpSource {
 
     fn consume(&mut self, offset: usize) {
         self.buffer.read_done(offset);
-        // Calling read_done() won't make free up writable memory.
-        // Therefore we need to call flush manually.
-        if self.buffer.write_available() < MAX_DATAGRAM_SIZE {
-            self.buffer.flush();
-        }
     }
 
     fn len(&self) -> usize {


### PR DESCRIPTION
Flushing the internal buffer on load is more reliable to avoid potential bugs when having an incomplete parser result on last packet before having the internal buffer almost filled.