### PR TITLE
TCP: Reconnect with Cancel-Safety & Use `keepalive` + Chipmunk CLI

### DIFF
--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -2702,6 +2702,7 @@ dependencies = [
  "regex",
  "serde",
  "shellexpand",
+ "socket2",
  "stypes",
  "thiserror 2.0.11",
  "tikv-jemallocator",

--- a/application/apps/indexer/session/src/handlers/observing/stream.rs
+++ b/application/apps/indexer/session/src/handlers/observing/stream.rs
@@ -40,7 +40,7 @@ pub async fn observe_stream(
             .await
         }
         stypes::Transport::TCP(settings) => {
-            let tcp_source = TcpSource::new(settings.bind_addr.clone(), None)
+            let tcp_source = TcpSource::new(&settings.bind_addr, None, None)
                 .await
                 .map_err(|e| stypes::NativeError {
                     severity: stypes::Severity::ERROR,

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -25,6 +25,7 @@ regex.workspace = true
 lazy_static.workspace = true
 shellexpand = "3.1"
 stypes = { path = "../stypes", features=["rustcore"] }
+socket2 = "0.5.8"
 
 [dev-dependencies]
 env_logger.workspace = true

--- a/application/apps/indexer/sources/src/socket/mod.rs
+++ b/application/apps/indexer/sources/src/socket/mod.rs
@@ -1,6 +1,4 @@
 use bufread::DeqBuffer;
-use std::time::Duration;
-use tokio::sync::watch::Sender;
 
 pub mod tcp;
 pub mod udp;
@@ -10,68 +8,6 @@ const MAX_DATAGRAM_SIZE: usize = 65_507;
 
 /// Maximum capacity for the buffer of socket byte-sources.
 const MAX_BUFF_SIZE: usize = 1024 * 1024;
-
-/// Defines methods on sockets to make them able to reconnect to server in case the
-/// connection is lost.
-trait ReconnectToServer {
-    /// Tries to reconnect to the server when [`ReconnectInfo`] are defined.
-    async fn reconnect(&mut self) -> ReconnectResult;
-}
-
-#[derive(Debug, Clone)]
-/// Represents the needed infos to reconnect to the server once the connection is lost.
-pub struct ReconnectInfo {
-    /// Maximum number of attempts to reconnect to the server.
-    max_attempts: usize,
-    /// The time interval between each try to connect to server.
-    interval: Duration,
-    /// Channel to send information of the state of reconnecting progress.
-    state_sender: Option<Sender<ReconnectStateMsg>>,
-}
-
-impl ReconnectInfo {
-    pub fn new(
-        max_attempts: usize,
-        interval: Duration,
-        state_sender: Option<Sender<ReconnectStateMsg>>,
-    ) -> Self {
-        Self {
-            max_attempts,
-            interval,
-            state_sender,
-        }
-    }
-}
-
-impl Default for ReconnectInfo {
-    fn default() -> Self {
-        Self::new(usize::MAX, Duration::from_secs(5), None)
-    }
-}
-
-#[derive(Debug)]
-/// Represent the return result of reconnect function.
-enum ReconnectResult {
-    /// Reconnection to server successful.
-    Reconnected,
-    /// Reconnect isn't configured on socket.
-    NotConfigured,
-    /// Error while reconnecting.
-    Error(std::io::Error),
-}
-
-#[derive(Debug, Clone)]
-/// Represent the information of the state of the reconnection progress.
-pub enum ReconnectStateMsg {
-    Connected,
-    Reconnecting {
-        attempts: usize,
-    },
-    Failed {
-        attempts: usize,
-        err_msg: Option<String>,
-    },
-}
 
 /// Represents the capacity state of the buffer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/application/apps/indexer/sources/src/socket/tcp.rs
+++ b/application/apps/indexer/sources/src/socket/tcp.rs
@@ -1,90 +1,70 @@
-use crate::{
-    socket::ReconnectStateMsg, ByteSource, Error as SourceError, ReloadInfo, SourceFilter,
-};
-use bufread::DeqBuffer;
-use tokio::{net::TcpStream, task::yield_now};
+use std::{net::SocketAddr, time::Duration};
 
-use super::{
-    handle_buff_capacity, BuffCapacityState, ReconnectInfo, ReconnectResult, ReconnectToServer,
-    MAX_BUFF_SIZE, MAX_DATAGRAM_SIZE,
-};
+use crate::{ByteSource, Error as SourceError, ReloadInfo, SourceFilter};
+use bufread::DeqBuffer;
+use reconnect::{ReconnectInfo, ReconnectResult, TcpReconnecter};
+use socket2::{SockRef, TcpKeepalive};
+use tokio::net::TcpStream;
+
+use super::{handle_buff_capacity, BuffCapacityState, MAX_BUFF_SIZE, MAX_DATAGRAM_SIZE};
+
+pub mod reconnect;
+
+/// Configurations for keep-alive probes in TCP communication.
+#[derive(Debug, Clone)]
+pub struct KeepAliveConfig {
+    /// Set the amount of time after which TCP keep-alive probes will be sent on
+    /// idle connections.
+    time: Duration,
+    /// Sets the time interval between TCP keep-alive probes.
+    interval: Duration,
+}
+
+impl KeepAliveConfig {
+    pub fn new(time: Duration, interval: Duration) -> Self {
+        Self { time, interval }
+    }
+}
 
 pub struct TcpSource {
     buffer: DeqBuffer,
     socket: TcpStream,
     tmp_buffer: Vec<u8>,
-    binding_address: String,
-    reconnect_info: Option<ReconnectInfo>,
+    reconnecter: Option<TcpReconnecter>,
 }
 
 impl TcpSource {
-    pub async fn new<A: Into<String>>(
-        addr: A,
+    pub async fn new(
+        addr: &str,
+        keepalive: Option<KeepAliveConfig>,
         reconnect_info: Option<ReconnectInfo>,
     ) -> Result<Self, std::io::Error> {
-        let binding_address: String = addr.into();
+        let binding_address = addr.parse().map_err(std::io::Error::other)?;
+        let socket = Self::create_socket(binding_address, keepalive.as_ref()).await?;
+        let reconnecter =
+            reconnect_info.map(|rec| TcpReconnecter::new(rec, binding_address, keepalive));
         Ok(Self {
             buffer: DeqBuffer::new(MAX_BUFF_SIZE),
-            socket: TcpStream::connect(&binding_address).await?,
+            socket,
             tmp_buffer: vec![0u8; MAX_DATAGRAM_SIZE],
-            binding_address,
-            reconnect_info,
+            reconnecter,
         })
     }
-}
 
-impl ReconnectToServer for TcpSource {
-    async fn reconnect(&mut self) -> ReconnectResult {
-        let Some(reconnect_info) = self.reconnect_info.as_ref() else {
-            log::debug!("No reconnect info provided. Skipping reconnecting");
-            return ReconnectResult::NotConfigured;
-        };
-
-        if let Some(sender) = &reconnect_info.state_sender {
-            sender.send_replace(ReconnectStateMsg::Reconnecting { attempts: 0 });
-            // Give receivers a chance to get the initial reconnecting state before sending
-            // the first attempt update.
-            yield_now().await;
+    async fn create_socket(
+        binding_address: SocketAddr,
+        keep_alive: Option<&KeepAliveConfig>,
+    ) -> std::io::Result<TcpStream> {
+        let socket = TcpStream::connect(binding_address).await?;
+        if let Some(keepalive_config) = keep_alive {
+            let socket_ref = SockRef::from(&socket);
+            let keepalive = TcpKeepalive::new()
+                .with_time(keepalive_config.time)
+                .with_interval(keepalive_config.interval);
+            socket_ref.set_tcp_keepalive(&keepalive)?;
         }
 
-        let mut attempts = 0;
-        loop {
-            attempts += 1;
-            if let Some(sender) = &reconnect_info.state_sender {
-                sender.send_replace(ReconnectStateMsg::Reconnecting { attempts });
-            }
-            log::info!("Reconnecting to TCP server. Attempt: {attempts}");
-            tokio::time::sleep(reconnect_info.interval).await;
-
-            match TcpStream::connect(&self.binding_address).await {
-                Ok(socket) => {
-                    self.socket = socket;
-
-                    if let Some(sender) = &reconnect_info.state_sender {
-                        if let Err(err) = sender.send(ReconnectStateMsg::Connected) {
-                            log::error!("Failed to send connected state with err: {err}");
-                        }
-                    }
-                    return ReconnectResult::Reconnected;
-                }
-                Err(err) => {
-                    log::debug!("Got following error while trying to reconnect: {err}");
-                    if attempts >= reconnect_info.max_attempts {
-                        if let Some(sender) = &reconnect_info.state_sender {
-                            sender.send_replace(ReconnectStateMsg::Failed {
-                                attempts,
-                                err_msg: Some(err.to_string()),
-                            });
-                            // Make sure the message has been sent before returning.
-                            yield_now().await;
-                        }
-                        log::warn!("Reconnecting to TCP server failed after {attempts} attemps.");
-
-                        return ReconnectResult::Error(err);
-                    }
-                }
-            }
-        }
+        Ok(socket)
     }
 }
 
@@ -106,6 +86,25 @@ impl ByteSource for TcpSource {
 
         // TODO use filter
         loop {
+            if let Some(reconnecter) = self.reconnecter.as_mut() {
+                if let Some(handle) = reconnecter.task_handle.as_mut() {
+                    match handle.await {
+                        Ok(ReconnectResult::Reconnected(socket)) => self.socket = socket,
+                        Ok(ReconnectResult::Error(err)) => {
+                            return Err(SourceError::Unrecoverable(format!(
+                                "Reconnect to TCP failed. Error: {err}"
+                            )))
+                        }
+                        Err(err) => {
+                            return Err(SourceError::Unrecoverable(format!(
+                                "Reconnect to TCP task panicked. Error: {err}"
+                            )))
+                        }
+                    }
+                    reconnecter.task_handle = None;
+                }
+            }
+
             debug!("Wait for tcp socket to become readable");
             self.socket
                 .readable()
@@ -118,13 +117,14 @@ impl ByteSource for TcpSource {
                     if len == 0 {
                         // No data were received -> Server may be temporally down
                         // then try to reconnect.
-                        match self.reconnect().await {
-                            ReconnectResult::Reconnected => continue,
-                            ReconnectResult::NotConfigured => {}
-                            ReconnectResult::Error(error) => {
-                                return Err(SourceError::Unrecoverable(error.to_string()));
-                            }
-                        };
+                        if let Some(rec) = self.reconnecter.as_mut() {
+                            rec.spawn_reconnect();
+                            continue;
+                        } else {
+                            let available_bytes = self.buffer.read_available();
+
+                            return Ok(Some(ReloadInfo::new(0, available_bytes, 0, None)));
+                        }
                     }
                     let added = self.buffer.write_from(&self.tmp_buffer[..len]);
                     if added < len {
@@ -142,29 +142,17 @@ impl ByteSource for TcpSource {
                 }
                 Err(e) => {
                     // Server may be temporally down -> Try to reconnect.
-                    match self.reconnect().await {
-                        ReconnectResult::Reconnected => {
-                            continue;
-                        }
-                        ReconnectResult::NotConfigured => {
-                            // Continue with the original error.
-                            return Err(SourceError::Setup(format!("{e}")));
-                        }
-                        ReconnectResult::Error(err) => {
-                            // return both errors.
-                            return Err(SourceError::Setup(format!(
-                                " Reconnection failed with error: {e}.\
-                                \nAfter recieving original error: {err}"
-                            )));
-                        }
-                    };
+                    if let Some(rec) = self.reconnecter.as_mut() {
+                        rec.spawn_reconnect();
+                        continue;
+                    } else {
+                        return Err(SourceError::Setup(format!(
+                            " Reconnection failed with error: {e}"
+                        )));
+                    }
                 }
             }
         }
-        // let len = self
-        //     .socket
-        //     .try_read(&mut self.tmp_buffer)
-        //     .map_err(|e| SourceError::Setup(format!("{}", e)))?;
     }
 
     fn current_slice(&self) -> &[u8] {
@@ -185,8 +173,14 @@ mod tests {
     use super::*;
 
     use crate::tests::general_source_reload_test;
+    use reconnect::ReconnectStateMsg;
     use std::time::Duration;
-    use tokio::{io::AsyncWriteExt, net::TcpListener, time::sleep};
+    use tokio::{
+        io::AsyncWriteExt,
+        net::TcpListener,
+        task::yield_now,
+        time::{sleep, timeout},
+    };
 
     static MESSAGES: &[&str] = &["one", "two", "three"];
 
@@ -208,7 +202,7 @@ mod tests {
                 sleep(Duration::from_millis(100)).await;
             }
         });
-        let mut tcp_source = TcpSource::new(SERVER, None).await?;
+        let mut tcp_source = TcpSource::new(SERVER, None, None).await?;
         let receive_handle = tokio::spawn(async move {
             for msg in MESSAGES {
                 tcp_source.load(None).await.expect("reload failed");
@@ -246,7 +240,7 @@ mod tests {
                 sleep(Duration::from_millis(100)).await;
             }
         });
-        let mut tcp_source = TcpSource::new(SERVER, None).await.unwrap();
+        let mut tcp_source = TcpSource::new(SERVER, None, None).await.unwrap();
 
         general_source_reload_test(&mut tcp_source).await;
     }
@@ -276,7 +270,7 @@ mod tests {
             }
         });
 
-        let mut tcp_source = TcpSource::new(SERVER, None).await.unwrap();
+        let mut tcp_source = TcpSource::new(SERVER, None, None).await.unwrap();
 
         while let Ok(Some(info)) = tcp_source.load(None).await {
             if info.available_bytes == 0 {
@@ -284,5 +278,370 @@ mod tests {
             }
             tcp_source.consume(info.available_bytes.min(CONSUME_LEN));
         }
+    }
+
+    #[tokio::test]
+    async fn reconnect_no_msgs() {
+        static SERVER: &str = "127.0.0.1:4003";
+        let listener = TcpListener::bind(&SERVER).await.unwrap();
+        let send_handle = tokio::spawn(async move {
+            // Run server sending data for first time.
+            let (stream, _) = listener.accept().await.unwrap();
+            let (_, mut send) = tokio::io::split(stream);
+            for msg in MESSAGES {
+                send.write_all(msg.as_bytes())
+                    .await
+                    .expect("could not send on socket");
+                send.flush().await.expect("flush message should work");
+                sleep(Duration::from_millis(30)).await;
+            }
+
+            // Then disconnected the server and sleep.
+            drop(send);
+            drop(listener);
+            sleep(Duration::from_millis(150)).await;
+
+            // Start new server sending data again.
+            let listener = TcpListener::bind(&SERVER).await.unwrap();
+            let (stream, _) = listener.accept().await.unwrap();
+            let (_, mut send) = tokio::io::split(stream);
+            for msg in MESSAGES {
+                send.write_all(msg.as_bytes())
+                    .await
+                    .expect("could not send on socket");
+                send.flush().await.expect("flush message should work");
+                sleep(Duration::from_millis(30)).await;
+            }
+        });
+
+        // Enable reconnect without configuring state channels.
+        let rec_info = ReconnectInfo::new(1000, Duration::from_millis(20), None);
+
+        let mut tcp_source = TcpSource::new(SERVER, None, Some(rec_info)).await.unwrap();
+        let receive_handle = tokio::spawn(async move {
+            // Byte source must receive same data twice without errors with active reconnect
+            for _ in 0..2 {
+                for msg in MESSAGES {
+                    tcp_source.load(None).await.expect("reload failed");
+                    println!(
+                        "receive: {:02X?}",
+                        std::str::from_utf8(tcp_source.current_slice())
+                    );
+                    assert_eq!(tcp_source.current_slice(), msg.as_bytes());
+                    tcp_source.consume(msg.len());
+                }
+            }
+        });
+
+        let (_, rec_res) = tokio::join!(send_handle, receive_handle);
+
+        assert!(rec_res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn reconnect_with_state_msgs() {
+        static SERVER: &str = "127.0.0.1:4004";
+        let listener = TcpListener::bind(&SERVER).await.unwrap();
+        let send_handle = tokio::spawn(async move {
+            // Run server sending data for first time.
+            let (stream, _) = listener.accept().await.unwrap();
+            let (_, mut send) = tokio::io::split(stream);
+            for msg in MESSAGES {
+                send.write_all(msg.as_bytes())
+                    .await
+                    .expect("could not send on socket");
+                send.flush().await.expect("flush message should work");
+                sleep(Duration::from_millis(30)).await;
+            }
+
+            // Then disconnected the server and sleep.
+            drop(send);
+            drop(listener);
+            sleep(Duration::from_millis(160)).await;
+
+            // Start new server sending data again.
+            let listener = TcpListener::bind(&SERVER).await.unwrap();
+            let (stream, _) = listener.accept().await.unwrap();
+            let (_, mut send) = tokio::io::split(stream);
+            for msg in MESSAGES {
+                send.write_all(msg.as_bytes())
+                    .await
+                    .expect("could not send on socket");
+                send.flush().await.expect("flush message should work");
+                sleep(Duration::from_millis(30)).await;
+            }
+        });
+
+        // Enable reconnect with state channels.
+        let (state_tx, mut state_rx) = tokio::sync::watch::channel(ReconnectStateMsg::Connected);
+
+        let rec_info = ReconnectInfo::new(1000, Duration::from_millis(50), Some(state_tx));
+
+        let mut tcp_source = TcpSource::new(SERVER, None, Some(rec_info)).await.unwrap();
+
+        // Tests reconnecting state messages.
+        let reconnect_handler = tokio::spawn(async move {
+            let mut attempts = 0;
+            loop {
+                state_rx.changed().await.unwrap();
+                match *state_rx.borrow_and_update() {
+                    ReconnectStateMsg::Connected => break,
+                    ReconnectStateMsg::Reconnecting { attempts: atts } => attempts = atts,
+                    ReconnectStateMsg::Failed {
+                        attempts,
+                        ref err_msg,
+                    } => {
+                        panic!(
+                            "Reconnect failed. attempts: {attempts}, Error: {}",
+                            err_msg.to_owned().unwrap_or_default()
+                        )
+                    }
+                };
+            }
+
+            // In 160 Milliseconds Down time and reconnect interval of 50 Milliseconds
+            // we must get 5 reconnect attempts.
+            assert_eq!(attempts, 5);
+        });
+
+        let receive_handle = tokio::spawn(async move {
+            // Byte source must receive same data twice without errors with active reconnect
+            for _ in 0..2 {
+                for msg in MESSAGES {
+                    tcp_source.load(None).await.expect("reload failed");
+                    println!(
+                        "receive: {:02X?}",
+                        std::str::from_utf8(tcp_source.current_slice())
+                    );
+                    assert_eq!(tcp_source.current_slice(), msg.as_bytes());
+                    tcp_source.consume(msg.len());
+                }
+            }
+        });
+
+        let (_, rec_res, reconnect_res) =
+            tokio::join!(send_handle, receive_handle, reconnect_handler);
+
+        assert!(rec_res.is_ok());
+        assert!(reconnect_res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn reconnect_fail() {
+        static SERVER: &str = "127.0.0.1:4005";
+        let listener = TcpListener::bind(&SERVER).await.unwrap();
+        let send_handle = tokio::spawn(async move {
+            // Run server sending some data then stop.
+            let (stream, _) = listener.accept().await.unwrap();
+            let (_, mut send) = tokio::io::split(stream);
+            for msg in MESSAGES {
+                send.write_all(msg.as_bytes())
+                    .await
+                    .expect("could not send on socket");
+                send.flush().await.expect("flush message should work");
+                sleep(Duration::from_millis(30)).await;
+            }
+        });
+
+        // Enable reconnect with state channels.
+        let (state_tx, mut state_rx) = tokio::sync::watch::channel(ReconnectStateMsg::Connected);
+
+        const MAX_ATTEMPTS: usize = 7;
+        let rec_info = ReconnectInfo::new(MAX_ATTEMPTS, Duration::from_millis(10), Some(state_tx));
+
+        let mut tcp_source = TcpSource::new(SERVER, None, Some(rec_info)).await.unwrap();
+
+        // Tests reconnecting state messages.
+        // Failed state message with MAX_ATTEMPTS is expected.
+        let reconnect_handler = tokio::spawn(async move {
+            loop {
+                state_rx.changed().await.unwrap();
+                match *state_rx.borrow_and_update() {
+                    ReconnectStateMsg::Connected => panic!("Connected state not expected"),
+                    ReconnectStateMsg::Reconnecting { attempts: _ } => {}
+                    ReconnectStateMsg::Failed {
+                        attempts,
+                        err_msg: _,
+                    } => {
+                        assert_eq!(attempts, MAX_ATTEMPTS);
+                        break;
+                    }
+                };
+            }
+        });
+
+        let receive_handle = tokio::spawn(async move {
+            // Byte source must receive some data then receive and error on failing reconnect.
+            for msg in MESSAGES {
+                tcp_source.load(None).await.expect("reload failed");
+                println!(
+                    "receive: {:02X?}",
+                    std::str::from_utf8(tcp_source.current_slice())
+                );
+                assert_eq!(tcp_source.current_slice(), msg.as_bytes());
+                tcp_source.consume(msg.len());
+            }
+            assert!(tcp_source.load(None).await.is_err());
+        });
+
+        let (_, rec_res, reconnect_res) =
+            tokio::join!(send_handle, receive_handle, reconnect_handler);
+
+        assert!(rec_res.is_ok());
+        assert!(reconnect_res.is_ok());
+    }
+
+    /// Ensure load and reconnect functions are cancel safe by keep sending notifications
+    /// in rapid interval while calling them.
+    #[tokio::test]
+    async fn load_reconnect_cancel_safe() {
+        static SERVER: &str = "127.0.0.1:4006";
+        let listener = TcpListener::bind(&SERVER).await.unwrap();
+        let send_handle = tokio::spawn(async move {
+            // Run server sending data for first time.
+            let (stream, _) = listener.accept().await.unwrap();
+            let (_, mut send) = tokio::io::split(stream);
+            for msg in MESSAGES {
+                send.write_all(msg.as_bytes())
+                    .await
+                    .expect("could not send on socket");
+                send.flush().await.expect("flush message should work");
+                sleep(Duration::from_millis(30)).await;
+            }
+
+            // Then disconnected the server and sleep.
+            drop(send);
+            drop(listener);
+            sleep(Duration::from_millis(150)).await;
+
+            // Start new server sending data again.
+            let listener = TcpListener::bind(&SERVER).await.unwrap();
+            let (stream, _) = listener.accept().await.unwrap();
+            let (_, mut send) = tokio::io::split(stream);
+            for msg in MESSAGES {
+                send.write_all(msg.as_bytes())
+                    .await
+                    .expect("could not send on socket");
+                send.flush().await.expect("flush message should work");
+                sleep(Duration::from_millis(30)).await;
+            }
+        });
+
+        // Enable reconnect without configuring state channels.
+        let rec_info = ReconnectInfo::new(1000, Duration::from_millis(30), None);
+
+        let (cancel_tx, mut cancel_rx) = tokio::sync::mpsc::channel(32);
+
+        let mut tcp_source = TcpSource::new(SERVER, None, Some(rec_info)).await.unwrap();
+
+        let cancel_handle = tokio::spawn(async move {
+            // Keep sending notifications causing load method to be dropped while both
+            // receiving data and reconnecting to ensure their cancel safety.
+            let mut sent = 0;
+            while cancel_tx.send(()).await.is_ok() {
+                sent += 1;
+                sleep(Duration::from_millis(2)).await;
+            }
+
+            // Ensure messages are actually sent.
+            assert!(sent > 50);
+        });
+
+        let receive_handle = tokio::spawn(async move {
+            // TCP source must receive three messages, reconnect then receive three
+            // more messages while receiving notifications with 2 milliseconds interval
+            // to prove its cancel safety while loading and reconnecting.
+            let mut idx = 0;
+            let mut received_cancels = 0;
+            while idx < MESSAGES.len() * 2 {
+                tokio::select! {
+                    _ = cancel_rx.recv() => {
+                        received_cancels += 1;
+                    }
+                    Ok(Some(_)) = tcp_source.load(None) => {
+                        let msg = MESSAGES[idx % MESSAGES.len()];
+                        assert_eq!(tcp_source.current_slice(), msg.as_bytes());
+                        tcp_source.consume(msg.len());
+                        idx += 1;
+                    }
+                };
+            }
+
+            // Ensure cancel messages are actually received.
+            assert!(received_cancels > 50);
+        });
+
+        let (_, rec_res, can_res) = tokio::join!(send_handle, receive_handle, cancel_handle);
+
+        assert!(rec_res.is_ok());
+        assert!(can_res.is_ok());
+    }
+
+    /// Ensure load and reconnect functions are cancel safe by keep calling it within a timeout
+    /// function with rapid interval.
+    #[tokio::test]
+    async fn load_reconnect_cancel_safe_timeout() {
+        static SERVER: &str = "127.0.0.1:4007";
+        let listener = TcpListener::bind(&SERVER).await.unwrap();
+        let send_handle = tokio::spawn(async move {
+            // Run server sending data for first time.
+            let (stream, _) = listener.accept().await.unwrap();
+            let (_, mut send) = tokio::io::split(stream);
+            for msg in MESSAGES {
+                send.write_all(msg.as_bytes())
+                    .await
+                    .expect("could not send on socket");
+                send.flush().await.expect("flush message should work");
+                sleep(Duration::from_millis(30)).await;
+            }
+
+            // Then disconnected the server and sleep.
+            drop(send);
+            drop(listener);
+            sleep(Duration::from_millis(150)).await;
+
+            // Start new server sending data again.
+            let listener = TcpListener::bind(&SERVER).await.unwrap();
+            let (stream, _) = listener.accept().await.unwrap();
+            let (_, mut send) = tokio::io::split(stream);
+            for msg in MESSAGES {
+                send.write_all(msg.as_bytes())
+                    .await
+                    .expect("could not send on socket");
+                send.flush().await.expect("flush message should work");
+                sleep(Duration::from_millis(30)).await;
+            }
+        });
+
+        // Enable reconnect without configuring state channels.
+        let rec_info = ReconnectInfo::new(1000, Duration::from_millis(30), None);
+
+        let mut tcp_source = TcpSource::new(SERVER, None, Some(rec_info)).await.unwrap();
+
+        let receive_handle = tokio::spawn(async move {
+            // TCP source must receive three messages, reconnect then receive three
+            // more messages while receiving notifications with 2 milliseconds interval
+            // to prove its cancel safety while loading and reconnecting.
+            let mut idx = 0;
+            let mut received_timeout = 0;
+            while idx < MESSAGES.len() * 2 {
+                match timeout(Duration::from_millis(2), tcp_source.load(None)).await {
+                    Ok(_) => {
+                        let msg = MESSAGES[idx % MESSAGES.len()];
+                        assert_eq!(tcp_source.current_slice(), msg.as_bytes());
+                        tcp_source.consume(msg.len());
+                        idx += 1;
+                    }
+                    Err(_elapsed) => received_timeout += 1,
+                }
+            }
+
+            // Ensure cancel messages are actually received.
+            assert!(received_timeout > 50);
+        });
+
+        let (_, rec_res) = tokio::join!(send_handle, receive_handle);
+
+        assert!(rec_res.is_ok());
     }
 }

--- a/application/apps/indexer/sources/src/socket/tcp/reconnect.rs
+++ b/application/apps/indexer/sources/src/socket/tcp/reconnect.rs
@@ -88,13 +88,13 @@ impl TcpReconnecter {
             self.task_handle.is_none(),
             "There must be no spawned reconnect task when spawn reconnect is called"
         );
-        let hanlde = tokio::spawn(reconnect(
+        let handle = tokio::spawn(reconnect(
             self.reconnect_info.clone(),
             self.binding_address,
             self.keep_alive.clone(),
         ));
 
-        self.task_handle = Some(hanlde);
+        self.task_handle = Some(handle);
     }
 }
 
@@ -139,7 +139,7 @@ async fn reconnect(
                         // Make sure the message has been sent before returning.
                         yield_now().await;
                     }
-                    log::warn!("Reconnecting to TCP server failed after {attempts} attemps.");
+                    log::warn!("Reconnecting to TCP server failed after {attempts} attempts.");
 
                     return ReconnectResult::Error(err);
                 }

--- a/application/apps/indexer/sources/src/socket/tcp/reconnect.rs
+++ b/application/apps/indexer/sources/src/socket/tcp/reconnect.rs
@@ -1,0 +1,151 @@
+use std::{net::SocketAddr, time::Duration};
+use tokio::{
+    net::TcpStream,
+    sync::watch,
+    task::{yield_now, JoinHandle},
+};
+
+use super::KeepAliveConfig;
+
+#[derive(Debug, Clone)]
+/// Represents the needed infos to reconnect to the server once the connection is lost.
+pub struct ReconnectInfo {
+    /// Maximum number of attempts to reconnect to the server.
+    max_attempts: usize,
+    /// The time interval between each try to connect to server.
+    interval: Duration,
+    /// Channel to send information of the state of reconnecting progress.
+    state_sender: Option<watch::Sender<ReconnectStateMsg>>,
+}
+
+impl ReconnectInfo {
+    pub fn new(
+        max_attempts: usize,
+        interval: Duration,
+        state_sender: Option<watch::Sender<ReconnectStateMsg>>,
+    ) -> Self {
+        Self {
+            max_attempts,
+            interval,
+            state_sender,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+/// Represent the information of the state of the reconnection progress.
+pub enum ReconnectStateMsg {
+    Connected,
+    Reconnecting {
+        attempts: usize,
+    },
+    Failed {
+        attempts: usize,
+        err_msg: Option<String>,
+    },
+}
+
+#[derive(Debug)]
+/// Represent the return result of reconnect function.
+pub enum ReconnectResult {
+    /// Reconnection to server successful.
+    Reconnected(TcpStream),
+    /// Error while reconnecting.
+    Error(std::io::Error),
+}
+
+/// Struct to manage reconnecting to TCP server.
+#[derive(Debug)]
+pub struct TcpReconnecter {
+    reconnect_info: ReconnectInfo,
+    binding_address: SocketAddr,
+    keep_alive: Option<KeepAliveConfig>,
+    /// Handle of spawned reconnecting task.
+    pub task_handle: Option<JoinHandle<ReconnectResult>>,
+}
+
+impl TcpReconnecter {
+    pub fn new(
+        reconnect_info: ReconnectInfo,
+        binding_address: SocketAddr,
+        keep_alive: Option<KeepAliveConfig>,
+    ) -> Self {
+        Self {
+            reconnect_info,
+            task_handle: None,
+            binding_address,
+            keep_alive,
+        }
+    }
+
+    /// Spawns a reconnect task setting its handle to the field [`Self::task_handle`]
+    ///
+    /// # Panics:
+    ///
+    /// This function panics if there is an already spawned task which hadn't been consumed yet.
+    pub fn spawn_reconnect(&mut self) {
+        assert!(
+            self.task_handle.is_none(),
+            "There must be no spawned reconnect task when spawn reconnect is called"
+        );
+        let hanlde = tokio::spawn(reconnect(
+            self.reconnect_info.clone(),
+            self.binding_address,
+            self.keep_alive.clone(),
+        ));
+
+        self.task_handle = Some(hanlde);
+    }
+}
+
+impl Drop for TcpReconnecter {
+    fn drop(&mut self) {
+        if let Some(task) = self.task_handle.take() {
+            task.abort();
+        }
+    }
+}
+
+async fn reconnect(
+    reconnect_info: ReconnectInfo,
+    binding_address: SocketAddr,
+    keep_alive: Option<KeepAliveConfig>,
+) -> ReconnectResult {
+    let mut attempts = 0;
+    loop {
+        attempts += 1;
+        if let Some(sender) = &reconnect_info.state_sender {
+            sender.send_replace(ReconnectStateMsg::Reconnecting { attempts });
+        }
+        log::info!("Reconnecting to TCP server. Attempt: {attempts}");
+
+        match super::TcpSource::create_socket(binding_address, keep_alive.as_ref()).await {
+            Ok(socket) => {
+                if let Some(sender) = &reconnect_info.state_sender {
+                    if let Err(err) = sender.send(ReconnectStateMsg::Connected) {
+                        log::error!("Failed to send connected state with err: {err}");
+                    }
+                }
+                return ReconnectResult::Reconnected(socket);
+            }
+            Err(err) => {
+                log::debug!("Got following error while trying to reconnect: {err}");
+                if attempts >= reconnect_info.max_attempts {
+                    if let Some(sender) = &reconnect_info.state_sender {
+                        sender.send_replace(ReconnectStateMsg::Failed {
+                            attempts,
+                            err_msg: Some(err.to_string()),
+                        });
+                        // Make sure the message has been sent before returning.
+                        yield_now().await;
+                    }
+                    log::warn!("Reconnecting to TCP server failed after {attempts} attemps.");
+
+                    return ReconnectResult::Error(err);
+                }
+            }
+        }
+
+        tokio::time::sleep(reconnect_info.interval).await;
+    }
+}

--- a/application/apps/rustcore/rs-bindings/Cargo.lock
+++ b/application/apps/rustcore/rs-bindings/Cargo.lock
@@ -2269,6 +2269,7 @@ dependencies = [
  "regex",
  "serde",
  "shellexpand",
+ "socket2",
  "stypes",
  "thiserror 2.0.3",
  "tokio",

--- a/cli/chipmunk-cli/CHANGELOG.md
+++ b/cli/chipmunk-cli/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.2.0
+
+## Changes:
+
+* Enhanced auto-reconnect to TCP server with optional `keepalive` probes.
+* Added new CLI arguments for configuring TCP `keepalive` probes.  
+* Change unit for intervals from milliseconds to seconds.
+* Improved performance and reliability of parse sessions.  
+* Improved parse error handling to minimize data loss and enhance app responsiveness.  
+
 # 0.1.0
 
 ## Features:

--- a/cli/chipmunk-cli/Cargo.lock
+++ b/cli/chipmunk-cli/Cargo.lock
@@ -1358,6 +1358,7 @@ dependencies = [
  "regex",
  "serde",
  "shellexpand",
+ "socket2",
  "stypes",
  "thiserror 2.0.11",
  "tokio",

--- a/cli/chipmunk-cli/Cargo.lock
+++ b/cli/chipmunk-cli/Cargo.lock
@@ -242,7 +242,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chipmunk-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/chipmunk-cli/Cargo.toml
+++ b/cli/chipmunk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chipmunk-cli"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ammar Abou Zor <ammar.abou.zor@accenture.com>"]
 edition = "2021"
 description = "CLI Tool for parsing bytes form different source supporting multiple data formats"

--- a/cli/chipmunk-cli/README.md
+++ b/cli/chipmunk-cli/README.md
@@ -139,6 +139,9 @@ When exporting to **binary format**, Chipmunk automatically generates a default 
 Chipmunk can establish a connection with a **TCP server**, receive data from it, and parse it. It also supports **automatic reconnection** if the connection is lost.
 Reconnection is enabled **only** when the `--max-reconnect` option is specified. If not set, the session will terminate as soon as the connection to the server is lost.
 
+Additionally, Chipmunk supports **keep-alive probes** to maintain the connection with the server. 
+Keep-alive is enabled **only** when the `--keep-alive` option is set. It specifies the time interval (in seconds) between keep-alive probes sent to the TCP server.
+
 ```shell
 $ chipmunk-cli dlt tcp --help
 Establish a TCP connection using the specified IP address as the input source
@@ -150,11 +153,15 @@ Arguments:
 
 Options:
   -u, --update-interval <UPDATE_INTERVAL>
-          Time interval (in milliseconds) to print current status [default: 5000]
+          Time interval (in seconds) to print current status [default: 5]
   -m, --max-reconnect <MAX_RECONNECT_COUNT>
-          Maximum number of reconnection attempts if the connection is lost
+          Maximum number of reconnection attempts if the connection is lost.
+          Value must be set to enable automatic reconnect to server.
   -r, --reconnect-interval <RECONNECT_INTERVAL>
-          Time interval (in milliseconds) between reconnection attempts [default: 1000]
+          Time interval (in seconds) between reconnection attempts [default: 1]
+  -k, --keep-alive <KEEP_ALIVE>
+          Time interval (in seconds) to send `keep-alive` probes to TCP server.
+          Value must be set to enable `keep-alive` on the server.
   -h, --help
           Print help
 ```
@@ -168,13 +175,16 @@ Since UDP is connectionless by design, Chipmunk will automatically handle incomi
 $ chipmunk-cli dlt udp --help
 Establish a UDP connection using the specified IP address as the input source
 
-Usage: chipmunk-cli dlt udp <ADDRESS>
+Usage: chipmunk-cli dlt udp [OPTIONS] <ADDRESS>
 
 Arguments:
   <ADDRESS>  The address to bind the connection to
 
 Options:
-  -h, --help  Print help
+  -u, --update-interval <UPDATE_INTERVAL>
+          Time interval (in seconds) to print current status [default: 5]
+  -h, --help
+          Print help
 ```
 
 ### File Input  

--- a/cli/chipmunk-cli/src/cli_args/mod.rs
+++ b/cli/chipmunk-cli/src/cli_args/mod.rs
@@ -89,11 +89,16 @@ pub enum InputSource {
         #[arg(short, long = "update-interval", default_value_t = 5000)]
         update_interval: u64,
         /// Maximum number of reconnection attempts if the connection is lost.
-        #[arg(short, long = "max-reconnect")]
+        /// Value must be set to enable automatic reconnect to server.
+        #[arg(short, long = "max-reconnect", verbatim_doc_comment)]
         max_reconnect_count: Option<usize>,
         /// Time interval (in milliseconds) between reconnection attempts.
         #[arg(short, long = "reconnect-interval", default_value_t = 1000)]
         reconnect_interval: u64,
+        /// Time interval (in milliseconds) to send `keep-alive` probes to TCP server.
+        /// Value must be set to enable `keep-alive` on the server.
+        #[arg(short, long = "keep-alive", verbatim_doc_comment)]
+        keep_alive: Option<u64>,
     },
     /// Establish a UDP connection using the specified IP address as the input source.
     Udp {
@@ -160,6 +165,7 @@ impl Cli {
                 update_interval,
                 max_reconnect_count: _,
                 reconnect_interval: interval_reconnect,
+                keep_alive,
             } => {
                 const UPDATE_INTERVAL_MIN: u64 = 100;
                 ensure!(*update_interval >= UPDATE_INTERVAL_MIN,
@@ -169,6 +175,10 @@ impl Cli {
                 ensure!(
                     *interval_reconnect > INTERVAL_RECONNECT_MIN,
                     "Reconnect interval must be bigger than {INTERVAL_RECONNECT_MIN} milliseconds"
+                );
+                ensure!(
+                    keep_alive.is_none_or(|v| v > 0),
+                    "Keepalive time must be greater than zero when set"
                 );
             }
             InputSource::Udp { address: _ } => {}

--- a/cli/chipmunk-cli/src/cli_args/mod.rs
+++ b/cli/chipmunk-cli/src/cli_args/mod.rs
@@ -85,17 +85,17 @@ pub enum InputSource {
         /// The address to bind the connection to.
         #[arg(index = 1)]
         address: String,
-        /// Time interval (in milliseconds) to print current status.
-        #[arg(short, long = "update-interval", default_value_t = 5000)]
+        /// Time interval (in seconds) to print current status.
+        #[arg(short, long = "update-interval", default_value_t = 5)]
         update_interval: u64,
         /// Maximum number of reconnection attempts if the connection is lost.
         /// Value must be set to enable automatic reconnect to server.
         #[arg(short, long = "max-reconnect", verbatim_doc_comment)]
         max_reconnect_count: Option<usize>,
-        /// Time interval (in milliseconds) between reconnection attempts.
-        #[arg(short, long = "reconnect-interval", default_value_t = 1000)]
+        /// Time interval (in seconds) between reconnection attempts.
+        #[arg(short, long = "reconnect-interval", default_value_t = 1)]
         reconnect_interval: u64,
-        /// Time interval (in milliseconds) to send `keep-alive` probes to TCP server.
+        /// Time interval (in seconds) to send `keep-alive` probes to TCP server.
         /// Value must be set to enable `keep-alive` on the server.
         #[arg(short, long = "keep-alive", verbatim_doc_comment)]
         keep_alive: Option<u64>,
@@ -105,6 +105,9 @@ pub enum InputSource {
         /// The address to bind the connection to.
         #[arg(index = 1)]
         address: String,
+        /// Time interval (in seconds) to print current status.
+        #[arg(short, long = "update-interval", default_value_t = 5)]
+        update_interval: u64,
     },
     /// Read input from a file at the specified path.
     File {
@@ -167,21 +170,28 @@ impl Cli {
                 reconnect_interval: interval_reconnect,
                 keep_alive,
             } => {
-                const UPDATE_INTERVAL_MIN: u64 = 100;
-                ensure!(*update_interval >= UPDATE_INTERVAL_MIN,
-                    "Update interval must be equal or bigger than {UPDATE_INTERVAL_MIN} milliseconds");
-
-                const INTERVAL_RECONNECT_MIN: u64 = 0;
                 ensure!(
-                    *interval_reconnect > INTERVAL_RECONNECT_MIN,
-                    "Reconnect interval must be bigger than {INTERVAL_RECONNECT_MIN} milliseconds"
+                    *update_interval > 0,
+                    "Update interval must be greater than zero"
+                );
+                ensure!(
+                    *interval_reconnect > 0,
+                    "Reconnect interval must be grater than zero"
                 );
                 ensure!(
                     keep_alive.is_none_or(|v| v > 0),
                     "Keepalive time must be greater than zero when set"
                 );
             }
-            InputSource::Udp { address: _ } => {}
+            InputSource::Udp {
+                address: _,
+                update_interval,
+            } => {
+                ensure!(
+                    *update_interval > 0,
+                    "Update interval must be greater than zero"
+                );
+            }
             InputSource::File { path } => {
                 ensure!(
                     path.exists(),

--- a/cli/chipmunk-cli/src/session/socket.rs
+++ b/cli/chipmunk-cli/src/session/socket.rs
@@ -6,7 +6,7 @@ use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
 use parsers::{LogMessage, Parser};
-use sources::{producer::MessageProducer, socket::ReconnectStateMsg, ByteSource};
+use sources::{producer::MessageProducer, socket::tcp::reconnect::ReconnectStateMsg, ByteSource};
 
 use crate::session::create_append_file_writer;
 
@@ -70,11 +70,11 @@ where
                 match msg.deref() {
                     ReconnectStateMsg::Reconnecting { attempts } => {
                         reconnecting = true;
-                        if *attempts == 0 {
+                        if *attempts == 1 {
                             println!("Connection to server lost. Trying to reconnect...");
-                        }else {
-                            println!("Reconnecting to TCP server. Attempt: {attempts}");
                         }
+                        println!("Reconnecting to TCP server. Attempt: {attempts}");
+
                     },
                     ReconnectStateMsg::Connected => {
                         reconnecting = false;


### PR DESCRIPTION
This PR provide the following:

* Reimplement the reconnect function with cancel-safety in mind. The new implementation will spawn reconnecting in a new task keeping track on each progress.
* Possibility to configure `keepalive` on TCP source + CLI arguments for its configuration on Chipmunk CLI, keeping the implementation on Chipmunk GUI for later.
* Unit tests for reconnect and cancel-safe load and reconnect calls.
* Change duration units on Chipmunk CLI from milliseconds to units since seconds accuracy is more suitable for this domain.
* Increase Chipmunk CLI version + Update readme and changelog

**Note:**
Manual timeout checks aren't implemented here, because they would increase the code complexity and introducing `Arc<RwLock<>` wrappers around the tcp sockets even though that this option may not ever be needed. However, I still have a prototype in a different branch in case we find out that is needed 
   