### PR TITLE
Plugins: README from core & Reload in UI

### DIFF
--- a/application/apps/indexer/plugins_host/src/plugins_manager/load/mod.rs
+++ b/application/apps/indexer/plugins_host/src/plugins_manager/load/mod.rs
@@ -18,6 +18,8 @@ use crate::{
 
 use super::{InitError, PluginEntity};
 
+pub const PLUGIN_README_FILENAME: &str = "README.md";
+
 /// Loads all the plugins from the plugin directory
 ///
 /// # Returns:
@@ -173,6 +175,16 @@ async fn load_plugin(
             }
         }
     };
+
+    let readme = plug_dir.join(PLUGIN_README_FILENAME);
+    let readme_path = if readme.exists() {
+        rd.info("README file found");
+        Some(readme)
+    } else {
+        rd.warn("README file not found");
+        None
+    };
+
     rd.info("Plugin has been load, checked and accepted");
     Ok(PluginEntityState::Valid(ExtendedPluginEntity::new(
         PluginEntity {
@@ -180,6 +192,7 @@ async fn load_plugin(
             plugin_type: plug_type,
             info: plug_info,
             metadata: plug_metadata,
+            readme_path,
         },
         rd,
     )))

--- a/application/apps/indexer/plugins_host/src/plugins_manager/tests.rs
+++ b/application/apps/indexer/plugins_host/src/plugins_manager/tests.rs
@@ -8,6 +8,8 @@ const PARSER_PATH_1: &str = "parser_1";
 const PARSER_PATH_2: &str = "parser_2";
 const SOURCE_PATH_1: &str = "source_1";
 const SOURCE_PATH_2: &str = "source_2";
+const PARSER_README_PATH: &str = "parser_1/README.md";
+const SOURCE_README_PATH: &str = "source_1/README.md";
 
 const INV_PARSER_PATH: &str = "inv_parse";
 const INV_SOURCE_PATH: &str = "inv_soruce";
@@ -31,6 +33,7 @@ fn create_manager() -> PluginsManager {
                 name: "parser_1".into(),
                 description: None,
             },
+            readme_path: Some(PARSER_README_PATH.into()),
         }
         .into(),
         PluginEntity {
@@ -49,6 +52,7 @@ fn create_manager() -> PluginsManager {
                 name: "parser_2".into(),
                 description: None,
             },
+            readme_path: None,
         }
         .into(),
         PluginEntity {
@@ -65,6 +69,7 @@ fn create_manager() -> PluginsManager {
                 name: "source_1".into(),
                 description: None,
             },
+            readme_path: Some(SOURCE_README_PATH.into()),
         }
         .into(),
         PluginEntity {
@@ -81,6 +86,7 @@ fn create_manager() -> PluginsManager {
                 name: "source_2".into(),
                 description: None,
             },
+            readme_path: None,
         }
         .into(),
     ];
@@ -113,8 +119,16 @@ fn test_installed_api() {
     let installed: Vec<&PluginEntity> = manager.installed_plugins().collect();
     assert_eq!(installed.len(), 4);
     assert_eq!(installed[0].dir_path, PathBuf::from(PARSER_PATH_1));
+    assert_eq!(
+        installed[0].readme_path,
+        Some(PathBuf::from(PARSER_README_PATH))
+    );
     assert_eq!(installed[1].dir_path, PathBuf::from(PARSER_PATH_2));
     assert_eq!(installed[2].dir_path, PathBuf::from(SOURCE_PATH_1));
+    assert_eq!(
+        installed[2].readme_path,
+        Some(PathBuf::from(SOURCE_README_PATH))
+    );
     assert_eq!(installed[3].dir_path, PathBuf::from(SOURCE_PATH_2));
 
     let mut paths = manager.installed_plugins_paths();
@@ -127,7 +141,11 @@ fn test_installed_api() {
     let parser_1 = manager
         .get_installed_plugin(&PathBuf::from(PARSER_PATH_1))
         .unwrap();
-    assert_eq!(parser_1.dir_path, PathBuf::from(PARSER_PATH_1))
+    assert_eq!(parser_1.dir_path, PathBuf::from(PARSER_PATH_1));
+    assert_eq!(
+        parser_1.readme_path,
+        Some(PathBuf::from(PARSER_README_PATH))
+    );
 }
 
 #[test]

--- a/application/apps/indexer/stypes/bindings/plugins.ts
+++ b/application/apps/indexer/stypes/bindings/plugins.ts
@@ -144,6 +144,10 @@ export type PluginEntity = {
      * Currently they are saved inside plugin `*.toml` file.
      */
     metadata: PluginMetadata;
+    /**
+     * Path of the readme file for the plugin to be rendered on the front-end
+     */
+    readme_path: string | null;
 };
 
 /**
@@ -173,7 +177,7 @@ export type PluginLogMessage = {
     /**
      * The timestamp of when the log message was generated, represented as a Unix timestamp.
      */
-    tm: bigint;
+    timestamp: bigint;
     /**
      * The actual content of the log message.
      */

--- a/application/apps/indexer/stypes/src/plugins/mod.rs
+++ b/application/apps/indexer/stypes/src/plugins/mod.rs
@@ -160,6 +160,8 @@ pub struct PluginEntity {
     /// Provides Plugins Metadata from separate source than the plugin binary.
     /// Currently they are saved inside plugin `*.toml` file.
     pub metadata: PluginMetadata,
+    /// Path of the readme file for the plugin to be rendered on the front-end
+    pub readme_path: Option<PathBuf>,
 }
 
 /// Represents different levels of logging severity for a plugin.

--- a/application/apps/indexer/stypes/src/plugins/proptest.rs
+++ b/application/apps/indexer/stypes/src/plugins/proptest.rs
@@ -171,13 +171,17 @@ impl Arbitrary for PluginEntity {
             any::<PluginType>(),
             any::<PluginInfo>(),
             any::<PluginMetadata>(),
+            prop::option::of(any::<PathBuf>()),
         )
-            .prop_map(|(dir_path, plugin_type, info, metadata)| Self {
-                dir_path,
-                plugin_type,
-                info,
-                metadata,
-            })
+            .prop_map(
+                |(dir_path, plugin_type, info, metadata, readme_path)| Self {
+                    dir_path,
+                    plugin_type,
+                    info,
+                    metadata,
+                    readme_path,
+                },
+            )
             .boxed()
     }
 }

