### PR TITLE
Plugins: Deliver Plugin Path and Configuration via toml File

### DIFF
--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -3587,6 +3587,7 @@ dependencies = [
  "tokio-serial",
  "tokio-stream",
  "tokio-util",
+ "toml",
  "uuid",
 ]
 

--- a/application/apps/indexer/plugins_host/benches/plugin_parser_init.rs
+++ b/application/apps/indexer/plugins_host/benches/plugin_parser_init.rs
@@ -1,35 +1,22 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use std::{hint::black_box, path::PathBuf};
-use stypes::{PluginConfigItem, PluginConfigValue};
+use std::hint::black_box;
 
-// Use the same environment variable for input source from other benchmarks
-pub const PLUGIN_PATH_ENV_VAR: &str = "CHIPMUNK_BENCH_SOURCE";
+mod plugin_utls;
 
 /// This benchmark covers loading, compiling and validating a parser plugin
 fn plugin_parser_init(c: &mut Criterion) {
-    let plugin_file = match std::env::var(PLUGIN_PATH_ENV_VAR) {
-        Ok(input) =>PathBuf::from(input),
-        Err(err) => panic!("Error while retrieving plugin file.\n\
-            Please ensure to provide the path of plugin file for benchmarks via command line arguments \
-            if you are using chipmunk build cli tool\n\
-            or via the environment variable: '{PLUGIN_PATH_ENV_VAR}' if you are running the benchmark directly.\n\
-            Error Info: {err}"),
-    };
+    let plug_config = plugin_utls::get_plugin_config();
 
     assert!(
-        plugin_file.exists(),
+        plug_config.binary_path.exists(),
         "Provided plugin file path doesn't exist. Path: {}",
-        plugin_file.display()
+        plug_config.binary_path.display()
     );
 
-    //TODO: Deliver plugin configurations for benchmarks.
-    //For now we are delivering hard-coded configurations of string parser plugin.
-    let plugin_configs = get_string_parser_configs();
-
     let settings = black_box(stypes::PluginParserSettings::new(
-        plugin_file,
+        plug_config.binary_path,
         stypes::PluginParserGeneralSettings::default(),
-        plugin_configs,
+        plug_config.config,
     ));
 
     c.bench_function("plugin_parser_init", |bencher| {
@@ -49,16 +36,6 @@ fn plugin_parser_init(c: &mut Criterion) {
                 black_box(&parser);
             })
     });
-}
-
-#[allow(dead_code)]
-fn get_string_parser_configs() -> Vec<PluginConfigItem> {
-    const LOSSY_ID: &str = "lossy";
-    const PREFIX_ID: &str = "prefix";
-    vec![
-        PluginConfigItem::new(LOSSY_ID, PluginConfigValue::Boolean(false)),
-        PluginConfigItem::new(PREFIX_ID, PluginConfigValue::Text(String::default())),
-    ]
 }
 
 criterion_group! {

--- a/application/apps/indexer/plugins_host/benches/plugin_utls.rs
+++ b/application/apps/indexer/plugins_host/benches/plugin_utls.rs
@@ -1,0 +1,61 @@
+#![allow(unused)]
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use stypes::{PluginConfigItem, PluginConfigValue};
+
+// Note:
+// Rust LSP may mark this as an error, but this is an issue with the LSP itself.
+// The code will compile without problems.
+
+#[path = "./../../sources/benches/bench_utls.rs"]
+mod bench_utls;
+
+/// Represents the needed configuration to run benchmarks on a plugin.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginBenchConfig {
+    /// The path for the plugin WASM file.
+    pub binary_path: PathBuf,
+    /// Configurations needed by the plugins.
+    pub config: Vec<PluginConfigItem>,
+}
+
+/// Retrieve plugin path and configurations from configuration path.
+///
+/// # Note:
+///
+/// This function expects to get the path for the plugin configurations `toml` file
+/// via bench configuration environment variable.
+pub fn get_plugin_config() -> PluginBenchConfig {
+    let config_path = bench_utls::get_config()
+        .map(PathBuf::from)
+        .expect("Path to plugin config must be provided as additional config");
+    assert!(config_path.exists(), "Config files doesn't exist");
+    let config_content =
+        std::fs::read_to_string(config_path).expect("Read plugin config file falied");
+
+    toml::from_str(&config_content).expect("Deserializing plugin config failed")
+}
+
+/// Provides the default configurations of string parser plugin hard-coded.
+pub fn get_string_parser_configs() -> Vec<PluginConfigItem> {
+    const LOSSY_ID: &str = "lossy";
+    const PREFIX_ID: &str = "prefix";
+    vec![
+        PluginConfigItem::new(LOSSY_ID, PluginConfigValue::Boolean(false)),
+        PluginConfigItem::new(PREFIX_ID, PluginConfigValue::Text(String::default())),
+    ]
+}
+
+/// Provides the default configurations of dlt parser plugin hard-coded.
+pub fn get_dlt_parser_configs() -> Vec<PluginConfigItem> {
+    const LOG_LEVEL_ID: &str = "log_level";
+    const FIBEX_ID: &str = "fibex_id";
+    const STORAGE_HEADER_ID: &str = "storage_header_id";
+    vec![
+        PluginConfigItem::new(LOG_LEVEL_ID, PluginConfigValue::Dropdown("Verbose".into())),
+        PluginConfigItem::new(FIBEX_ID, PluginConfigValue::Files(Vec::new())),
+        PluginConfigItem::new(STORAGE_HEADER_ID, PluginConfigValue::Boolean(true)),
+    ]
+}

--- a/application/apps/indexer/plugins_host/src/bytesource_shared/mod.rs
+++ b/application/apps/indexer/plugins_host/src/bytesource_shared/mod.rs
@@ -7,12 +7,12 @@ use stypes::{PluginInfo, PluginType, RenderOptions, SemanticVersion};
 use wasmtime::component::Component;
 
 use crate::{
-    plugins_shared::plugin_errors::PluginError, v0_1_0, wasm_host::get_wasm_host,
-    PluginHostInitError, WasmPlugin,
+    plugins_shared::{
+        load::{load_and_inspect, WasmComponentInfo},
+        plugin_errors::PluginError,
+    },
+    v0_1_0, PluginHostError, WasmPlugin,
 };
-
-/// Interface name for the byte-source plugin with the package name as defined in WIT file.
-const BYTESOURCE_INTERFACE_NAME: &str = "chipmunk:bytesource/byte-source";
 
 /// The maximum number of consecutive returns with empty bytes allowed from a plugin.
 /// If a plugin exceeds this number, it may be considered harmful to the system.
