### PR TITLE
Plugins: Documentation for `plugins_api` crate

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -23,7 +23,7 @@ This guide provides an overview of how to develop plugins for Chipmunk applicati
 
 ## Overview
 
-Chipmunk supports plugins built as WebAssembly components. The plugins system uses [WIT](https://component-model.bytecodealliance.org/design/wit.html) files to define plugin types and the API, allowing developers to write plugins in any language that supports the WASM component model.
+Chipmunk supports plugins built as WebAssembly components. The plugins system uses [WASM Interface Format (WIT)](https://component-model.bytecodealliance.org/design/wit.html) files to define plugin types and the API, allowing developers to write plugins in any language that supports the WASM component model.
 
 ---
 
@@ -118,7 +118,7 @@ Chipmunk currently supports two main types of plugins:
 Parser plugins receive an array of bytes, attempt to parse them, and return the parsed items. They can also define configuration schemas and specify rendering options if needed.
 
 **Development in Rust:**  
-- Implement a struct that adheres to the `Parser` trait defined in the [`plugins-api`](./plugins_api/) crate.
+- Create a struct that implements to the `Parser` trait defined in the [`plugins-api`](./plugins_api/) crate.
 - Use the `parser_export!()` macro to export your parser struct.
 
 The [`plugins-api`](./plugins_api/) crate also offers helper functions for logging and configuration management.
@@ -137,7 +137,7 @@ For reference, see the `string_parser` and `dlt_parser` examples.
 Byte-source plugins deliver arrays of bytes of a specified length during each load call. These bytes are then processed by a selected parser. Like parser plugins, they can define configuration schemas that are provided during session initialization.
 
 **Development in Rust:**  
-- Implement a struct that adheres to the `ByteSource` trait defined in the [`plugins-api`](./plugins_api/) crate.
+- Create a struct that implements to the `ByteSource` trait defined in the [`plugins-api`](./plugins_api/) crate.
 - Use the `bytesource_export!()` macro to export your byte-source struct.
 
 The [`plugins-api`](./plugins_api/) crate again provides helper functions for logging and configuration management.

--- a/plugins/plugins_api/README.md
+++ b/plugins/plugins_api/README.md
@@ -1,0 +1,38 @@
+<!--TODO AAZ: Update links once merged into master by removing `plugins_support`-->
+# Chipmunk Plugins API Crate
+
+This crate simplifies the development of plugins for [Chipmunk](https://github.com/esrlabs/chipmunk) in Rust.  
+
+Chipmunk supports plugins using [WebAssembly (Wasm)](https://webassembly.org/) and the [WebAssembly Component Model](https://component-model.bytecodealliance.org/). It exposes its public API via the [WASM Interface Format (WIT)](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md), enabling developers to write plugins in any language that supports Wasm and the Component Model.
+
+For a detailed guide on developing plugins, refer to the [Plugins Development Guide](https://github.com/esrlabs/chipmunk/blob/plugins_support/plugins/README.md).
+
+## What This Crate Provides
+
+This crate provides utilities to streamline plugin development in Rust by:
+
+- Generating Rust types for `WIT` definitions.
+- Defining traits that plugins must implement based on their type.
+- Providing helper functions for logging and configuration extraction to reduce boilerplate.
+- Offering export macros to generate the necessary bindings for your structs to function as Chipmunk plugins.
+
+## Plugin Types:
+
+Each plugin type is associated with a feature in this crate. A feature must be enabled when adding this crate as a dependency, or the build will fail.
+
+### Parser Plugins:
+* To develop a parser plugin, enable the `parser` feature in `Cargo.toml`.
+* Implement `Parser` trait on your struct to define a parser plugin.
+* Use `parser_export!()` macro with your struct to generate the necessary bindings for integration with Chipmunk.
+* Please refer to the [examples](https://github.com/esrlabs/chipmunk/blob/plugins_support/plugins/examples) and [parser template](https://github.com/esrlabs/chipmunk/blob/plugins_support/plugins/templates/parser_template) provided in Chipmunk repo to get started.
+
+
+### Byte-Source Plugins:
+
+> **NOTE:** Byte-Source plugins are not yet supported in Chipmunk. 
+
+* To develop a byte-source plugin, enable the `bytesource` feature in `Cargo.toml`.
+* Implement `ByteSource` trait on your struct to define a byte-source plugin.
+* Use `bytesource_export!()` macro with your struct to generate the necessary bindings for integration with Chipmunk.
+<!--TODO: Update here once template for byte-source is done. -->
+* Please refer to the [examples](https://github.com/esrlabs/chipmunk/blob/plugins_support/plugins/examples) provided in Chipmunk repo to get started.

--- a/plugins/plugins_api/src/lib.rs
+++ b/plugins/plugins_api/src/lib.rs
@@ -4,14 +4,8 @@
 // conditional compilation detail in the docs, even it would require to specify the cfg_attr on
 // every conditional public module.
 #![cfg_attr(docsrs, feature(doc_cfg))]
-
-//! This library provides types, functions and macros to write plugins for [Chipmunk](https://github.com/esrlabs/chipmunk).
-//!
-//! The provided types and functions match the definitions from the `WIT` files defined in Chipmunk
-//! repository.
-//!
-//! TODO AAZ: This is basic documentation that need a lot of improvements and examples
-//!
+// Use the readme as the main documentation page.
+#![doc = include_str!("../README.md")]
 
 mod shared;
 pub use shared::{

--- a/plugins/plugins_api/src/shared/config.rs
+++ b/plugins/plugins_api/src/shared/config.rs
@@ -5,16 +5,16 @@ use crate::shared_types::{ConfigItem, ConfigValue, InitError};
 /// Macro to generate getter functions for [`ConfigValue`] types, returning an owned value.
 macro_rules! generate_get_config_function_owned {
     ($fn: ident, $typ:ty, $conf_typ:path) => {
-        /// Provides the corresponding value with the given [`config_id`] from the given
-        /// [`plugins_configs`]
+        /// Provides the corresponding value with the given `config_id` from the given
+        /// `plugins_configs`
         ///
         /// # Arguments:
         /// * `config_id`: The ID of the configuration items.
         /// * `plugins_configs`: All the provided configuration items.
         ///
         /// # Returns:
-        /// This function returns the corresponding config value if the the provided [`config_id`]
-        /// exists in the provided [`plugins_configs`] and have a matching value type.
+        /// This function returns the corresponding config value if the the provided `config_id`
+        /// exists in the provided `plugins_configs` and have a matching value type.
         /// Otherwise it will return an [`InitError::Config`] with the matching error message.
         pub fn $fn(config_id: &str, plugins_configs: &[ConfigItem]) -> Result<$typ, InitError> {
             let prefix_config_item = plugins_configs
@@ -41,16 +41,16 @@ macro_rules! generate_get_config_function_owned {
 /// Macro to generate getter functions for [`ConfigValue`] types, returning a borrowed value.
 macro_rules! generate_get_config_function_borrow {
     ($fn: ident, $typ:ty, $conf_typ:path) => {
-        /// Provides the corresponding value with the given [`config_id`] from the given
-        /// [`plugins_configs`]
+        /// Provides the corresponding value with the given `config_id` from the given
+        /// `plugins_configs`
         ///
         /// # Arguments:
         /// * `config_id`: The ID of the configuration items.
         /// * `plugins_configs`: All the provided configuration items.
         ///
         /// # Returns:
-        /// This function returns the corresponding config value if the the provided [`config_id`]
-        /// exists in the provided [`plugins_configs`] and have a matching value type.
+        /// This function returns the corresponding config value if the the provided `config_id`
+        /// exists in the provided `plugins_configs` and have a matching value type.
         /// Otherwise it will return an [`InitError::Config`] with the matching error message.
         pub fn $fn<'a>(config_id: &str, plugins_configs: &'a [ConfigItem]) -> Result<&'a $typ, InitError> {
             let prefix_config_item = plugins_configs


### PR DESCRIPTION
This PR checks one task from #2222, providing documentation for `plugins_api` crate.

It includes:
* Provide README file for plugins_api crate and use it as the main page for `cargo docs`
* Small fixes to documentation comments in code, removing warning when `cargo doc` is run.