### PR TITLE
Up to 3.16.5

### DIFF
--- a/application/client/package.json
+++ b/application/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chipmunk",
-  "version": "3.16.4",
+  "version": "3.16.5",
   "description": "Logs analyzer tool",
   "author": "Dmitry Astafyev",
   "scripts": {

--- a/application/holder/package.json
+++ b/application/holder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chipmunk",
-  "version": "3.16.4",
+  "version": "3.16.5",
   "chipmunk": {
     "versions": {}
   },

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+# 3.16.5 (28.03.2025)
+
+## Changes
+- Upgrade DLT parser version
+- Add TCP reconnection support
+- Refactoring to fit cancel safe requirements
+
 # 3.16.4 (21.03.2025)
 
 ## Fixes


### PR DESCRIPTION
# 3.16.5 (28.03.2025)

## Changes
- Upgrade DLT parser version
- Add TCP reconnection support
- Refactoring to fit cancel safe requirements