@@ -45,7 +45,7 @@ impl PluginsByteSource {
                 patch: 0,
             } => v0_1_0::bytesource::PluginByteSource::get_info(component).await?,
             invalid_version => {
-                return Err(PluginHostInitError::PluginInvalid(format!(
+                return Err(PluginHostError::PluginInvalid(format!(
                     "Plugin version {invalid_version} is not supported"
                 ))
                 .into())
@@ -66,44 +66,18 @@ impl PluginsByteSource {
     /// Loads and validate a plugin returning the its [`Component`] and API [`SemanticVersion`]
     async fn load(
         plugin_path: impl AsRef<Path>,
-    ) -> Result<(Component, SemanticVersion), PluginHostInitError> {
-        let engine = get_wasm_host()
-            .map(|host| &host.engine)
-            .map_err(|err| PluginHostInitError::from(err.to_owned()))?;
-        let plugin_path = plugin_path.as_ref();
+    ) -> Result<(Component, SemanticVersion), PluginHostError> {
+        let WasmComponentInfo {
+            component,
+            plugin_type,
+            version,
+        } = load_and_inspect(&plugin_path).await?;
 
-        if !plugin_path.exists() {
-            return Err(PluginHostInitError::IO("Plugin path doesn't exist".into()));
+        if plugin_type != PluginType::ByteSource {
+            return Err(PluginHostError::PluginInvalid(format!(
+                "Invalid plugin type {plugin_type}"
+            )));
         }
-
-        if !plugin_path.is_file() {
-            return Err(PluginHostInitError::IO("Plugin path is not a file".into()));
-        }
-
-        let component = Component::from_file(engine, plugin_path)
-            .map_err(|err| PluginHostInitError::PluginInvalid(err.to_string()))?;
-
-        let component_types = component.component_type();
-
-        let export_info = component_types.exports(engine).next().ok_or_else(|| {
-            PluginHostInitError::PluginInvalid("Plugin doesn't have exports information".into())
-        })?;
-
-        let (interface_name, version) = export_info.0.split_once('@').ok_or_else(|| {
-            PluginHostInitError::PluginInvalid(
-                "Plugin package schema doesn't match `wit` file definitions".into(),
-            )
-        })?;
-
-        if interface_name != BYTESOURCE_INTERFACE_NAME {
-            return Err(PluginHostInitError::PluginInvalid(
-                "Plugin package name doesn't match `wit` file".into(),
-            ));
-        }
-
-        let version: SemanticVersion = version.parse().map_err(|err| {
-            PluginHostInitError::PluginInvalid(format!("Plugin version parsing failed: {err}"))
-        })?;
 
         Ok((component, version))
     }
@@ -113,7 +87,7 @@ impl PluginsByteSource {
         plugin_path: impl AsRef<Path>,
         general_config: &stypes::PluginByteSourceGeneralSettings,
         plugin_configs: Vec<stypes::PluginConfigItem>,
-    ) -> Result<Self, PluginHostInitError> {
+    ) -> Result<Self, PluginHostError> {
         let (component, version) = Self::load(&plugin_path).await?;
 
         match version {
@@ -134,7 +108,7 @@ impl PluginsByteSource {
                     empty_count: 0,
                 })
             }
-            invalid_version => Err(PluginHostInitError::PluginInvalid(format!(
+            invalid_version => Err(PluginHostError::PluginInvalid(format!(
                 "Plugin version {invalid_version} is not supported"
             ))),
         }

--- a/application/apps/indexer/plugins_host/src/lib.rs
+++ b/application/apps/indexer/plugins_host/src/lib.rs
@@ -15,7 +15,7 @@ pub use parser_shared::{plugin_parse_message::PluginParseMessage, PluginsParser}
 
 pub use bytesource_shared::PluginsByteSource;
 
-pub use plugins_shared::plugin_errors::{PluginGuestInitError, PluginHostInitError};
+pub use plugins_shared::plugin_errors::{PluginGuestError, PluginHostError};
 use stypes::{PluginType, SemanticVersion};
 
 /// Provided needed method and definitions for all WASM plugins in Chipmunk.

--- a/application/apps/indexer/plugins_host/src/plugins_manager/cache/mod.rs
+++ b/application/apps/indexer/plugins_host/src/plugins_manager/cache/mod.rs
@@ -102,7 +102,6 @@ impl CacheManager {
         &mut self,
         plug_dir: &Path,
         state: CachedPluginState,
-        persist: bool,
     ) -> Result<(), PluginsCacheError> {
         let calculated_hash = self.calc_plugin_hash(plug_dir)?;
 
@@ -121,10 +120,6 @@ impl CacheManager {
             }
         };
 
-        if persist {
-            self.persist()?;
-        }
-
         Ok(())
     }
 
@@ -141,6 +136,29 @@ impl CacheManager {
         let mut file = File::create(cache_path)?;
         let cached_json = serde_json::to_string_pretty(self)?;
         file.write_all(cached_json.as_bytes())?;
+
+        Ok(())
+    }
+
+    /// Remove plugin from cache registry of exists with the option to persist the current cache.
+    pub fn remove_plugin(
+        &mut self,
+        plugin_dir: &Path,
+        persist: bool,
+    ) -> Result<(), PluginsCacheError> {
+        let Some(plugin_idx) = self
+            .plugins_info
+            .iter()
+            .position(|plug| plug.plugin_dir == plugin_dir)
+        else {
+            return Ok(());
+        };
+
+        let _ = self.plugins_info.remove(plugin_idx);
+
+        if persist {
+            self.persist()?;
+        }
 
         Ok(())
     }

--- a/application/apps/indexer/plugins_host/src/plugins_manager/errors.rs
+++ b/application/apps/indexer/plugins_host/src/plugins_manager/errors.rs
@@ -3,14 +3,17 @@ use std::io;
 use stypes::{NativeError, NativeErrorKind, Severity};
 use thiserror::Error;
 
-use crate::wasm_host::WasmHostInitError;
+use crate::{wasm_host::WasmHostInitError, PluginHostError};
 
 /// Plugins manager initialization Error.
 #[derive(Debug, Error)]
-pub enum InitError {
+pub enum PluginsManagerError {
     /// Errors while initializing wasm host for plugins.
     #[error("Initialization of WASM host failed. {0}")]
-    WasmHost(#[from] WasmHostInitError),
+    WasmHostInit(#[from] WasmHostInitError),
+    /// Error related to plugins host.
+    #[error("Plugins Host Error: {0}")]
+    PluginHost(#[from] PluginHostError),
     /// Errors from WASM runtime.
     #[error(transparent)]
     WasmRunTimeError(#[from] anyhow::Error),
@@ -25,8 +28,8 @@ pub enum InitError {
     Other(String),
 }
 
-impl From<InitError> for NativeError {
-    fn from(err: InitError) -> Self {
+impl From<PluginsManagerError> for NativeError {
+    fn from(err: PluginsManagerError) -> Self {
         Self {
             severity: Severity::ERROR,
             kind: NativeErrorKind::Plugins,

--- a/application/apps/indexer/plugins_host/src/plugins_manager/load.rs
+++ b/application/apps/indexer/plugins_host/src/plugins_manager/load.rs
@@ -200,7 +200,7 @@ pub async fn load_plugin(
                     .unwrap_or("Unknown");
 
                 PluginMetadata {
-                    name: dir_name.into(),
+                    title: dir_name.into(),
                     description: None,
                 }
             }
@@ -213,7 +213,7 @@ pub async fn load_plugin(
                 .unwrap_or("Unknown");
 
             PluginMetadata {
-                name: dir_name.into(),
+                title: dir_name.into(),
                 description: None,
             }
         }

--- a/application/apps/indexer/plugins_host/src/plugins_manager/mod.rs
+++ b/application/apps/indexer/plugins_host/src/plugins_manager/mod.rs
@@ -10,13 +10,16 @@ mod tests;
 
 use std::path::{Path, PathBuf};
 
+use crate::plugins_shared::load::{load_and_inspect, WasmComponentInfo};
 use cache::CacheManager;
+use load::{load_plugin, validate_plugin_files, PluginEntityState, PluginFilesStatus};
+use paths::extract_plugin_file_paths;
 use stypes::{
     ExtendedInvalidPluginEntity, ExtendedPluginEntity, InvalidPluginEntity, PluginEntity,
-    PluginRunData,
+    PluginLogLevel, PluginRunData, PluginType,
 };
 
-pub use errors::{InitError, PluginsCacheError};
+pub use errors::{PluginsCacheError, PluginsManagerError};
 
 /// Plugins manager responsible of loading the plugins, providing their states, info and metadata.
 #[derive(Debug)]
@@ -28,7 +31,7 @@ pub struct PluginsManager {
 
 impl PluginsManager {
     /// Load plugins from their directory.
-    pub async fn load() -> Result<Self, InitError> {
+    pub async fn load() -> Result<Self, PluginsManagerError> {
         let mut cache_manager = match CacheManager::load() {
             Ok(manager) => manager,
             Err(err) => {
@@ -138,7 +141,7 @@ impl PluginsManager {
     }
 
     /// Reload all the plugins from the plugins directory.
-    pub async fn reload(&mut self) -> Result<(), InitError> {
+    pub async fn reload(&mut self) -> Result<(), PluginsManagerError> {
         let Self {
             cache_manager,
             installed_plugins,
@@ -156,4 +159,166 @@ impl PluginsManager {
 
         Ok(())
     }
+
+    /// Adds a plugin with the given directory path and the optional plugin type.
+    ///
+    /// * `plugin_dir_src`: Path of the plugin directory to be copied into chipmunk plugins directory.
+    /// * `plugin_type`: Type of the plugin, when not provided plugin type will be entered from plugin
+    ///   `WIT` signature in its binary file.
+    pub async fn add_plugin(
+        &mut self,
+        plugin_dir_src: PathBuf,
+        plugin_type: Option<PluginType>,
+    ) -> Result<(), PluginsManagerError> {
+        if !plugin_dir_src.is_dir() {
+            let err_msg = format!(
+                "Plugin directory isn't a directory. Path: {}",
+                plugin_dir_src.display()
+            );
+
+            return Err(PluginsManagerError::Other(err_msg));
+        }
+
+        let plugin_name = paths::get_plugin_name(&plugin_dir_src).ok_or_else(|| {
+            PluginsManagerError::Other(format!(
+                "Extracting plugin name failed. Path: {}",
+                plugin_dir_src.display()
+            ))
+        })?;
+
+        let (wasm_path_src, metadata_path_src, readme_path_src) =
+            match validate_plugin_files(&plugin_dir_src)? {
+                PluginFilesStatus::Valid {
+                    wasm_path,
+                    metadata_file,
+                    readme_file,
+                } => (wasm_path, metadata_file, readme_file),
+                PluginFilesStatus::Invalid { err_msg } => {
+                    return Err(PluginsManagerError::Other(format!(
+                        "Plugin files are invalid: Error: {err_msg}"
+                    )));
+                }
+            };
+
+        // Retrieve plugin type from its binary if not provided.
+        let plugin_type = if let Some(plug_type) = plugin_type {
+            plug_type
+        } else {
+            let WasmComponentInfo { plugin_type, .. } = load_and_inspect(&wasm_path_src).await?;
+            plugin_type
+        };
+
+        // Check if the plugin already exist in the valid plugins.
+        // If plugin existed and invalid then we can replace it.
+        if self
+            .installed_plugins
+            .iter()
+            .filter(|plug| plug.entity.plugin_type == plugin_type)
+            .any(|plug| {
+                paths::get_plugin_name(&plug.entity.dir_path)
+                    .is_some_and(|name| name == plugin_name)
+            })
+        {
+            let err_msg =
+                format!("Installed plugin with the same name already exist. Name: '{plugin_name}'");
+            return Err(PluginsManagerError::Other(err_msg));
+        }
+
+        // Copy plugin relevant files to plugin dist directory, removing it if exists.
+        let plugin_dir_dist = plugin_root_dir(plugin_type)?.join(plugin_name);
+        if plugin_dir_dist.exists() {
+            std::fs::remove_dir_all(&plugin_dir_dist)?;
+        }
+        std::fs::create_dir_all(&plugin_dir_dist)?;
+
+        let dist_paths = extract_plugin_file_paths(&plugin_dir_dist)
+            .ok_or_else(|| PluginsManagerError::Other("Failed to extract plugin files".into()))?;
+
+        tokio::fs::copy(&wasm_path_src, &dist_paths.wasm_file).await?;
+
+        if let Some(meta_src) = &metadata_path_src {
+            tokio::fs::copy(meta_src, &dist_paths.metadata_file).await?;
+        }
+
+        if let Some(readme_src) = &readme_path_src {
+            tokio::fs::copy(readme_src, &dist_paths.readme_file).await?;
+        }
+
+        // Load plugin form its directory after copying.
+        let plugin_entity =
+            match load_plugin(plugin_dir_dist, plugin_type, &mut self.cache_manager).await? {
+                PluginEntityState::Valid(plugin_entity) => plugin_entity,
+                PluginEntityState::Invalid(invalid_entity) => {
+                    use std::fmt::Write;
+                    let mut err_msg = String::from("Invalid Plugin. Logs:\n");
+                    invalid_entity
+                        .run_data
+                        .logs
+                        .into_iter()
+                        .filter(|msg| match msg.level {
+                            PluginLogLevel::Err | PluginLogLevel::Warn => true,
+                            PluginLogLevel::Debug | PluginLogLevel::Info => false,
+                        })
+                        .for_each(|msg| {
+                            _ = writeln!(&mut err_msg, "{}", msg.msg);
+                        });
+
+                    return Err(PluginsManagerError::Other(err_msg));
+                }
+            };
+
+        self.installed_plugins.push(plugin_entity);
+
+        // Loading will update the cache manager but won't persist it.
+        self.cache_manager.persist()?;
+
+        Ok(())
+    }
+
+    pub async fn remove_plugin(&mut self, plugin_dir: &Path) -> Result<(), PluginsManagerError> {
+        if !plugin_dir.is_dir() {
+            let err_msg = format!(
+                "Plugin directory isn't a directory. Path: {}",
+                plugin_dir.display()
+            );
+
+            return Err(PluginsManagerError::Other(err_msg));
+        }
+
+        if let Some(plug_idx) = self
+            .installed_plugins
+            .iter()
+            .position(|plug| plug.entity.dir_path == plugin_dir)
+        {
+            let _ = self.installed_plugins.remove(plug_idx);
+        } else if let Some(invalid_plug_idx) = self
+            .invalid_plugins
+            .iter()
+            .position(|plug| plug.entity.dir_path == plugin_dir)
+        {
+            let _ = self.invalid_plugins.remove(invalid_plug_idx);
+        } else {
+            let err_msg = format!(
+                "Plugin can't be found in registry. Plugin directory path: {}",
+                plugin_dir.display()
+            );
+
+            return Err(PluginsManagerError::Other(err_msg));
+        }
+
+        std::fs::remove_dir_all(plugin_dir)?;
+        self.cache_manager.remove_plugin(plugin_dir, true)?;
+
+        Ok(())
+    }
+}
+
+/// Provides the root path of the plugins directory for the provided plugin type.
+fn plugin_root_dir(plug_type: PluginType) -> Result<PathBuf, PluginsManagerError> {
+    let plugins_dir = match plug_type {
+        PluginType::Parser => paths::parser_dir(),
+        PluginType::ByteSource => paths::bytesource_dir(),
+    };
+    plugins_dir
+        .ok_or_else(|| PluginsManagerError::Other(String::from("Failed to find home directory")))
 }

--- a/application/apps/indexer/plugins_host/src/plugins_manager/paths.rs
+++ b/application/apps/indexer/plugins_host/src/plugins_manager/paths.rs
@@ -73,10 +73,19 @@ impl PluginFiles {
 ///
 /// Paths for the plugin files when plugins directory is valid.
 pub fn extract_plugin_file_paths(plugin_dir: &Path) -> Option<PluginFiles> {
-    let dir_name = plugin_dir.file_name().and_then(|name| name.to_str())?;
-    let plugin_path = plugin_dir.join(format!("{dir_name}.wasm"));
-    let metadata_path = plugin_dir.join(format!("{dir_name}.toml"));
+    let plugin_name = get_plugin_name(plugin_dir)?;
+    let plugin_path = plugin_dir.join(format!("{plugin_name}.wasm"));
+    let metadata_path = plugin_dir.join(format!("{plugin_name}.toml"));
     let readme_path = plugin_dir.join(PLUGIN_README_FILENAME);
 
     Some(PluginFiles::new(plugin_path, metadata_path, readme_path))
+}
+
+/// Provide plugin name from its directory name according to conventions which
+/// stats that plugin name should be matching to the directory name.
+///
+/// # Returns:
+/// Plugin name when directory have a name, otherwise `None`
+pub fn get_plugin_name(plugin_dir: &Path) -> Option<&str> {
+    plugin_dir.file_name().and_then(|name| name.to_str())
 }

--- a/application/apps/indexer/plugins_host/src/plugins_manager/tests.rs
+++ b/application/apps/indexer/plugins_host/src/plugins_manager/tests.rs
@@ -30,7 +30,7 @@ fn create_manager() -> PluginsManager {
                 })),
             },
             metadata: PluginMetadata {
-                name: "parser_1".into(),
+                title: "parser_1".into(),
                 description: None,
             },
             readme_path: Some(PARSER_README_PATH.into()),
@@ -49,7 +49,7 @@ fn create_manager() -> PluginsManager {
                 })),
             },
             metadata: PluginMetadata {
-                name: "parser_2".into(),
+                title: "parser_2".into(),
                 description: None,
             },
             readme_path: None,
@@ -66,7 +66,7 @@ fn create_manager() -> PluginsManager {
                 render_options: RenderOptions::ByteSource,
             },
             metadata: PluginMetadata {
-                name: "source_1".into(),
+                title: "source_1".into(),
                 description: None,
             },
             readme_path: Some(SOURCE_README_PATH.into()),
@@ -83,7 +83,7 @@ fn create_manager() -> PluginsManager {
                 render_options: RenderOptions::ByteSource,
             },
             metadata: PluginMetadata {
-                name: "source_2".into(),
+                title: "source_2".into(),
                 description: None,
             },
             readme_path: None,

--- a/application/apps/indexer/plugins_host/src/plugins_shared/load.rs
+++ b/application/apps/indexer/plugins_host/src/plugins_shared/load.rs
@@ -1,0 +1,78 @@
+//! Module to handle loading plugins WASM binaries and inspecting their `WIT` infos.
+
+use std::path::Path;
+
+use stypes::{PluginType, SemanticVersion};
+use wasmtime::component::Component;
+
+use crate::{wasm_host::get_wasm_host, PluginHostError};
+
+/// Interface name for the parser plugin with the package name as defined in WIT file.
+const PARSER_INTERFACE_NAME: &str = "chipmunk:parser/parser";
+
+/// Interface name for the byte-source plugin with the package name as defined in WIT file.
+const BYTESOURCE_INTERFACE_NAME: &str = "chipmunk:bytesource/byte-source";
+
+/// Represents a WASM plugin [`Component`] alongside with extracted information from it.
+pub(crate) struct WasmComponentInfo {
+    /// The compiled component from plugin WASM file.
+    pub component: Component,
+    /// Type of the plugin.
+    pub plugin_type: PluginType,
+    /// Version of `WIT` API used within the plugin WASM file.
+    pub version: SemanticVersion,
+}
+
+/// Loads, inspect and validate a plugin returning its component alongside with
+/// extracted infos from it.
+pub(crate) async fn load_and_inspect(
+    plugin_path: impl AsRef<Path>,
+) -> Result<WasmComponentInfo, PluginHostError> {
+    let engine = get_wasm_host()
+        .map(|host| &host.engine)
+        .map_err(|err| PluginHostError::from(err.to_owned()))?;
+    let plugin_path = plugin_path.as_ref();
+
+    if !plugin_path.exists() {
+        return Err(PluginHostError::IO("Plugin path doesn't exist".into()));
+    }
+
+    if !plugin_path.is_file() {
+        return Err(PluginHostError::IO("Plugin path is not a file".into()));
+    }
+
+    let component = Component::from_file(engine, plugin_path)
+        .map_err(|err| PluginHostError::PluginInvalid(err.to_string()))?;
+
+    let component_types = component.component_type();
+
+    let export_info = component_types.exports(engine).next().ok_or_else(|| {
+        PluginHostError::PluginInvalid("Plugin doesn't have exports information".into())
+    })?;
+
+    let (interface_name, version) = export_info.0.split_once('@').ok_or_else(|| {
+        PluginHostError::PluginInvalid(
+            "Plugin package schema doesn't match `wit` file definitions".into(),
+        )
+    })?;
+
+    let plugin_type = match interface_name {
+        PARSER_INTERFACE_NAME => PluginType::Parser,
+        BYTESOURCE_INTERFACE_NAME => PluginType::ByteSource,
+        invalid => {
+            return Err(PluginHostError::PluginInvalid(format!(
+                "Unknown plugin interface name '{invalid}'",
+            )))
+        }
+    };
+
+    let version: SemanticVersion = version.parse().map_err(|err| {
+        PluginHostError::PluginInvalid(format!("Plugin version parsing failed: {err}"))
+    })?;
+
+    Ok(WasmComponentInfo {
+        component,
+        plugin_type,
+        version,
+    })
+}

--- a/application/apps/indexer/plugins_host/src/plugins_shared/mod.rs
+++ b/application/apps/indexer/plugins_host/src/plugins_shared/mod.rs
@@ -2,15 +2,16 @@ use anyhow::Context;
 use stypes::{RenderOptions, SemanticVersion};
 use wasmtime_wasi::{DirPerms, FilePerms, WasiCtxBuilder};
 
-use crate::PluginHostInitError;
+use crate::PluginHostError;
 
+pub mod load;
 pub mod plugin_errors;
 
 /// Creates [`WasiCtxBuilder`] with shared configurations, giving the plugin read access to
 /// their configuration files' directories.
 pub fn get_wasi_ctx_builder(
     plugin_configs: &[stypes::PluginConfigItem],
-) -> Result<WasiCtxBuilder, PluginHostInitError> {
+) -> Result<WasiCtxBuilder, PluginHostError> {
     use stypes::PluginConfigValue as ConfValue;
     let mut ctx = WasiCtxBuilder::new();
     ctx.inherit_stdout().inherit_stderr().inherit_env();
@@ -29,7 +30,7 @@ pub fn get_wasi_ctx_builder(
         })
         .flatten()
     {
-        let config_dir = config_path.parent().ok_or(PluginHostInitError::IO(format!(
+        let config_dir = config_path.parent().ok_or(PluginHostError::IO(format!(
             "Resolve config file parent failed. File path: {}",
             config_path.display()
         )))?;
@@ -51,7 +52,7 @@ pub fn get_wasi_ctx_builder(
     Ok(ctx)
 }
 
-// Represents the retrieved static information form parser WASM file.
+// Represents the retrieved static information form plugin WASM file.
 pub(crate) struct PluginInfo {
     /// The version of the plugins itself.
     /// # Note:

--- a/application/apps/indexer/plugins_host/src/plugins_shared/plugin_errors.rs
+++ b/application/apps/indexer/plugins_host/src/plugins_shared/plugin_errors.rs
@@ -3,9 +3,9 @@ use thiserror::Error;
 
 use crate::wasm_host::WasmHostInitError;
 
-/// Initialization error of the host of a specific plugin.
+/// Error related to plugins host.
 #[derive(Debug, Error)]
-pub enum PluginHostInitError {
+pub enum PluginHostError {
     /// Error in WASM engine host.
     #[error("Error while initializing WASM Engine. {0}")]
     EngineError(#[from] WasmHostInitError),
@@ -15,7 +15,7 @@ pub enum PluginHostInitError {
     #[error("Error reported from the plugin. {0}")]
     /// Error reported from the plugin when calling initialize method on it with
     /// the provided configurations.
-    GuestError(PluginGuestInitError),
+    GuestError(PluginGuestError),
     /// IO Error while initializing the plugin.
     #[error("IO Error while initializing WASM Plugin. {0}")]
     IO(String),
@@ -24,19 +24,19 @@ pub enum PluginHostInitError {
     WasmRunTimeError(#[from] anyhow::Error),
 }
 
-impl From<PluginHostInitError> for NativeError {
-    fn from(err: PluginHostInitError) -> Self {
+impl From<PluginHostError> for NativeError {
+    fn from(err: PluginHostError) -> Self {
         NativeError {
             severity: Severity::ERROR,
             kind: NativeErrorKind::Plugins,
-            message: Some(format!("Plugin initializations failed. Error: {err}")),
+            message: Some(format!("Plugin Host Error: {err}")),
         }
     }
 }
 
-/// Error reported from the plugin guest while calling initialization.
+/// Error reported from plugins guest.
 #[derive(Debug, Error)]
-pub enum PluginGuestInitError {
+pub enum PluginGuestError {
     /// Plugin configuration error. Configurations can be the defined one by the plugin
     /// itself or one of general configurations.
     #[error("Configuration Error: {0}")]
@@ -55,9 +55,9 @@ pub enum PluginGuestInitError {
 /// Represents general errors in communication with plugins.
 #[derive(Debug, Error)]
 pub enum PluginError {
-    /// Error while initialization wasm host for the plugin.
-    #[error("Error while initializing plugin host. {0}")]
-    HostInitError(#[from] PluginHostInitError),
+    /// Error related to plugins host.
+    #[error("Plugins Host Error: {0}")]
+    PluginHostError(#[from] PluginHostError),
     /// Error form WASM runtime.
     #[error(transparent)]
     WasmRunTimeError(#[from] anyhow::Error),

--- a/application/apps/indexer/plugins_host/src/v0_1_0/bytesource/mod.rs
+++ b/application/apps/indexer/plugins_host/src/v0_1_0/bytesource/mod.rs
@@ -18,7 +18,7 @@ use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder};
 use crate::{
     plugins_shared::{get_wasi_ctx_builder, plugin_errors::PluginError, PluginInfo},
     wasm_host::get_wasm_host,
-    PluginGuestInitError, PluginHostInitError,
+    PluginGuestError, PluginHostError,
 };
 
 /// Host of the byte-source plugin for plugins API version 0.1.0
@@ -47,7 +47,7 @@ impl PluginByteSource {
     }
 
     /// Creates a new byte-source instance without initializing it with custom configurations.
-    async fn create(component: Component, ctx: WasiCtx) -> Result<Self, PluginHostInitError> {
+    async fn create(component: Component, ctx: WasiCtx) -> Result<Self, PluginHostError> {
         let engine = get_wasm_host()
             .map(|host| &host.engine)
             .map_err(|err| err.to_owned())?;
@@ -75,7 +75,7 @@ impl PluginByteSource {
         component: Component,
         general_config: &stypes::PluginByteSourceGeneralSettings,
         plugin_configs: Vec<stypes::PluginConfigItem>,
-    ) -> Result<Self, PluginHostInitError> {
+    ) -> Result<Self, PluginHostError> {
         let mut ctx = get_wasi_ctx_builder(&plugin_configs)?;
         let ctx = ctx.build();
 
@@ -92,9 +92,7 @@ impl PluginByteSource {
                 &plugin_configs,
             )
             .await?
-            .map_err(|guest_err| {
-                PluginHostInitError::GuestError(PluginGuestInitError::from(guest_err))
-            })?;
+            .map_err(|guest_err| PluginHostError::GuestError(PluginGuestError::from(guest_err)))?;
 
         Ok(byte_source)
     }

--- a/application/apps/indexer/plugins_host/src/v0_1_0/shared/bindings.rs
+++ b/application/apps/indexer/plugins_host/src/v0_1_0/shared/bindings.rs
@@ -1,7 +1,7 @@
 use self::chipmunk::shared::shared_types::{
     ConfigItem, ConfigSchemaItem, ConfigSchemaType, ConfigValue, InitError, Version,
 };
-use crate::PluginGuestInitError;
+use crate::PluginGuestError;
 use stypes::{
     PluginConfigSchemaType as HostSchemaType, PluginConfigValue as HostConfValue,
     SemanticVersion as HostVersion,
@@ -17,9 +17,9 @@ wasmtime::component::bindgen!({
     }
 });
 
-impl From<InitError> for PluginGuestInitError {
+impl From<InitError> for PluginGuestError {
     fn from(value: InitError) -> Self {
-        use PluginGuestInitError as GuestErr;
+        use PluginGuestError as GuestErr;
         match value {
             InitError::Config(msg) => GuestErr::Config(msg),
             InitError::Io(msg) => GuestErr::IO(msg),

--- a/application/apps/indexer/session/src/unbound/api.rs
+++ b/application/apps/indexer/session/src/unbound/api.rs
@@ -307,4 +307,35 @@ impl UnboundSessionAPI {
         self.process_command(id, rx_results, Command::ReloadPlugins(tx_results))
             .await
     }
+
+    /// Adds a plugin with the given directory path and optional plugin type.
+    pub async fn add_plugin(
+        &self,
+        id: u64,
+        plugin_path: String,
+        plugin_type: Option<stypes::PluginType>,
+    ) -> Result<stypes::CommandOutcome<()>, stypes::ComputationError> {
+        let (tx_results, rx_results) = oneshot::channel();
+        self.process_command(
+            id,
+            rx_results,
+            Command::AddPlugin(plugin_path, plugin_type, tx_results),
+        )
+        .await
+    }
+
+    /// Removes the plugin with the given directory path.
+    pub async fn remove_plugin(
+        &self,
+        id: u64,
+        plugin_path: String,
+    ) -> Result<stypes::CommandOutcome<()>, stypes::ComputationError> {
+        let (tx_results, rx_results) = oneshot::channel();
+        self.process_command(
+            id,
+            rx_results,
+            Command::RemovePlugin(plugin_path, tx_results),
+        )
+        .await
+    }
 }

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -30,6 +30,7 @@ stypes = { path = "../stypes", features=["rustcore"] }
 env_logger.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
 plugins_host = {path = "../plugins_host/"}
+toml.workspace = true
 mimalloc = "0.1"
 # Jemalloc combined with Node.js exceeds the default TLS memory limit on Linux.
 tikv-jemallocator = { version = "0.6" , features = ["disable_initial_exec_tls"] }

--- a/application/apps/indexer/sources/benches/bench_utls.rs
+++ b/application/apps/indexer/sources/benches/bench_utls.rs
@@ -12,7 +12,6 @@ use std::{
 use criterion::Criterion;
 use parsers::{LogMessage, MessageStreamItem};
 use sources::{binary::raw::BinaryByteSource, producer::MessageProducer};
-use tokio_stream::StreamExt;
 
 pub const INPUT_SOURCE_ENV_VAR: &str = "CHIPMUNK_BENCH_SOURCE";
 pub const CONFIG_ENV_VAR: &str = "CHIPMUNK_BENCH_CONFIG";

--- a/application/apps/indexer/sources/benches/plugin_praser_producer.rs
+++ b/application/apps/indexer/sources/benches/plugin_praser_producer.rs
@@ -1,36 +1,38 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use plugins_host::PluginsParser;
-use std::{hint::black_box, path::PathBuf};
-use stypes::{PluginConfigItem, PluginConfigValue};
+use std::hint::black_box;
 
-use bench_utls::{
-    bench_standrad_config, create_binary_bytesource, get_config, read_binary, run_producer,
-};
+use bench_utls::{bench_standrad_config, create_binary_bytesource, read_binary, run_producer};
 use sources::producer::MessageProducer;
 
 mod bench_utls;
 
+// Note:
+// Rust LSP may mark this as an error, but this is an issue with the LSP itself.
+// The code will compile without problems.
+
+#[path = "./../../plugins_host/benches/plugin_utls.rs"]
+mod plugin_utls;
+
 /// This benchmark covers parsing the given file using a plugin parser.
-/// The path for the plugin is provided via the additional configuration environment variable.
-/// Plugin parser will run using the default prototyping configuration temporally.
+/// The path for the plugin's configurations file is provided via the additional
+/// configuration environment variable.
 fn plugin_parser_producer(c: &mut Criterion) {
     let data = read_binary();
 
-    // Additional configuration are assumed to be the path for the parser plugin binary.
-    let plugin_path = get_config()
-        .map(PathBuf::from)
-        .expect("Path to plugin must be provided as additional config");
+    let plug_config = plugin_utls::get_plugin_config();
 
-    //TODO: Deliver plugin configurations for benchmarks.
-    //For now we are delivering hard-coded configurations of string parser and DLT plugins.
-    // let plugin_configs = get_string_parser_configs();
-    let plugin_configs = get_dlt_parser_configs();
-
-    let settings = stypes::PluginParserSettings::new(
-        plugin_path,
-        stypes::PluginParserGeneralSettings::default(),
-        plugin_configs,
+    assert!(
+        plug_config.binary_path.exists(),
+        "Provided plugin file path doesn't exist. Path: {}",
+        plug_config.binary_path.display()
     );
+
+    let settings = black_box(stypes::PluginParserSettings::new(
+        plug_config.binary_path,
+        stypes::PluginParserGeneralSettings::default(),
+        plug_config.config,
+    ));
 
     c.bench_function("plugin_parser_producer", |bencher| {
         bencher
@@ -53,28 +55,6 @@ fn plugin_parser_producer(c: &mut Criterion) {
                 BatchSize::SmallInput,
             )
     });
-}
-
-#[allow(dead_code)]
-fn get_string_parser_configs() -> Vec<PluginConfigItem> {
-    const LOSSY_ID: &str = "lossy";
-    const PREFIX_ID: &str = "prefix";
-    vec![
-        PluginConfigItem::new(LOSSY_ID, PluginConfigValue::Boolean(false)),
-        PluginConfigItem::new(PREFIX_ID, PluginConfigValue::Text(String::default())),
-    ]
-}
-
-#[allow(dead_code)]
-fn get_dlt_parser_configs() -> Vec<PluginConfigItem> {
-    const LOG_LEVEL_ID: &str = "log_level";
-    const FIBEX_ID: &str = "fibex_id";
-    const STORAGE_HEADER_ID: &str = "storage_header_id";
-    vec![
-        PluginConfigItem::new(LOG_LEVEL_ID, PluginConfigValue::Dropdown("Verbose".into())),
-        PluginConfigItem::new(FIBEX_ID, PluginConfigValue::Files(Vec::new())),
-        PluginConfigItem::new(STORAGE_HEADER_ID, PluginConfigValue::Boolean(true)),
-    ]
 }
 
 criterion_group! {

--- a/application/apps/indexer/stypes/bindings/plugins.ts
+++ b/application/apps/indexer/stypes/bindings/plugins.ts
@@ -185,9 +185,9 @@ export type PluginLogMessage = {
 };
 
 /**
- * Represents the plugins metadata like name, description...
+ * Represents the plugins metadata like title, description...
  */
-export type PluginMetadata = { name: string; description: string | null };
+export type PluginMetadata = { title: string; description: string | null };
 
 /**
  * General settings for all parsers as plugins

--- a/application/apps/indexer/stypes/src/plugins/converting.rs
+++ b/application/apps/indexer/stypes/src/plugins/converting.rs
@@ -24,3 +24,21 @@ impl FromStr for SemanticVersion {
         })
     }
 }
+
+impl FromStr for PluginType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Reminder to update this function on new plugin types.
+        match Self::Parser {
+            PluginType::Parser => (),
+            PluginType::ByteSource => (),
+        }
+
+        match s {
+            "Parser" => Ok(Self::Parser),
+            "ByteSource" => Ok(Self::ByteSource),
+            invalid => Err(format!("Invalid plugin type: '{invalid}'")),
+        }
+    }
+}

--- a/application/apps/indexer/stypes/src/plugins/mod.rs
+++ b/application/apps/indexer/stypes/src/plugins/mod.rs
@@ -230,7 +230,7 @@ pub struct InvalidPluginEntity {
     pub plugin_type: PluginType,
 }
 
-/// Represents the plugins metadata like name, description...
+/// Represents the plugins metadata like title, description...
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[extend::encode_decode]
 #[cfg_attr(
@@ -239,7 +239,7 @@ pub struct InvalidPluginEntity {
     ts(export, export_to = "plugins.ts")
 )]
 pub struct PluginMetadata {
-    pub name: String,
+    pub title: String,
     pub description: Option<String>,
 }
 

--- a/application/apps/indexer/stypes/src/plugins/proptest.rs
+++ b/application/apps/indexer/stypes/src/plugins/proptest.rs
@@ -192,7 +192,7 @@ impl Arbitrary for PluginMetadata {
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         (any::<String>(), prop::option::of(any::<String>()))
-            .prop_map(|(name, description)| Self { name, description })
+            .prop_map(|(title, description)| Self { title, description })
             .boxed()
     }
 }

--- a/application/apps/rustcore/rs-bindings/src/js/jobs/mod.rs
+++ b/application/apps/rustcore/rs-bindings/src/js/jobs/mod.rs
@@ -323,6 +323,32 @@ impl UnboundJobs {
     }
 
     #[node_bindgen]
+    async fn add_plugin(
+        &self,
+        id: i64,
+        plugin_path: String,
+    ) -> Result<stypes::CommandOutcome<()>, stypes::ComputationError> {
+        self.api
+            .as_ref()
+            .ok_or(stypes::ComputationError::SessionUnavailable)?
+            .add_plugin(u64_from_i64(id)?, plugin_path, None)
+            .await
+    }
+
+    #[node_bindgen]
+    async fn remove_plugin(
+        &self,
+        id: i64,
+        plugin_path: String,
+    ) -> Result<stypes::CommandOutcome<()>, stypes::ComputationError> {
+        self.api
+            .as_ref()
+            .ok_or(stypes::ComputationError::SessionUnavailable)?
+            .remove_plugin(u64_from_i64(id)?, plugin_path)
+            .await
+    }
+
+    #[node_bindgen]
     async fn job_cancel_test(
         &self,
         id: i64,

--- a/application/apps/rustcore/ts-bindings/src/api/jobs.ts
+++ b/application/apps/rustcore/ts-bindings/src/api/jobs.ts
@@ -382,4 +382,32 @@ export class Jobs extends Base {
         );
         return job;
     }
+
+    public addPlugin(plugin_path: string): CancelablePromise<void> {
+        const sequence = this.sequence();
+        const job: CancelablePromise<void> = this.execute(
+            (buf: Uint8Array): any | Error => {
+                return decode<void>(buf, protocol.decodeCommandOutcomeWithVoid);
+            },
+            this.native.addPlugin(sequence, plugin_path),
+            sequence,
+            'addPlugin',
+        );
+
+        return job;
+    }
+
+    public removePlugin(plugin_path: string): CancelablePromise<void> {
+        const sequence = this.sequence();
+        const job: CancelablePromise<void> = this.execute(
+            (buf: Uint8Array): any | Error => {
+                return decode<void>(buf, protocol.decodeCommandOutcomeWithVoid);
+            },
+            this.native.removePlugin(sequence, plugin_path),
+            sequence,
+            `removePlugin`,
+        );
+
+        return job;
+    }
 }

--- a/application/apps/rustcore/ts-bindings/src/native/native.jobs.ts
+++ b/application/apps/rustcore/ts-bindings/src/native/native.jobs.ts
@@ -61,6 +61,8 @@ export abstract class JobsNative {
     public abstract invalidPluginsInfo(sequence: number, plugin_path: string): Promise<Uint8Array>;
     public abstract getPluginRunData(sequence: number, plugin_path: string): Promise<Uint8Array>;
     public abstract reloadPlugins(sequence: number): Promise<Uint8Array>;
+    public abstract addPlugin(sequence: number, plugin_path: string): Promise<Uint8Array>;
+    public abstract removePlugin(sequence: number, plugin_path: string): Promise<Uint8Array>;
 }
 
 interface Job {

--- a/application/client/src/app/service/plugins.ts
+++ b/application/client/src/app/service/plugins.ts
@@ -133,6 +133,34 @@ export class Service extends Implementation {
                 .catch(reject);
         });
     }
+
+    public addPlugin(pluginPath: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            Requests.IpcRequest.send(
+                Requests.Plugins.AddPlugin.Response,
+                new Requests.Plugins.AddPlugin.Request({ pluginPath }),
+            )
+                .then(() => {
+                    // To drop a cache to update list.
+                    this.ready().catch(reject).finally(resolve);
+                })
+                .catch(reject);
+        });
+    }
+
+    public removePlugin(pluginPath: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            Requests.IpcRequest.send(
+                Requests.Plugins.RemovePlugin.Response,
+                new Requests.Plugins.RemovePlugin.Request({ pluginPath }),
+            )
+                .then(() => {
+                    // To drop a cache to update list.
+                    this.ready().catch(reject).finally(resolve);
+                })
+                .catch(reject);
+        });
+    }
 }
 
 export interface Service extends Interface {}

--- a/application/client/src/app/ui/tabs/observe/parsers/general/plugin/state.ts
+++ b/application/client/src/app/ui/tabs/observe/parsers/general/plugin/state.ts
@@ -90,8 +90,8 @@ export class State extends Base {
         this.selectedParser && this.selected.emit(this.selectedParser);
     }
 
-    public getPluginName(parser: PluginEntity): string {
-        return parser.metadata?.name ?? getSafeFileName(parser.dir_path);
+    public getPluginTitle(parser: PluginEntity): string {
+        return parser.metadata?.title ?? getSafeFileName(parser.dir_path);
     }
 
     public getPluginConfigs(parser?: PluginEntity): PluginConfigSchemaItem[] {

--- a/application/client/src/app/ui/tabs/observe/state.ts
+++ b/application/client/src/app/ui/tabs/observe/state.ts
@@ -54,10 +54,10 @@ export class WrappedParserRef {
         const plugin = this.as_plugin();
         if (plugin !== undefined) {
             return {
-                major: plugin.metadata.name,
+                major: plugin.metadata.title,
                 minor: plugin.metadata.description
                     ? plugin.metadata.description
-                    : plugin.metadata.name,
+                    : plugin.metadata.title,
                 icon: undefined,
             };
         }
@@ -225,8 +225,8 @@ export class State extends Subscriber {
                     instance instanceof FileOrigin.Configuration
                         ? [instance.filename()]
                         : instance instanceof ConcatOrigin.Configuration
-                        ? instance.files()
-                        : undefined;
+                          ? instance.files()
+                          : undefined;
                 if (files === undefined) {
                     return;
                 }

--- a/application/client/src/app/ui/tabs/plugins/component.ts
+++ b/application/client/src/app/ui/tabs/plugins/component.ts
@@ -4,6 +4,7 @@ import { Initial } from '@env/decorators/initial';
 import { ChangesDetector } from '@ui/env/extentions/changes';
 import { Provider } from './provider';
 import { Target } from './list/component';
+import { bridge } from '@service/bridge';
 
 @Component({
     selector: 'app-tabs-plugins-manager',
@@ -41,6 +42,21 @@ export class PluginsManager extends ChangesDetector implements AfterContentInit,
 
     public async reload() {
         await this.provider.load(true);
+    }
+
+    public async addPlugin() {
+        await bridge
+            .folders()
+            .select()
+            .then((dirs: string[]) => {
+                if (dirs.length === 0) {
+                    return Promise.resolve();
+                }
+                return this.provider.addPlugin(dirs[0]);
+            })
+            .catch((err: Error) => {
+                console.error(`Error while opening folders: ${err.message}`);
+            });
     }
 }
 

--- a/application/client/src/app/ui/tabs/plugins/desc.ts
+++ b/application/client/src/app/ui/tabs/plugins/desc.ts
@@ -53,7 +53,7 @@ export class InstalledPluginDesc extends PluginDescription {
         } else if (!this.entity.metadata && this.path) {
             return this.path.name;
         } else if (this.entity.metadata) {
-            return this.entity.metadata.name;
+            return this.entity.metadata.title;
         } else {
             return this.entity.dir_path;
         }

--- a/application/client/src/app/ui/tabs/plugins/details/component.ts
+++ b/application/client/src/app/ui/tabs/plugins/details/component.ts
@@ -201,6 +201,13 @@ export class Details extends ChangesDetector implements AfterViewInit, AfterCont
             },
         };
     }
+
+    public async removePlugin(): Promise<void> {
+        if (this.plugin.path === undefined) {
+            return;
+        }
+        await this.provider.removePlugin(this.plugin.path.filename);
+    }
 }
 
 export interface Details extends IlcInterface {}

--- a/application/client/src/app/ui/tabs/plugins/details/template.html
+++ b/application/client/src/app/ui/tabs/plugins/details/template.html
@@ -16,7 +16,9 @@
     >
         Inspect
     </button>
-    <button class="flat-codicon-button" [disabled]="true">Remove</button>
+    <button class="flat-codicon-button" [disabled]="loading" (click)="removePlugin()">
+        Remove
+    </button>
 </div>
 <div class="readme">
     <ng-container *ngIf="loading">

--- a/application/client/src/app/ui/tabs/plugins/provider.ts
+++ b/application/client/src/app/ui/tabs/plugins/provider.ts
@@ -125,4 +125,10 @@ export class Provider {
         ].find((pl) => pl.entity.dir_path === path);
         this.subjects.get().selected.emit(path);
     }
+    public addPlugin(pluginPath: string): Promise<void> {
+        return plugins.addPlugin(pluginPath);
+    }
+    public removePlugin(pluginPath: string): Promise<void> {
+        return plugins.removePlugin(pluginPath);
+    }
 }

--- a/application/client/src/app/ui/tabs/plugins/template.html
+++ b/application/client/src/app/ui/tabs/plugins/template.html
@@ -25,7 +25,13 @@
             <mat-card>
                 <mat-card-content>
                     <div class="controlls">
-                        <button mat-stroked-button [disabled]="true">Add</button>
+                        <button
+                            mat-stroked-button
+                            [disabled]="provider.state.loading"
+                            (click)="addPlugin()"
+                        >
+                            Add
+                        </button>
                         <button
                             mat-stroked-button
                             [disabled]="provider.state.loading"

--- a/application/holder/src/service/unbound.ts
+++ b/application/holder/src/service/unbound.ts
@@ -155,6 +155,24 @@ export class Service extends Implementation {
                     RequestHandlers.Plugins.Relaod.handler,
                 ),
         );
+        this.register(
+            electron
+                .ipc()
+                .respondent(
+                    this.getName(),
+                    Requests.Plugins.AddPlugin.Request,
+                    RequestHandlers.Plugins.AddPlugin.handler,
+                ),
+        );
+        this.register(
+            electron
+                .ipc()
+                .respondent(
+                    this.getName(),
+                    Requests.Plugins.RemovePlugin.Request,
+                    RequestHandlers.Plugins.RemovePlugin.handler,
+                ),
+        );
         return Promise.resolve();
     }
 

--- a/application/holder/src/service/unbound/plugins/add_plugin.ts
+++ b/application/holder/src/service/unbound/plugins/add_plugin.ts
@@ -1,0 +1,24 @@
+import { CancelablePromise } from 'platform/env/promise';
+import { Logger } from 'platform/log';
+import { unbound } from '@service/unbound';
+
+import * as Requests from 'platform/ipc/request';
+
+export const handler = Requests.InjectLogger<
+    Requests.Plugins.AddPlugin.Request,
+    CancelablePromise<Requests.Plugins.AddPlugin.Response>
+>(
+    (
+        _log: Logger,
+        request: Requests.Plugins.AddPlugin.Request,
+    ): CancelablePromise<Requests.Plugins.AddPlugin.Response> => {
+        return new CancelablePromise((reslove, reject) => {
+            unbound.jobs
+                .addPlugin(request.pluginPath)
+                .then(() => {
+                    reslove(new Requests.Plugins.AddPlugin.Response({}));
+                })
+                .catch(reject);
+        });
+    },
+);

--- a/application/holder/src/service/unbound/plugins/index.ts
+++ b/application/holder/src/service/unbound/plugins/index.ts
@@ -6,3 +6,5 @@ export * as InstalledPluginInfo from './installed_plugin_info';
 export * as InvalidPluginInfo from './invalid_plugin_info';
 export * as PluginRunData from './rundata';
 export * as Relaod from './reload';
+export * as AddPlugin from './add_plugin';
+export * as RemovePlugin from './remove_plugin';

--- a/application/holder/src/service/unbound/plugins/remove_plugin.ts
+++ b/application/holder/src/service/unbound/plugins/remove_plugin.ts
@@ -1,0 +1,24 @@
+import { CancelablePromise } from 'platform/env/promise';
+import { Logger } from 'platform/log';
+import { unbound } from '@service/unbound';
+
+import * as Requests from 'platform/ipc/request';
+
+export const handler = Requests.InjectLogger<
+    Requests.Plugins.RemovePlugin.Request,
+    CancelablePromise<Requests.Plugins.RemovePlugin.Response>
+>(
+    (
+        _log: Logger,
+        request: Requests.Plugins.RemovePlugin.Request,
+    ): CancelablePromise<Requests.Plugins.RemovePlugin.Response> => {
+        return new CancelablePromise((reslove, reject) => {
+            unbound.jobs
+                .removePlugin(request.pluginPath)
+                .then(() => {
+                    reslove(new Requests.Plugins.RemovePlugin.Response({}));
+                })
+                .catch(reject);
+        });
+    },
+);

--- a/application/platform/ipc/request/plugins/add_plugin.ts
+++ b/application/platform/ipc/request/plugins/add_plugin.ts
@@ -1,0 +1,28 @@
+import { Define, Interface, SignatureRequirement } from '../declarations';
+
+import * as validator from '../../../env/obj';
+
+@Define({ name: 'AddPluginRequest' })
+export class Request extends SignatureRequirement {
+    public pluginPath: string;
+
+    constructor(input: { pluginPath: string }) {
+        super();
+        validator.isObject(input);
+        this.pluginPath = validator.getAsNotEmptyString(input, 'pluginPath');
+    }
+}
+export interface Request extends Interface {}
+
+@Define({ name: 'AddPluginResponse' })
+export class Response extends SignatureRequirement {
+    public error?: string;
+
+    constructor(input: { error?: string }) {
+        super();
+        validator.isObject(input);
+        this.error = validator.getAsNotEmptyStringOrAsUndefined(input, 'error');
+    }
+}
+
+export interface Response extends Interface {}

--- a/application/platform/ipc/request/plugins/index.ts
+++ b/application/platform/ipc/request/plugins/index.ts
@@ -6,3 +6,5 @@ export * as InstalledPluginInfo from './installed_plugin_info';
 export * as InvalidPluginInfo from './invalid_plugin_info';
 export * as PluginRunData from './rundata';
 export * as Reload from './reload';
+export * as AddPlugin from './add_plugin';
+export * as RemovePlugin from './remove_plugin';

--- a/application/platform/ipc/request/plugins/remove_plugin.ts
+++ b/application/platform/ipc/request/plugins/remove_plugin.ts
@@ -1,0 +1,28 @@
+import { Define, Interface, SignatureRequirement } from '../declarations';
+
+import * as validator from '../../../env/obj';
+
+@Define({ name: 'RemovePluginRequest' })
+export class Request extends SignatureRequirement {
+    public pluginPath: string;
+
+    constructor(input: { pluginPath: string }) {
+        super();
+        validator.isObject(input);
+        this.pluginPath = validator.getAsNotEmptyString(input, 'pluginPath');
+    }
+}
+export interface Request extends Interface {}
+
+@Define({ name: 'RemovePluginResponse' })
+export class Response extends SignatureRequirement {
+    public error?: string;
+
+    constructor(input: { error?: string }) {
+        super();
+        validator.isObject(input);
+        this.error = validator.getAsNotEmptyStringOrAsUndefined(input, 'error');
+    }
+}
+
+export interface Response extends Interface {}

--- a/application/platform/types/bindings/plugins.ts
+++ b/application/platform/types/bindings/plugins.ts
@@ -185,9 +185,9 @@ export type PluginLogMessage = {
 };
 
 /**
- * Represents the plugins metadata like name, description...
+ * Represents the plugins metadata like title, description...
  */
-export type PluginMetadata = { name: string; description: string | null };
+export type PluginMetadata = { title: string; description: string | null };
 
 /**
  * General settings for all parsers as plugins

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -16,7 +16,10 @@ This guide provides an overview of how to develop plugins for Chipmunk applicati
   - [Parser Plugins](#parser-plugins)
   - [Byte-Source Plugins](#byte-source-plugins)
 - [Developing Plugins in Other Languages](#developing-plugins-in-other-languages)
-- [Useful Tools](#useful-tools)
+  - [Useful Tools](#useful-tools)
+- [Plugins Benchmarking](#plugins-benchmarking)
+  - [Plugin Initialization](#plugin-initialization)
+  - [Parser Plugin](#parser-plugin)
 - [Additional Resources](#additional-resources)
 
 ---
@@ -159,6 +162,37 @@ Plugins can also be developed in any language that supports compiling to WASM wi
 #### Wit-bindgen
 
 [wit-bindgen](https://github.com/bytecodealliance/wit-bindgen) is a bindings generator for WIT and the WASM Component Model. It supports multiple languages, including Rust, C/C++, C#, and Java, and can help generate the necessary bindings from your WIT files.
+
+---
+
+## Plugins Benchmarking:
+
+Chipmunk includes several benchmarks designed to measure the performance of various tasks within your plugins. Each benchmark requires a TOML configuration file that specifies the plugin’s path and other relevant settings. You can refer to the provided templates and examples for more details on how to structure the configuration.  
+
+To run the benchmarks, you first need to install the [Chipmunk development tool](./../cli/development-cli/README.md), which is required for managing and executing these benchmarks.  
+
+Once installed, you can explore the available benchmarking options with the following command to see detailed information about each benchmark:
+```sh
+cargo chipmunk bench core --help
+```
+
+### Plugin Initialization  
+This benchmark measures how much time it takes to initialize the plugin with the provided configuration. This is useful for gauging the overhead of loading and setting up the plugin before it begins processing actual data.  
+
+To run this benchmark within the Chipmunk repository, use the following command, substituting `{path_to_plugin_config_file}` with the path to your configuration file:  
+```sh
+cargo chipmunk bench core plugin_parser_init -c {path_to_plugin_conig_file}.toml
+```
+
+### Parser Plugin:
+This benchmark is designed to evaluate the performance of parser plugins when processing input files. It simulates the real-world scenario of parsing data and allows you to measure how well the plugin performs under various conditions.  
+
+Run the benchmark with the following command, replacing `{path_to_input_file}` with the path to the file you want to parse, and `{path_to_plugin_config_file}` with the path to the corresponding configuration file:  
+
+```sh
+cargo chipmunk bench core plugin_praser_producer -i {path_to_input_file} -c {path_to_plugin_conig_file}.toml 
+```
+For a working example of a parser plugin configuration, refer to the [DLT parser config file](./examples/dlt_parser/bench_config.toml). This example will help you understand how to structure your configuration for the parser plugin.
 
 ---
 

--- a/plugins/examples/dlt_parser/bench_config.toml
+++ b/plugins/examples/dlt_parser/bench_config.toml
@@ -1,0 +1,24 @@
+# Configuration required to run the parser in Chipmunk benchmarks.
+
+# Example command to run parsing benchmarks using Chipmunk development tool
+# ```sh
+#  cargo chipmunk bench core plugin_praser_producer -i {input_file_path}.dlt -c {path_to_this_file}.toml 
+# ```
+
+# Path to the plugin WebAssembly (WASM) file.
+# Can be absolute or relative to the `indexer` directory within the Chipmunk repository.
+binary_path = "../../../../plugins/examples/dlt_parser/target/wasm32-wasip1/release/dlt_parser.wasm"
+
+# Plugin-specific configurations:
+
+[[config]]
+id = "log_level"
+value.Dropdown = "Verbose"
+
+[[config]]
+id = "fibex_id"
+value.Files = []
+
+[[config]]
+id = "storage_header_id"
+value.Boolean = true

--- a/plugins/examples/dlt_parser/dlt_parser.toml
+++ b/plugins/examples/dlt_parser/dlt_parser.toml
@@ -1,2 +1,2 @@
-name = "DLT Parser"
+title = "DLT Parser"
 description = "Example for parser plugins. It replicates the built-in parser in Chipmunk"

--- a/plugins/examples/file_source/bench_config.toml
+++ b/plugins/examples/file_source/bench_config.toml
@@ -1,0 +1,8 @@
+# Configuration required to run the byte source in Chipmunk benchmarks.
+
+# Path to the plugin WebAssembly (WASM) file.
+# Can be absolute or relative to the `indexer` directory within the Chipmunk repository.
+binary_path = "../../../../plugins/examples/file_source/target/wasm32-wasip1/release/file_source.wasm"
+
+# Plugin-specific configurations:
+# TODO:

--- a/plugins/examples/file_source/file_source.toml
+++ b/plugins/examples/file_source/file_source.toml
@@ -1,4 +1,4 @@
 # This is example of the plugin metadata file which should placed in the plugin directory 
 # next to plugin wasm file.
-name = "File Binary Source"
+title = "File Binary Source"
 description = "Example for byte-source plugins. It reads the data from the provided file as binary"

--- a/plugins/examples/protobuf/bench_config.toml
+++ b/plugins/examples/protobuf/bench_config.toml
@@ -1,0 +1,8 @@
+# Configuration required to run the parser in Chipmunk benchmarks.
+
+# Path to the plugin WebAssembly (WASM) file.
+# Can be absolute or relative to the `indexer` directory within the Chipmunk repository.
+binary_path = "../../../../plugins/examples/protobuf/target/wasm32-wasip1/release/protobuf.wasm"
+
+# Plugin-specific configurations:
+# TODO:

--- a/plugins/examples/protobuf/protobuf_parser.toml
+++ b/plugins/examples/protobuf/protobuf_parser.toml
@@ -1,2 +1,2 @@
-name = "Protobuf Parser"
+title = "Protobuf Parser"
 description = "Example for parser plugins. It replicates the built-in parser in Chipmunk"

--- a/plugins/examples/string_parser/bench_config.toml
+++ b/plugins/examples/string_parser/bench_config.toml
@@ -1,0 +1,15 @@
+# Configuration required to run the parser in Chipmunk benchmarks.
+
+# Path to the plugin WebAssembly (WASM) file.
+# Can be absolute or relative to the `indexer` directory within the Chipmunk repository.
+binary_path = "../../../../plugins/examples/string_parser/target/wasm32-wasip1/release/string_parser.wasm"
+
+# Plugin-specific configurations:
+
+[[config]]
+id = "lossy"
+value.Boolean = true
+
+[[config]]
+id = "prefix"
+value.Text = ""

--- a/plugins/examples/string_parser/string_parser.toml
+++ b/plugins/examples/string_parser/string_parser.toml
@@ -1,4 +1,4 @@
 # This is example of the plugin metadata file which should placed in the plugin directory 
 # next to plugin wasm file.
-name = "String Parser"
+title = "String Parser"
 description = "Example for parser plugins. It parses the bytes to UTF-8 strings"

--- a/plugins/templates/parser_template/bench_config.toml
+++ b/plugins/templates/parser_template/bench_config.toml
@@ -1,0 +1,16 @@
+# Configuration required to run the parser in Chipmunk benchmarks.
+
+# Path to the plugin WebAssembly (WASM) file.
+# Can be absolute or relative to the `indexer` directory within the Chipmunk repository.
+binary_path = "../../../../plugins/templates/parser_template/target/wasm32-wasip1/release/parser_template.wasm"
+
+# Plugin-specific configurations:
+
+[[config]]
+id = "my_bool_config"
+value.Boolean = true
+
+[[config]]
+id = "my_text_config"
+value.Text = "Text Config Value"
+


### PR DESCRIPTION
This PR solves one task from #2218 

It includes:
* Plugins path and configurations can be provided to plugins benchmarks via toml config files.
* Provide benchmarks config files for all example plugins and template.
* Extend plugins readme file with infos about benchmarking.