### PR TITLE
Development CLI: Include Chipmunk CLI in release command.

### DIFF
--- a/application/apps/indexer/indexer_base/src/config.rs
+++ b/application/apps/indexer/indexer_base/src/config.rs
@@ -31,16 +31,8 @@ impl IndexSection {
     }
 
     pub fn left(&mut self, offset: usize) {
-        self.first_line = if self.first_line < offset {
-            0
-        } else {
-            self.first_line - offset
-        };
-        self.last_line = if self.last_line < offset {
-            0
-        } else {
-            self.last_line - offset
-        };
+        self.first_line = self.first_line.saturating_sub(offset);
+        self.last_line = self.last_line.saturating_sub(offset);
     }
 
     pub fn from(range: &RangeInclusive<u64>) -> Self {

--- a/application/apps/indexer/session/src/state/attachments.rs
+++ b/application/apps/indexer/session/src/state/attachments.rs
@@ -48,17 +48,13 @@ fn get_valid_file_path(dest: &Path, origin: &str) -> Result<PathBuf, io::Error> 
             .collect()
     }
     let origin_path = PathBuf::from(origin);
-    let origin_file_name = PathBuf::from(origin_path.file_name().ok_or(io::Error::new(
-        io::ErrorKind::Other,
+    let origin_file_name = PathBuf::from(origin_path.file_name().ok_or(io::Error::other(
         format!("Cannot get file name from {origin:?}"),
     ))?);
     let basename = sanitize(
         origin_file_name
             .file_stem()
-            .ok_or(io::Error::new(
-                io::ErrorKind::Other,
-                "Fail to parse origin attachment path",
-            ))?
+            .ok_or(io::Error::other("Fail to parse origin attachment path"))?
             .to_string_lossy(),
     );
     let extension = origin_file_name.extension();
@@ -82,10 +78,9 @@ fn get_valid_file_path(dest: &Path, origin: &str) -> Result<PathBuf, io::Error> 
             index += 1;
         }
         if index > FILE_NAME_INDEXES_LIMIT {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!("Cannot find suitable file name for {origin}"),
-            ));
+            return Err(io::Error::other(format!(
+                "Cannot find suitable file name for {origin}"
+            )));
         }
     }
 }

--- a/application/apps/indexer/sources/src/serial/serialport.rs
+++ b/application/apps/indexer/sources/src/serial/serialport.rs
@@ -20,10 +20,7 @@ impl Decoder for LineCodec {
         match &src.iter().position(|b| *b == b'\n') {
             Some(n) => match str::from_utf8(&src.split_to(n + 1)) {
                 Ok(s) => Ok(Some(s.to_string())),
-                Err(err) => Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("Failed to format string: {err}"),
-                )),
+                Err(err) => Err(io::Error::other(format!("Failed to format string: {err}"))),
             },
             None => Ok(None),
         }

--- a/cli/development-cli/CHANGELOG.md
+++ b/cli/development-cli/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.4.2
+
+## Changes:
+
+* Include Chipmunk CLI tool in release command.
+
 # 0.4.1
 
 ## Changes:

--- a/cli/development-cli/Cargo.lock
+++ b/cli/development-cli/Cargo.lock
@@ -159,7 +159,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cargo-chipmunk"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/development-cli/Cargo.toml
+++ b/cli/development-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chipmunk"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Ammar Abou Zor <ammar.abou.zor@accenture.com>"]
 edition = "2021"
 description = "CLI Tool for chipmunk application development"

--- a/cli/development-cli/src/release/compress.rs
+++ b/cli/development-cli/src/release/compress.rs
@@ -1,13 +1,16 @@
-//! Manages compressing the bundled Chipmunk app, providing one compressed file per platform and
-//! including the current version of Chipmunk in the file name.
+//! Manages compressing the bundled Chipmunk app and CLI tool, providing one compressed file
+//! for each per platform and including the current version of Chipmunk in the file name.
 
-use std::{fs::File, io::BufReader};
+use std::{
+    fs::{self, File},
+    io::BufReader,
+};
 
 use anyhow::{ensure, Context};
 use serde_json::Value;
 
 use crate::{
-    release::paths::{release_build_path, release_path},
+    release::paths::{cli_binary_dir, cli_binary_name, release_build_path, release_path},
     shell::shell_tokio_command,
     target::Target,
 };
@@ -64,6 +67,17 @@ pub async fn compress() -> anyhow::Result<()> {
 /// Provides the release file on the current platform, reading and adding
 /// Chipmunk version to the filename.
 pub fn release_file_name() -> anyhow::Result<String> {
+    let version = chipmunk_version().context("Error while retrieving Chipmunk version")?;
+    let prefix = os_env_prefix();
+
+    let file_name = format!("chipmunk@{version}-{prefix}-portable");
+
+    Ok(file_name)
+}
+
+/// Provides the prefix for release file names based on the operating system and
+/// the system's architecture.
+fn os_env_prefix() -> String {
     let mut prefix = if cfg!(target_os = "linux") {
         String::from("linux")
     } else if cfg!(target_os = "macos") {
@@ -82,11 +96,7 @@ pub fn release_file_name() -> anyhow::Result<String> {
         prefix.push_str("-arm64");
     }
 
-    let version = chipmunk_version().context("Error while retrieving Chipmunk version")?;
-
-    let file_name = format!("chipmunk@{version}-{prefix}-portable");
-
-    Ok(file_name)
+    prefix
 }
 
 /// Reads current Chipmunk version from `package.json` file.
@@ -121,4 +131,89 @@ fn chipmunk_version() -> anyhow::Result<String> {
             }
         })
         .context("Chipmunk version doesn't exist in json value from Electron `package.json` file.")
