### PR TITLE
Move SDE communication to observe session.

### DIFF
--- a/application/apps/indexer/addons/dlt-tools/src/lib.rs
+++ b/application/apps/indexer/addons/dlt-tools/src/lib.rs
@@ -42,7 +42,7 @@ pub async fn scan_dlt_ft(
                 None,
                 with_storage_header,
             );
-            let mut producer = MessageProducer::new(parser, source, None);
+            let mut producer = MessageProducer::new(parser, source);
 
             let mut canceled = false;
 

--- a/application/apps/indexer/indexer_cli/src/interactive.rs
+++ b/application/apps/indexer/indexer_cli/src/interactive.rs
@@ -40,7 +40,7 @@ pub(crate) async fn handle_interactive_session(input: Option<PathBuf>) {
                             static RECEIVER: &str = "127.0.0.1:5000";
                             let udp_source = UdpSource::new(RECEIVER, vec![]).await.unwrap();
                             let dlt_parser = DltParser::new(None, None, None, None, false);
-                            let mut dlt_msg_producer = MessageProducer::new(dlt_parser, udp_source, None);
+                            let mut dlt_msg_producer = MessageProducer::new(dlt_parser, udp_source);
                             loop {
                                 select! {
                                     _ = cancel.cancelled() => {

--- a/application/apps/indexer/indexer_cli/src/main.rs
+++ b/application/apps/indexer/indexer_cli/src/main.rs
@@ -805,7 +805,7 @@ pub async fn main() -> Result<()> {
             let dlt_parser = DltParser::new(None, None, None, None, true);
             let reader = BufReader::new(&in_file);
             let source = BinaryByteSource::new(reader);
-            let dlt_msg_producer = MessageProducer::new(dlt_parser, source, None);
+            let dlt_msg_producer = MessageProducer::new(dlt_parser, source);
             let cancel = CancellationToken::new();
             export_raw(
                 dlt_msg_producer,
@@ -1370,7 +1370,7 @@ async fn count_dlt_messages(input: &Path) -> Result<u64, DltParseError> {
 
         let source = BinaryByteSource::new(second_reader);
 
-        let mut dlt_msg_producer = MessageProducer::new(dlt_parser, source, None);
+        let mut dlt_msg_producer = MessageProducer::new(dlt_parser, source);
         let mut msgs_count = 0;
         while let Some(items) = dlt_msg_producer.read_next_segment().await {
             msgs_count += items.len();
@@ -1391,7 +1391,7 @@ async fn detect_messages_type(input: &Path) -> Result<bool, DltParseError> {
             let buf_reader = BufReader::new(fs::File::open(input)?);
             let source = BinaryByteSource::new(buf_reader);
             let dlt_parser = DltRangeParser::new();
-            let mut dlt_msg_producer = MessageProducer::new(dlt_parser, source, None);
+            let mut dlt_msg_producer = MessageProducer::new(dlt_parser, source);
             let mut item_count = 0usize;
             let mut attachment_count = 0usize;
             let mut err_count = 0usize;
@@ -1436,7 +1436,7 @@ async fn detect_messages_type(input: &Path) -> Result<bool, DltParseError> {
             let some_parser = SomeipParser::new();
             match PcapngByteSource::new(fs::File::open(input)?) {
                 Ok(source) => {
-                    let mut some_msg_producer = MessageProducer::new(some_parser, source, None);
+                    let mut some_msg_producer = MessageProducer::new(some_parser, source);
                     let mut item_count = 0usize;
                     let mut err_count = 0usize;
                     let mut consumed = 0usize;
@@ -1473,7 +1473,7 @@ async fn detect_messages_type(input: &Path) -> Result<bool, DltParseError> {
             // let buf_reader = BufReader::new(fs::File::open(&input)?);
             match PcapngByteSource::new(fs::File::open(input)?) {
                 Ok(source) => {
-                    let mut dlt_msg_producer = MessageProducer::new(dlt_parser, source, None);
+                    let mut dlt_msg_producer = MessageProducer::new(dlt_parser, source);
                     let mut item_count = 0usize;
                     let mut attachment_count = 0usize;
                     let mut err_count = 0usize;
@@ -1523,7 +1523,7 @@ async fn detect_messages_type(input: &Path) -> Result<bool, DltParseError> {
             let txt_parser = StringTokenizer {};
             let buf_reader = BufReader::new(fs::File::open(input)?);
             let source = BinaryByteSource::new(buf_reader);
-            let mut txt_msg_producer = MessageProducer::new(txt_parser, source, None);
+            let mut txt_msg_producer = MessageProducer::new(txt_parser, source);
             let mut item_count = 0usize;
             let mut err_count = 0usize;
             let mut skipped_count = 0usize;

--- a/application/apps/indexer/session/src/handlers/export_raw.rs
+++ b/application/apps/indexer/session/src/handlers/export_raw.rs
@@ -138,7 +138,7 @@ async fn export<S: ByteSource>(
             } else {
                 SomeipParser::new()
             };
-            let producer = MessageProducer::new(parser, source, None);
+            let producer = MessageProducer::new(parser, source);
             export_runner(producer, dest, sections, read_to_end, false, cancel).await
         }
         stypes::ParserType::Dlt(settings) => {
@@ -150,11 +150,11 @@ async fn export<S: ByteSource>(
                 None,
                 settings.with_storage_header,
             );
-            let producer = MessageProducer::new(parser, source, None);
+            let producer = MessageProducer::new(parser, source);
             export_runner(producer, dest, sections, read_to_end, false, cancel).await
         }
         stypes::ParserType::Text(()) => {
-            let producer = MessageProducer::new(StringTokenizer {}, source, None);
+            let producer = MessageProducer::new(StringTokenizer {}, source);
             export_runner(producer, dest, sections, read_to_end, true, cancel).await
         }
     }

--- a/application/apps/indexer/session/src/handlers/observe.rs
+++ b/application/apps/indexer/session/src/handlers/observe.rs
@@ -4,7 +4,7 @@ use crate::{
     state::SessionStateAPI,
 };
 use log::error;
-use sources::producer::SdeReceiver;
+use sources::sde::SdeReceiver;
 
 pub async fn start_observing(
     operation_api: OperationAPI,

--- a/application/apps/indexer/session/src/handlers/observing/mod.rs
+++ b/application/apps/indexer/session/src/handlers/observing/mod.rs
@@ -13,7 +13,8 @@ use parsers::{
     LogMessage, MessageStreamItem, ParseYield, Parser,
 };
 use sources::{
-    producer::{MessageProducer, SdeReceiver},
+    producer::MessageProducer,
+    sde::{SdeMsg, SdeReceiver},
     ByteSource,
 };
 use tokio::{
@@ -26,6 +27,7 @@ enum Next<'a, T: LogMessage> {
     Items(&'a mut Vec<(usize, MessageStreamItem<T>)>),
     Timeout,
     Waiting,
+    Sde(SdeMsg),
 }
 
 pub mod concat;
@@ -83,12 +85,12 @@ async fn run_source_intern<S: ByteSource>(
                 }
                 None => SomeipParser::new(),
             };
-            let producer = MessageProducer::new(someip_parser, source, rx_sde);
-            run_producer(operation_api, state, source_id, producer, rx_tail).await
+            let producer = MessageProducer::new(someip_parser, source);
+            run_producer(operation_api, state, source_id, producer, rx_tail, rx_sde).await
         }
         stypes::ParserType::Text(()) => {
-            let producer = MessageProducer::new(StringTokenizer {}, source, rx_sde);
-            run_producer(operation_api, state, source_id, producer, rx_tail).await
+            let producer = MessageProducer::new(StringTokenizer {}, source);
+            run_producer(operation_api, state, source_id, producer, rx_tail, rx_sde).await
         }
         stypes::ParserType::Dlt(settings) => {
             let fmt_options = Some(FormatOptions::from(settings.tz.as_ref()));
@@ -102,8 +104,8 @@ async fn run_source_intern<S: ByteSource>(
                 someip_metadata.as_ref(),
                 settings.with_storage_header,
             );
-            let producer = MessageProducer::new(dlt_parser, source, rx_sde);
-            run_producer(operation_api, state, source_id, producer, rx_tail).await
+            let producer = MessageProducer::new(dlt_parser, source);
+            run_producer(operation_api, state, source_id, producer, rx_tail, rx_sde).await
         }
     }
 }
@@ -114,6 +116,7 @@ async fn run_producer<T: LogMessage, P: Parser<T>, S: ByteSource>(
     source_id: u16,
     mut producer: MessageProducer<T, P, S>,
     mut rx_tail: Option<Receiver<Result<(), tail::Error>>>,
+    mut rx_sde: Option<SdeReceiver>,
 ) -> OperationResult<()> {
     use log::debug;
     state.set_session_file(None).await?;
@@ -133,6 +136,14 @@ async fn run_producer<T: LogMessage, P: Parser<T>, S: ByteSource>(
                 Err(_) => Some(Next::Timeout),
             }
         } => next_from_stream,
+        Some(sde_msg) = async {
+            if let Some(rx_sde) = rx_sde.as_mut() {
+                rx_sde.recv().await
+            } else {
+                None
+            }
+        } => Some(Next::Sde(sde_msg)),
+
         _ = cancel.cancelled() => None,
     } {
         match next {
@@ -201,6 +212,12 @@ async fn run_producer<T: LogMessage, P: Parser<T>, S: ByteSource>(
                     }
                 } else {
                     break;
+                }
+            }
+            Next::Sde((msg, tx_response)) => {
+                let sde_res = producer.sde_income(msg).await.map_err(|e| e.to_string());
+                if tx_response.send(sde_res).is_err() {
+                    log::warn!("Fail to send back message from source");
                 }
             }
         }

--- a/application/apps/indexer/session/src/handlers/observing/stream.rs
+++ b/application/apps/indexer/session/src/handlers/observing/stream.rs
@@ -5,10 +5,11 @@ use crate::{
 };
 use sources::{
     command::process::ProcessSource,
-    producer::SdeReceiver,
     serial::serialport::SerialSource,
     socket::{tcp::TcpSource, udp::UdpSource},
 };
+
+use super::SdeReceiver;
 
 pub async fn observe_stream(
     operation_api: OperationAPI,

--- a/application/apps/indexer/session/src/operations.rs
+++ b/application/apps/indexer/session/src/operations.rs
@@ -3,7 +3,7 @@ use log::{debug, error, warn};
 use merging::merger::FileMergeOptions;
 use processor::search::filter::SearchFilter;
 use serde::Serialize;
-use sources::producer::{SdeReceiver, SdeSender};
+use sources::sde::{SdeReceiver, SdeSender};
 use std::{
     ops::RangeInclusive,
     path::PathBuf,

--- a/application/apps/indexer/session/src/tracker.rs
+++ b/application/apps/indexer/session/src/tracker.rs
@@ -1,6 +1,6 @@
 use crate::{operations::OperationStat, progress::ProgressProviderAPI, state::SessionStateAPI};
 use log::{debug, error};
-use sources::producer::SdeSender;
+use sources::sde::SdeSender;
 use std::collections::{hash_map::Entry, HashMap};
 use tokio::{
     sync::{

--- a/application/apps/indexer/sources/benches/dlt_producer.rs
+++ b/application/apps/indexer/sources/benches/dlt_producer.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use std::{hint::black_box, path::PathBuf};
+use std::path::PathBuf;
 
 use bench_utls::{
     bench_standrad_config, create_binary_bytesource, get_config, read_binary, run_producer,
@@ -36,7 +36,7 @@ fn dlt_producer(c: &mut Criterion) {
                 || {
                     let parser = DltParser::new(None, fibex.as_ref(), None, None, true);
                     let source = create_binary_bytesource(data);
-                    MessageProducer::new(parser, source, black_box(None))
+                    MessageProducer::new(parser, source)
                 },
                 run_producer,
                 BatchSize::SmallInput,

--- a/application/apps/indexer/sources/benches/macros/mock_producer_multi.rs
+++ b/application/apps/indexer/sources/benches/macros/mock_producer_multi.rs
@@ -19,7 +19,6 @@ macro_rules! mocks_producer_multi {
     ($name:ident, $allocator:path) => {
         use ::criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
         use ::sources::producer::MessageProducer;
-        use ::std::hint::black_box;
         use bench_utls::{bench_standrad_config, run_producer};
         use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
 
@@ -56,8 +55,7 @@ macro_rules! mocks_producer_multi {
                                 // Exclude initiation time from benchmarks.
                                 let parser = MockParser::new_multi(max);
                                 let byte_source = MockByteSource::new();
-                                let producer =
-                                    MessageProducer::new(parser, byte_source, black_box(None));
+                                let producer = MessageProducer::new(parser, byte_source);
 
                                 producer
                             },

--- a/application/apps/indexer/sources/benches/macros/mock_producer_multi_parallel.rs
+++ b/application/apps/indexer/sources/benches/macros/mock_producer_multi_parallel.rs
@@ -20,7 +20,6 @@ macro_rules! mocks_producer_multi_parallel {
     ($name:ident, $allocator:path) => {
         use ::criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
         use ::sources::producer::MessageProducer;
-        use ::std::hint::black_box;
         use bench_utls::{bench_standrad_config, run_producer};
         use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
 
@@ -60,8 +59,7 @@ macro_rules! mocks_producer_multi_parallel {
                                 for _ in 0..tasks_count {
                                     let parser = MockParser::new_multi(max);
                                     let byte_source = MockByteSource::new();
-                                    let producer =
-                                        MessageProducer::new(parser, byte_source, black_box(None));
+                                    let producer = MessageProducer::new(parser, byte_source);
 
                                     producers.push(producer);
                                 }

--- a/application/apps/indexer/sources/benches/macros/mock_producer_once.rs
+++ b/application/apps/indexer/sources/benches/macros/mock_producer_once.rs
@@ -19,7 +19,6 @@ macro_rules! mocks_producer_once {
     ($name:ident, $allocator:path) => {
         use ::criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
         use ::sources::producer::MessageProducer;
-        use ::std::hint::black_box;
         use bench_utls::{bench_standrad_config, run_producer};
         use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
 
@@ -56,8 +55,7 @@ macro_rules! mocks_producer_once {
                                 // Exclude initiation time from benchmarks.
                                 let parser = MockParser::new_once(max);
                                 let byte_source = MockByteSource::new();
-                                let producer =
-                                    MessageProducer::new(parser, byte_source, black_box(None));
+                                let producer = MessageProducer::new(parser, byte_source);
 
                                 producer
                             },

--- a/application/apps/indexer/sources/benches/macros/mock_producer_once_parallel.rs
+++ b/application/apps/indexer/sources/benches/macros/mock_producer_once_parallel.rs
@@ -20,7 +20,6 @@ macro_rules! mocks_producer_once_parallel {
     ($name:ident, $allocator:path) => {
         use ::criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
         use ::sources::producer::MessageProducer;
-        use ::std::hint::black_box;
         use bench_utls::{bench_standrad_config, run_producer};
         use mocks::{mock_parser::MockParser, mock_source::MockByteSource};
 
@@ -60,8 +59,7 @@ macro_rules! mocks_producer_once_parallel {
                                 for _ in 0..tasks_count {
                                     let parser = MockParser::new_once(max);
                                     let byte_source = MockByteSource::new();
-                                    let producer =
-                                        MessageProducer::new(parser, byte_source, black_box(None));
+                                    let producer = MessageProducer::new(parser, byte_source);
 
                                     producers.push(producer);
                                 }

--- a/application/apps/indexer/sources/benches/someip_legacy_producer.rs
+++ b/application/apps/indexer/sources/benches/someip_legacy_producer.rs
@@ -1,6 +1,6 @@
 mod bench_utls;
 
-use std::{hint::black_box, io::Cursor, path::PathBuf};
+use std::{io::Cursor, path::PathBuf};
 
 use bench_utls::{bench_standrad_config, get_config, read_binary, run_producer};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
@@ -32,7 +32,7 @@ fn someip_legacy_producer(c: &mut Criterion) {
                 || {
                     let parser = create_someip_parser(fibex_path.as_ref());
                     let source = PcapLegacyByteSource::new(Cursor::new(data)).unwrap();
-                    MessageProducer::new(parser, source, black_box(None))
+                    MessageProducer::new(parser, source)
                 },
                 run_producer,
                 BatchSize::SmallInput,

--- a/application/apps/indexer/sources/benches/someip_producer.rs
+++ b/application/apps/indexer/sources/benches/someip_producer.rs
@@ -1,4 +1,4 @@
-use std::{hint::black_box, io::Cursor, path::PathBuf};
+use std::{io::Cursor, path::PathBuf};
 
 use bench_utls::{bench_standrad_config, get_config, read_binary, run_producer};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
@@ -32,7 +32,7 @@ fn someip_producer(c: &mut Criterion) {
                 || {
                     let parser = create_someip_parser(fibex_path.as_ref());
                     let source = PcapngByteSource::new(Cursor::new(data)).unwrap();
-                    MessageProducer::new(parser, source, black_box(None))
+                    MessageProducer::new(parser, source)
                 },
                 run_producer,
                 BatchSize::SmallInput,

--- a/application/apps/indexer/sources/benches/text_producer.rs
+++ b/application/apps/indexer/sources/benches/text_producer.rs
@@ -1,5 +1,3 @@
-use std::hint::black_box;
-
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 
 use bench_utls::{bench_standrad_config, create_binary_bytesource, read_binary, run_producer};
@@ -20,7 +18,7 @@ fn text_producer(c: &mut Criterion) {
                 || {
                     let parser = StringTokenizer {};
                     let source = create_binary_bytesource(data);
-                    MessageProducer::new(parser, source, black_box(None))
+                    MessageProducer::new(parser, source)
                 },
                 run_producer,
                 BatchSize::SmallInput,

--- a/application/apps/indexer/sources/src/lib.rs
+++ b/application/apps/indexer/sources/src/lib.rs
@@ -130,8 +130,7 @@ pub trait ByteSource: Send + Sync {
     ///
     /// # Note:
     ///
-    /// This function must be **Cancel-Safe** if for structs which support [`stypes::SdeRequest`] by
-    /// implementing the method [`ByteSource::income()`].
+    /// This function must be **Cancel-Safe**
     async fn load(&mut self, filter: Option<&SourceFilter>) -> Result<Option<ReloadInfo>, Error>;
 
     /// In case the ByteSource is some kind of connection that does not end,
@@ -142,11 +141,6 @@ pub trait ByteSource: Send + Sync {
     }
 
     /// Append incoming (SDE) Source-Data-Exchange to the data.
-    ///
-    /// # Note:
-    ///
-    /// The method [`ByteSource::reload()`] must be **Cancel-Safe** for structs that support this
-    /// method
     async fn income(&mut self, _msg: stypes::SdeRequest) -> Result<stypes::SdeResponse, Error> {
         Err(Error::NotSupported)
     }

--- a/application/apps/indexer/sources/src/producer.rs
+++ b/application/apps/indexer/sources/src/producer.rs
@@ -1,22 +1,10 @@
 #[cfg(test)]
 mod tests;
 
-use crate::{sde::SdeMsg, ByteSource, ReloadInfo, SourceFilter};
+use crate::{ByteSource, ReloadInfo, SourceFilter};
 use log::warn;
 use parsers::{Error as ParserError, LogMessage, MessageStreamItem, Parser};
 use std::marker::PhantomData;
-use tokio::{
-    select,
-    sync::mpsc::{UnboundedReceiver, UnboundedSender},
-};
-
-pub type SdeSender = UnboundedSender<SdeMsg>;
-pub type SdeReceiver = UnboundedReceiver<SdeMsg>;
-
-enum Next {
-    Read((usize, usize, usize)),
-    Sde(Option<SdeMsg>),
-}
 
 /// Number of bytes to skip on initial parse errors before terminating the session.
 const INITIAL_PARSE_ERROR_LIMIT: usize = 1024;
@@ -36,13 +24,12 @@ where
     total_loaded: usize,
     total_skipped: usize,
     done: bool,
-    rx_sde: Option<SdeReceiver>,
     buffer: Vec<(usize, MessageStreamItem<T>)>,
 }
 
 impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
     /// create a new producer by plugging into a byte source
-    pub fn new(parser: P, source: D, rx_sde: Option<SdeReceiver>) -> Self {
+    pub fn new(parser: P, source: D) -> Self {
         MessageProducer {
             byte_source: source,
             parser,
@@ -52,7 +39,6 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
             total_loaded: 0,
             total_skipped: 0,
             done: false,
-            rx_sde,
             buffer: Vec::new(),
         }
     }
@@ -61,7 +47,8 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
     /// The caller can choose whether to consume the items or not.
     ///
     /// # Cancel Safety:
-    /// This function is cancel safe
+    /// This function is cancel safe as long [`ByteSource::load()`] method on used byte source is
+    /// safe as well.
     ///
     /// # Return:
     /// Return a mutable reference for the newly parsed items when there are more data available,
@@ -80,47 +67,9 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
             debug!("done...no next segment");
             return None;
         }
-        let (_newly_loaded, mut available, mut skipped_bytes) = 'outer: loop {
-            //TODO: Not Cancel Safe.
-            if let Some(mut rx_sde) = self.rx_sde.take() {
-                'inner: loop {
-                    // SDE mode: listening next chunk and possible incoming message for source
-                    match select! {
-                        msg = rx_sde.recv() => Next::Sde(msg),
-                        read = self.load() => Next::Read(read.unwrap_or((0, 0, 0))),
-                    } {
-                        Next::Read(next) => {
-                            self.rx_sde = Some(rx_sde);
-                            break 'outer next;
-                        }
-                        Next::Sde(msg) => {
-                            if let Some((msg, tx_response)) = msg {
-                                if tx_response
-                                    .send(
-                                        self.byte_source
-                                            .income(msg)
-                                            .await
-                                            .map_err(|e| e.to_string()),
-                                    )
-                                    .is_err()
-                                {
-                                    warn!("Fail to send back message from source");
-                                }
-                            } else {
-                                // Means - no more senders; but it isn't an error as soon as implementation of
-                                // source could just do not use a data exchanging
-                                self.rx_sde = None;
-                                // Exiting from inner loop to avoid select! and go to NoSDE mode
-                                break 'inner;
-                            }
-                        }
-                    }
-                }
-            } else {
-                // NoSDE mode: listening only next chunk
-                break 'outer self.load().await.unwrap_or((0, 0, 0));
-            };
-        };
+        let (_newly_loaded, mut available, mut skipped_bytes) =
+            self.load().await.unwrap_or((0, 0, 0));
+
         // 1. buffer loaded? if not, fill buffer with frame data
         // 2. try to parse message from buffer
         // 3a. if message, pop it of the buffer and deliver
@@ -343,10 +292,18 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
     }
 
     /// Checks if the producer have already produced any parsed items in the current session.
-    pub fn did_produce_items(&self) -> bool {
+    fn did_produce_items(&self) -> bool {
         // Produced items will be added to the internal buffer increasing its capacity.
         // This isn't straight forward way, but used to avoid having to introduce a new field
         // and keep track on its state.
         self.buffer.capacity() > 0
+    }
+
+    /// Append incoming (SDE) Source-Data-Exchange to the underline byte source data.
+    pub async fn sde_income(
+        &mut self,
+        msg: stypes::SdeRequest,
+    ) -> Result<stypes::SdeResponse, super::Error> {
+        self.byte_source.income(msg).await
     }
 }

--- a/application/apps/indexer/sources/src/producer/tests/cancel_safety.rs
+++ b/application/apps/indexer/sources/src/producer/tests/cancel_safety.rs
@@ -44,7 +44,7 @@ async fn cancel_safe_no_errors() {
         ],
     );
 
-    let mut producer = MessageProducer::new(parser, source, None);
+    let mut producer = MessageProducer::new(parser, source);
     let (cancel_tx, mut cancel_rx) = tokio::sync::mpsc::channel(32);
 
     let cancel_handel = tokio::spawn(async move {
@@ -162,7 +162,7 @@ async fn cancel_safe_incomplete() {
         ],
     );
 
-    let mut producer = MessageProducer::new(parser, source, None);
+    let mut producer = MessageProducer::new(parser, source);
     let (cancel_tx, mut cancel_rx) = tokio::sync::mpsc::channel(32);
 
     let cancel_handel = tokio::spawn(async move {
@@ -273,7 +273,7 @@ async fn cancel_safe_eof() {
         ],
     );
 
-    let mut producer = MessageProducer::new(parser, source, None);
+    let mut producer = MessageProducer::new(parser, source);
     let (cancel_tx, mut cancel_rx) = tokio::sync::mpsc::channel(32);
 
     let cancel_handel = tokio::spawn(async move {
@@ -386,7 +386,7 @@ async fn cancel_safe_parse_err_no_load() {
         ],
     );
 
-    let mut producer = MessageProducer::new(parser, source, None);
+    let mut producer = MessageProducer::new(parser, source);
     let (cancel_tx, mut cancel_rx) = tokio::sync::mpsc::channel(32);
 
     let cancel_handel = tokio::spawn(async move {
@@ -507,7 +507,7 @@ async fn cancel_safe_parse_err_with_load() {
         ],
     );
 
-    let mut producer = MessageProducer::new(parser, source, None);
+    let mut producer = MessageProducer::new(parser, source);
     let (cancel_tx, mut cancel_rx) = tokio::sync::mpsc::channel(32);
 
     let cancel_handel = tokio::spawn(async move {
@@ -618,7 +618,7 @@ async fn cancel_safe_timeout() {
         ],
     );
 
-    let mut producer = MessageProducer::new(parser, source, None);
+    let mut producer = MessageProducer::new(parser, source);
 
     let mut timeout_received = 0;
     let mut read_idx = 0;

--- a/application/apps/indexer/sources/src/producer/tests/multi_parse.rs
+++ b/application/apps/indexer/sources/src/producer/tests/multi_parse.rs
@@ -1,14 +1,12 @@
 //! Tests for parsers returning multiple values
 
 use std::collections::VecDeque;
-use std::time::Duration;
 
 use super::mock_byte_source::*;
 use super::mock_parser::*;
 use super::*;
 
 use parsers::{Error as ParseError, ParseYield};
-use tokio::sync::{mpsc::unbounded_channel, oneshot};
 
 use crate::producer::MessageProducer;
 
@@ -33,7 +31,7 @@ async fn parse_items_then_skip() {
         ],
     );
 
-    let mut producer = MessageProducer::new(parser, source, None);
+    let mut producer = MessageProducer::new(parser, source);
 
     // First results should be two messages with content
     let next = producer.read_next_segment().await.unwrap();
@@ -89,7 +87,7 @@ async fn parse_incomplete() {
         ],
     );
 
-    let mut producer = MessageProducer::new(parser, source, None);
+    let mut producer = MessageProducer::new(parser, source);
 
     // First message should be two messages with content
     let next = producer.read_next_segment().await.unwrap();
@@ -146,7 +144,7 @@ async fn success_parse_err_success() {
         ],
     );
 
-    let mut producer = MessageProducer::new(parser, source, None);
+    let mut producer = MessageProducer::new(parser, source);
 
     // First two messages succeed.
     let next = producer.read_next_segment().await.unwrap();
@@ -219,7 +217,7 @@ async fn parse_with_skipped_bytes() {
         ],
     );
 
-    let mut producer = MessageProducer::new(parser, source, None);
+    let mut producer = MessageProducer::new(parser, source);
 
     // Two Messages with content 1 should be yielded considering skipped bytes on the first item
     // only
@@ -296,7 +294,7 @@ async fn initial_parsing_error() {
 
     let source = MockByteSource::new(0, [Ok(Some(MockReloadSeed::new(LOADED_BYTES_COUNT, 0)))]);
 
-    let mut producer = MessageProducer::new(parser, source, None);
+    let mut producer = MessageProducer::new(parser, source);
 
     // Done message should be sent on initial parsing with unused bytes,
     // considering the skipped bytes.
@@ -342,7 +340,7 @@ async fn success_parse_error_success_err_skipped_bytes() {
         ],
     );
 
-    let mut producer = MessageProducer::new(parser, source, None);
+    let mut producer = MessageProducer::new(parser, source);
 
     // Two Messages with content should be yielded considering the skipped bytes on the first item
     // only with both reload calls.
@@ -390,76 +388,4 @@ async fn success_parse_error_success_err_skipped_bytes() {
     // Then the stream should be closed
     let next = producer.read_next_segment().await;
     assert!(next.is_none());
-}
-
-#[tokio::test]
-/// This function tests the sde SDE Communication in the producer loop
-async fn sde_communication() {
-    let parser = MockParser::new([Ok(vec![
-        MockParseSeed::new(4, Some(ParseYield::Message(MockMessage::from(1)))),
-        MockParseSeed::new(6, Some(ParseYield::Message(MockMessage::from(1)))),
-    ])]);
-
-    // The duration which `reload()` should wait for before delivering the data.
-    const SLEEP_DURATION: Duration = Duration::from_millis(50);
-
-    let source = MockByteSource::new(
-        0,
-        [
-            // This value must never be delivered because `reload()` on `MockByteSource`
-            // isn't cancel safe, and the value here will be dropped with the `reload()` future
-            // within the `select!()` macro in producer loop.
-            Ok(Some(
-                MockReloadSeed::new(10, 0).sleep_duration(SLEEP_DURATION),
-            )),
-            // This value should be delivered because the first one must be dropped because of the
-            // cancel safety issue
-            Ok(Some(MockReloadSeed::new(10, 0))),
-        ],
-    );
-
-    // Create producer with sde channels
-    let (tx_sde, rx_sde) = unbounded_channel();
-    let mut producer = MessageProducer::new(parser, source, Some(rx_sde));
-
-    // Send message to sde receiver before calling next.
-    let (tx_sde_response, mut rx_sde_response) = oneshot::channel();
-    const SDE_TEXT: &str = "sde_msg";
-    tx_sde
-        .send((
-            stypes::SdeRequest::WriteText(String::from(SDE_TEXT)),
-            tx_sde_response,
-        ))
-        .unwrap();
-
-    // The first source seed has a delay and won't be picked in the `select!` macro in the producer
-    // loop, and it will be dropped because `reload()` in `MockByteSource` isn't cancel safe.
-    let next = producer.read_next_segment().await.unwrap();
-    assert_eq!(next.len(), 2);
-    assert!(matches!(
-        next[0],
-        (
-            4,
-            MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
-        )
-    ));
-    assert!(matches!(
-        next[1],
-        (
-            6,
-            MessageStreamItem::Item(ParseYield::Message(MockMessage { content: 1 }))
-        )
-    ));
-
-    // Producer loop must have called `income()` and sent the message by now.
-    // The bytes length must match the sent message length as it implemented and tested in `MockByteSource`
-    let sde_response_res = rx_sde_response
-        .try_recv()
-        .expect("Sde Response must be sent by now because of the delay");
-
-    let sde_response =
-        sde_response_res.expect("`income()` method on `MockByteSource` should never fail");
-
-    // Returned bytes' length must match the length of the sent data.
-    assert_eq!(sde_response.bytes, SDE_TEXT.len());
 }

--- a/application/apps/indexer/sources/src/sde.rs
+++ b/application/apps/indexer/sources/src/sde.rs
@@ -1,4 +1,7 @@
-use tokio::sync::oneshot;
+use tokio::sync::{
+    mpsc::{UnboundedReceiver, UnboundedSender},
+    oneshot,
+};
 
 // SourceDataExchange - Sde
 // Channel allows to send message into ByteSource implementaion in run-time
@@ -6,3 +9,6 @@ pub type SdeMsg = (
     stypes::SdeRequest,
     oneshot::Sender<Result<stypes::SdeResponse, String>>,
 );
+
+pub type SdeSender = UnboundedSender<SdeMsg>;
+pub type SdeReceiver = UnboundedReceiver<SdeMsg>;

--- a/cli/chipmunk-cli/src/session/file.rs
+++ b/cli/chipmunk-cli/src/session/file.rs
@@ -35,7 +35,7 @@ where
     D: ByteSource,
     W: MessageFormatter,
 {
-    let mut producer = MessageProducer::new(parser, bytesource, None);
+    let mut producer = MessageProducer::new(parser, bytesource);
 
     let mut file_writer = create_append_file_writer(&output_path)?;
 

--- a/cli/chipmunk-cli/src/session/socket.rs
+++ b/cli/chipmunk-cli/src/session/socket.rs
@@ -37,7 +37,7 @@ where
     D: ByteSource,
     W: MessageFormatter,
 {
-    let mut producer = MessageProducer::new(parser, bytesource, None);
+    let mut producer = MessageProducer::new(parser, bytesource);
 
     let mut update_interval = tokio::time::interval(update_interval);
 


### PR DESCRIPTION
This PR close #2257 

SDE communications are special case that are used in observe sessions only and can be moved to there since producer isn't locked with stream interface anymore. 
This change won't force cancel safety on income method, and ensure that writing to serial ports byte by byte won't be interrupted.