### PR TITLE
Draft1: Cancel Safety for SDE Communications

### DIFF
--- a/application/apps/indexer/sources/src/command/process.rs
+++ b/application/apps/indexer/sources/src/command/process.rs
@@ -215,7 +215,7 @@ impl ByteSource for ProcessSource {
 
     async fn income(
         &mut self,
-        request: stypes::SdeRequest,
+        request: &stypes::SdeRequest,
     ) -> Result<stypes::SdeResponse, SourceError> {
         let bytes = match request {
             stypes::SdeRequest::WriteText(ref str) => str.as_bytes(),

--- a/application/apps/indexer/sources/src/lib.rs
+++ b/application/apps/indexer/sources/src/lib.rs
@@ -147,7 +147,7 @@ pub trait ByteSource: Send + Sync {
     ///
     /// The method [`ByteSource::reload()`] must be **Cancel-Safe** for structs that support this
     /// method
-    async fn income(&mut self, _msg: stypes::SdeRequest) -> Result<stypes::SdeResponse, Error> {
+    async fn income(&mut self, _msg: &stypes::SdeRequest) -> Result<stypes::SdeResponse, Error> {
         Err(Error::NotSupported)
     }
 }

--- a/application/apps/indexer/sources/src/producer.rs
+++ b/application/apps/indexer/sources/src/producer.rs
@@ -240,7 +240,7 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
                 //TODO AAZ: Check if income can take a reference form the data.
                 let val = self
                     .byte_source
-                    .income(msg.to_owned())
+                    .income(msg)
                     .await
                     .map_err(|e| e.to_string());
 

--- a/application/apps/indexer/sources/src/producer/tests/cancel_safety.rs
+++ b/application/apps/indexer/sources/src/producer/tests/cancel_safety.rs
@@ -3,7 +3,10 @@ use std::time::Duration;
 use mock_byte_source::*;
 use mock_parser::*;
 use parsers::{Error as ParseError, ParseYield};
-use tokio::time::{sleep, timeout};
+use tokio::{
+    sync::{mpsc::unbounded_channel, oneshot},
+    time::{sleep, timeout},
+};
 
 use super::*;
 
@@ -685,4 +688,141 @@ async fn cancel_safe_timeout() {
     }
 
     assert!(timeout_received > 50);
+}
+
+#[tokio::test]
+/// Cancel safety test for SDE Communication in the producer loop
+async fn sde_communication() {
+    let parser = MockParser::new([
+        Ok(vec![MockParseSeed::new(
+            5,
+            Some(ParseYield::Message(MockMessage::from(1))),
+        )]),
+        Ok(vec![MockParseSeed::new(
+            4,
+            Some(ParseYield::Message(MockMessage::from(2))),
+        )]),
+        Ok(vec![MockParseSeed::new(
+            6,
+            Some(ParseYield::Message(MockMessage::from(3))),
+        )]),
+    ]);
+
+    let source = MockByteSource::new(
+        0,
+        [
+            Ok(Some(
+                MockReloadSeed::new(5, 0).sleep_duration(SOURCE_SLEEP_DURATION),
+            )),
+            Ok(Some(
+                MockReloadSeed::new(4, 0).sleep_duration(SOURCE_SLEEP_DURATION),
+            )),
+            Ok(Some(
+                MockReloadSeed::new(6, 0).sleep_duration(SOURCE_SLEEP_DURATION),
+            )),
+            Ok(None),
+            Ok(None),
+        ],
+    );
+
+    // Create producer with sde channels
+    let (tx_sde, rx_sde) = unbounded_channel();
+    let mut producer = MessageProducer::new(parser, source, Some(rx_sde));
+
+    // Spawn task sending a couple of SDE messages.
+    let sde_hanndle = tokio::spawn(async move {
+        const SDE_TEXT: &str = "sde_msg";
+        for _ in 0..3 {
+            let (tx_sde_response, mut rx_sde_response) = oneshot::channel();
+            tx_sde
+                .send((
+                    stypes::SdeRequest::WriteText(SDE_TEXT.into()),
+                    tx_sde_response,
+                ))
+                .unwrap();
+
+            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            // Producer loop must have called `income()` and sent the message by now.
+            // The bytes length must match the sent message length as it implemented and tested in `MockByteSource`
+            let sde_response_res = rx_sde_response
+                .try_recv()
+                .expect("Sde Response must be sent by now because of the delay");
+
+            let sde_response =
+                sde_response_res.expect("`income()` method on `MockByteSource` should never fail");
+
+            // Returned bytes length must match the length of the sent data.
+            assert_eq!(sde_response.bytes, SDE_TEXT.len());
+        }
+    });
+
+    let mut timeout_received = 0;
+    let mut read_idx = 0;
+    loop {
+        match timeout(Duration::from_millis(2), producer.read_next_segment()).await {
+            Ok(items) => {
+                match read_idx {
+                    0 => {
+                        let items = items.unwrap();
+                        assert_eq!(items.len(), 1);
+                        assert!(matches!(
+                            items[0],
+                            (
+                                5,
+                                MessageStreamItem::Item(ParseYield::Message(MockMessage {
+                                    content: 1
+                                }))
+                            )
+                        ));
+                    }
+                    1 => {
+                        let items = items.unwrap();
+                        assert_eq!(items.len(), 1);
+                        assert!(matches!(
+                            items[0],
+                            (
+                                4,
+                                MessageStreamItem::Item(ParseYield::Message(MockMessage {
+                                    content: 2
+                                }))
+                            )
+                        ));
+                    }
+                    2 => {
+                        let items = items.unwrap();
+                        assert_eq!(items.len(), 1);
+                        assert!(matches!(
+                            items[0],
+                            (
+                                6,
+                                MessageStreamItem::Item(ParseYield::Message(MockMessage {
+                                    content: 3
+                                }))
+                            )
+                        ));
+                    }
+                    3 => {
+                        let items = items.unwrap();
+                        assert_eq!(items.len(), 1);
+                        assert!(matches!(items[0], (0, MessageStreamItem::Done)));
+                    }
+                    4 => {
+                        assert!(items.is_none());
+                        break;
+                    }
+                    _invalid => panic!("Unexpected read_next_segment() results. Idx: {_invalid}"),
+                };
+                read_idx += 1;
+            }
+            Err(_elapsed) => {
+                timeout_received += 1;
+            }
+        }
+    }
+
+    assert!(timeout_received > 50);
+
+    // Make sure SDE completed successfully.
+    sde_hanndle.await.expect("SDE send task should never fail");
 }

--- a/application/apps/indexer/sources/src/producer/tests/mock_byte_source.rs
+++ b/application/apps/indexer/sources/src/producer/tests/mock_byte_source.rs
@@ -138,7 +138,7 @@ impl ByteSource for MockByteSource {
         }
     }
 
-    async fn income(&mut self, msg: stypes::SdeRequest) -> Result<stypes::SdeResponse, Error> {
+    async fn income(&mut self, msg: &stypes::SdeRequest) -> Result<stypes::SdeResponse, Error> {
         // Read the input for now and return it's length
         let bytes = match &msg {
             stypes::SdeRequest::WriteText(text) => text.as_bytes(),
@@ -228,7 +228,7 @@ async fn test_mock_byte_source_income() {
 
     let byte_msg = stypes::SdeRequest::WriteBytes(vec![b'a'; BYTES_LEN]);
 
-    let byte_income_res = source.income(byte_msg).await;
+    let byte_income_res = source.income(&byte_msg).await;
     // Byte income should succeed producing a response with the length of the provided bytes.
     assert!(matches!(
         byte_income_res,
@@ -241,7 +241,7 @@ async fn test_mock_byte_source_income() {
 
     let text_msg = stypes::SdeRequest::WriteText(TEXT.into());
 
-    let text_income_res = source.income(text_msg).await;
+    let text_income_res = source.income(&text_msg).await;
 
     // Text income should succeed producing a response wit the length of the provided text bytes.
     assert!(matches!(


### PR DESCRIPTION
This PR closes #2257

This PR tries to ensure cancel safety for SDE communications while keeping it inside the producer loop.
To achieve that:
* SDE communication is moved to the load method, 
* SDE channel will be borrowed instead of the current take() and reassign logic.
* We will keep state of the received msg in case income() method got cancelled.
* Writing to serial ports will block the current thread unit it's done to prevent interruption while writing.

This implementation force incomplete function to be cancel safe, but keep the SDE communications inside the producer loop. However, it would be better to move SDE communications to the session to avoid forcing `income()` method on byte source to be cancel safe.