--- a/application/client/src/app/ui/tabs/plugins/component.ts
+++ b/application/client/src/app/ui/tabs/plugins/component.ts
@@ -39,8 +39,8 @@ export class PluginsManager extends ChangesDetector implements AfterContentInit,
         this.provider.load();
     }
 
-    public reload() {
-        this.provider.load();
+    public async reload() {
+        await this.provider.load(true);
     }
 }
 

--- a/application/client/src/app/ui/tabs/plugins/desc.ts
+++ b/application/client/src/app/ui/tabs/plugins/desc.ts
@@ -7,15 +7,18 @@ export abstract class PluginDescription {
     public desc: string = '';
     public icon: string = '';
     public path: ParsedPath | undefined;
+    public readmePath: string | undefined;
 
     protected abstract getName(): string;
     protected abstract getDesc(): string;
     protected abstract getIcon(): string;
+    protected abstract getReadmePath(): string | undefined;
 
     protected update() {
         this.icon = this.getIcon();
         this.name = this.getName();
         this.desc = this.getDesc();
+        this.readmePath = this.getReadmePath();
     }
 
     public abstract getPath(): string;
@@ -69,6 +72,9 @@ export class InstalledPluginDesc extends PluginDescription {
     public override getPath(): string {
         return this.entity.dir_path;
     }
+    public override getReadmePath(): string | undefined {
+        return this.entity.readme_path ?? undefined;
+    }
     public override isValid(): boolean {
         return true;
     }
@@ -102,6 +108,9 @@ export class InvalidPluginDesc extends PluginDescription {
     }
     public override getPath(): string {
         return this.entity.dir_path;
+    }
+    public override getReadmePath(): string | undefined {
+        return undefined;
     }
     public override isValid(): boolean {
         return false;

--- a/application/platform/types/bindings/plugins.ts
+++ b/application/platform/types/bindings/plugins.ts
@@ -144,6 +144,10 @@ export type PluginEntity = {
      * Currently they are saved inside plugin `*.toml` file.
      */
     metadata: PluginMetadata;
+    /**
+     * Path of the readme file for the plugin to be rendered on the front-end
+     */
+    readme_path: string | null;
 };
 
 /**
@@ -173,7 +177,7 @@ export type PluginLogMessage = {
     /**
      * The timestamp of when the log message was generated, represented as a Unix timestamp.
      */
-    tm: bigint;
+    timestamp: bigint;
     /**
      * The actual content of the log message.
      */

--- a/plugins/examples/dlt_parser/README.md
+++ b/plugins/examples/dlt_parser/README.md
@@ -1,0 +1,15 @@
+# DLT Parser Plugin.
+
+This is an example for parser plugins accepting raw bytes in DLT format and parsing them returning the messages alongside with the attachments when exist.
+
+## Usage:
+
+After installing the parser in Chipmunk, you can use this parser with the all available byte sources: DLT files or TCP/UDP streams.
+
+## Configurations:
+
+This plugin needs the following 
+- **With strage header**: Set if the coming DLT messages have storage headers. Normally only messages stored in files contains storage headers.
+- **Log Level**: Determine the minimum log level for messages (Default to Verbose)
+- **Fibex files**: Provided needed FIBEX files for the session.
+


### PR DESCRIPTION
This PR closes #2247 

It provides the following:

* Provide the path of readme file from rust core instead from UI.
* Basic implementation for reload functionality on front end.
* Complete rename 'ts' to 'timestamp' in front end.
* Basic readme file for DLT parser plugin