+}
+
+/// Compresses the bundled Chipmunk CLI on the current platform, Creating one compressed file
+/// to be used on releases.
+pub async fn compress_cli() -> anyhow::Result<()> {
+    let release_file_name = cli_release_file_name()?;
+
+    let arch_name = format!("{}.tgz", release_file_name);
+
+    let tar_cmd = format!(
+        "tar -czf {arch_name} --directory={binary_path} {binary_name}",
+        binary_path = cli_binary_dir().to_string_lossy(),
+        binary_name = cli_binary_name()
+    );
+
+    println!("Running command: '{tar_cmd}'");
+
+    // We must call the shell and pass it all the arguments at once because we are using the shell
+    // wild card `*` which can't be running without a shell.
+    let mut command = shell_tokio_command();
+
+    let cmd_status = command
+        .arg(tar_cmd)
+        .current_dir(release_path())
+        .kill_on_drop(true)
+        .status()
+        .await
+        .context("Error while running compress command")?;
+
+    ensure!(cmd_status.success(), "Release: Compress Command  failed");
+
+    let created_file_path = release_path().join(arch_name);
+
+    ensure!(
+        created_file_path.exists(),
+        "Chipmunk CLI compressed file doesn't exist. Path {}",
+        created_file_path.display()
+    );
+
+    println!(
+        "Compressed file for release successfully created: {}",
+        created_file_path.display()
+    );
+
+    Ok(())
+}
+
+/// Provides the release file name for Chipmunk CLI on the current platform.
+pub fn cli_release_file_name() -> anyhow::Result<String> {
+    let version = chipmunk_cli_version().context("Error while retrieving chipmunk cli version")?;
+    let prefix = os_env_prefix();
+
+    let file_name = format!("chipmunk-cli@{version}-{prefix}-portable");
+
+    Ok(file_name)
+}
+
+/// Reads current Chipmunk CLI version from `cargo.toml` file.
+fn chipmunk_cli_version() -> anyhow::Result<String> {
+    let cargo_path = Target::CliChipmunk.cwd().join("Cargo.toml");
+
+    ensure!(
+        cargo_path.exists(),
+        "`Cargo.toml` file doesn't exit. File path: {}",
+        cargo_path.display()
+    );
+
+    let cargo_content =
+        fs::read_to_string(&cargo_path).context("Error while reading `Cargo.toml` file")?;
+
+    let cargo_toml: toml::Value = cargo_content
+        .parse()
+        .context("Parsing content of `Cargo.toml` file failed")?;
+
+    cargo_toml
+        .get("package")
+        .and_then(|pkg| pkg.get("version"))
+        .and_then(|ver| {
+            if let toml::Value::String(version) = ver {
+                Some(version.to_owned())
+            } else {
+                None
+            }
+        })
+        .context("Enable to find Chipmunk CLI version on `Cargo.toml` file")
 }

--- a/cli/development-cli/src/release/mod.rs
+++ b/cli/development-cli/src/release/mod.rs
@@ -16,7 +16,7 @@ use std::{fs, path::PathBuf, time::Instant};
 use anyhow::{ensure, Context};
 use bundle::bundle_release;
 use codesign::CodeSign;
-use compress::compress;
+use compress::{compress, compress_cli};
 use console::style;
 use env_utls::load_from_env_file;
 use paths::release_path;
@@ -87,7 +87,7 @@ pub async fn do_release(development: bool, code_sign_path: Option<PathBuf>) -> a
     );
 
     let results = jobs_runner::run(
-        &[Target::App, Target::Updater],
+        &[Target::App, Target::Updater, Target::CliChipmunk],
         JobType::Build {
             production: !development,
         },
@@ -170,6 +170,9 @@ pub async fn do_release(development: bool, code_sign_path: Option<PathBuf>) -> a
     let compress_start = Instant::now();
 
     compress().await?;
+    compress_cli()
+        .await
+        .context("Error while compressing Chipmunk CLI binary")?;
 
     let finish_msg = format!(
         "Compressing succeeded in {} seconds.",

--- a/cli/development-cli/src/release/paths.rs
+++ b/cli/development-cli/src/release/paths.rs
@@ -72,3 +72,17 @@ pub fn release_build_dir() -> &'static str {
         );
     }
 }
+
+/// Provides the path for release directory Chipmunk CLI binary file.
+pub fn cli_binary_dir() -> PathBuf {
+    Target::CliChipmunk.cwd().join("target").join("release")
+}
+
+/// Filename of Chipmunk CLI binary file.
+pub fn cli_binary_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "chipmunk-cli.exe"
+    } else {
+        "chipmunk-cli"
+    }
+}


### PR DESCRIPTION
This PR provide the following:

* Include chipmunk CLI in release workflow providing additional archive for CLI tool with the name pattern `chipmunk-cli@{cli-version}-{platform}-portable.
* The archive of Chipmunk CLI will be provided in the same release directory to avoid changing release GitHub action.
* Code signing on MacOS still not tested.

@itsmesamster Could you please have a look on the changes for code signing and test them