### PR TITLE
Plugins: Provide API for accessing temporary directory

### DIFF
--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -2706,6 +2706,7 @@ dependencies = [
  "futures",
  "log",
  "parsers",
+ "rand",
  "serde",
  "serde_json",
  "sources",

--- a/application/apps/indexer/plugins_host/Cargo.toml
+++ b/application/apps/indexer/plugins_host/Cargo.toml
@@ -14,6 +14,7 @@ log.workspace = true
 dirs.workspace = true
 toml.workspace = true
 blake3.workspace = true
+rand.workspace = true
 
 wasmtime = "31.0"
 wasmtime-wasi = "31.0"

--- a/application/apps/indexer/plugins_host/src/v0_1_0/bytesource/bytesource_plugin_state.rs
+++ b/application/apps/indexer/plugins_host/src/v0_1_0/bytesource/bytesource_plugin_state.rs
@@ -1,20 +1,43 @@
+use std::path::PathBuf;
+
 use wasmtime_wasi::{IoView, ResourceTable, WasiCtx, WasiView};
+
+use crate::plugins_shared::create_plug_temp_dir;
 
 use super::bindings::{
     bytesource_types::{self, Level},
-    chipmunk::shared::{logging, shared_types},
+    chipmunk::shared::{logging, sandbox, shared_types},
 };
 
 /// State to be used within wasmtime runtime store but byte-source host.
 pub struct ByteSourcePluginState {
     pub ctx: WasiCtx,
     pub table: ResourceTable,
+    temp_dir: Option<PathBuf>,
 }
 
 impl ByteSourcePluginState {
     /// Creates new [`ByteSourcePluginState`] instance from the given arguments.
     pub fn new(ctx: WasiCtx, table: ResourceTable) -> Self {
-        Self { ctx, table }
+        Self {
+            ctx,
+            table,
+            temp_dir: None,
+        }
+    }
+}
+
+impl Drop for ByteSourcePluginState {
+    fn drop(&mut self) {
+        // Remove temp directory on drop.
+        if let Some(tmp_dir) = self.temp_dir.as_ref() {
+            if let Err(err) = std::fs::remove_dir_all(tmp_dir) {
+                log::error!(
+                    "Error while removing plugin temporary directory. Path: {}, err: {err}",
+                    tmp_dir.display()
+                );
+            }
+        }
     }
 }
 
@@ -48,5 +71,20 @@ impl logging::Host for ByteSourcePluginState {
             Level::Debug => log::debug!(target: PARSER_LOG_TARGET, "{msg}"),
             Level::Trace => log::trace!(target: PARSER_LOG_TARGET, "{msg}"),
         }
+    }
+}
+
+impl sandbox::Host for ByteSourcePluginState {
+    fn temp_directory(&mut self) -> Result<String, String> {
+        if let Some(tmp_path) = self.temp_dir.as_ref() {
+            return Ok(tmp_path.to_string_lossy().to_string());
+        }
+
+        let temp_dir = create_plug_temp_dir().map_err(|err| err.to_string())?;
+        let path_as_string = temp_dir.to_string_lossy().to_string();
+
+        self.temp_dir = Some(temp_dir);
+
+        Ok(path_as_string)
     }
 }

--- a/application/apps/indexer/plugins_host/src/v0_1_0/bytesource/mod.rs
+++ b/application/apps/indexer/plugins_host/src/v0_1_0/bytesource/mod.rs
@@ -13,7 +13,7 @@ use wasmtime::{
     component::{Component, Linker},
     Store,
 };
-use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder};
+use wasmtime_wasi::{ResourceTable, WasiCtx};
 
 use crate::{
     plugins_shared::{get_wasi_ctx_builder, plugin_errors::PluginError, PluginInfo},
@@ -30,7 +30,8 @@ pub struct PluginByteSource {
 impl PluginByteSource {
     /// Load wasm file temporally to retrieve the static plugin information defined by `wit` file
     pub(crate) async fn get_info(component: Component) -> Result<PluginInfo, PluginError> {
-        let ctx = WasiCtxBuilder::new().build();
+        let mut ctx = get_wasi_ctx_builder(&[])?;
+        let ctx = ctx.build();
         let mut source = Self::create(component, ctx).await?;
 
         let version = source.plugin_version().await?;

--- a/application/apps/indexer/plugins_host/src/v0_1_0/parser/bindings.rs
+++ b/application/apps/indexer/plugins_host/src/v0_1_0/parser/bindings.rs
@@ -18,6 +18,7 @@ wasmtime::component::bindgen!({
     with: {
         "chipmunk:shared/logging@0.1.0": crate::v0_1_0::shared::logging,
         "chipmunk:shared/shared-types@0.1.0": crate::v0_1_0::shared::shared_types,
+        "chipmunk:shared/sandbox@0.1.0": crate::v0_1_0::shared::sandbox,
     }
 });
 

--- a/application/apps/indexer/plugins_host/src/v0_1_0/parser/mod.rs
+++ b/application/apps/indexer/plugins_host/src/v0_1_0/parser/mod.rs
@@ -10,7 +10,7 @@ use wasmtime::{
     component::{Component, Linker},
     Store,
 };
-use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder};
+use wasmtime_wasi::{ResourceTable, WasiCtx};
 
 use crate::{
     plugins_shared::{get_wasi_ctx_builder, plugin_errors::PluginError, PluginInfo},
@@ -29,7 +29,9 @@ pub struct PluginParser {
 impl PluginParser {
     /// Load wasm file temporally to retrieve the static plugin information defined by `wit` file
     pub(crate) async fn get_info(component: Component) -> Result<PluginInfo, PluginError> {
-        let ctx = WasiCtxBuilder::new().build();
+        let mut ctx = get_wasi_ctx_builder(&[])?;
+        let ctx = ctx.build();
+
         let mut parser = Self::create(component, ctx).await?;
 
         let version = parser.plugin_version().await?;

--- a/application/apps/indexer/plugins_host/src/v0_1_0/parser/parser_plugin_state.rs
+++ b/application/apps/indexer/plugins_host/src/v0_1_0/parser/parser_plugin_state.rs
@@ -1,21 +1,46 @@
+use std::path::PathBuf;
+
 use wasmtime_wasi::{IoView, ResourceTable, WasiCtx, WasiView};
 
-use super::bindings::chipmunk::parser::parse_types;
-use super::bindings::chipmunk::shared::{
-    logging::{self, Level},
-    shared_types,
+use crate::plugins_shared::create_plug_temp_dir;
+
+use super::bindings::chipmunk::{
+    parser::parse_types,
+    shared::{
+        logging::{self, Level},
+        sandbox, shared_types,
+    },
 };
 
 /// State to be used within wasmtime runtime store but parser host.
 pub struct ParserPluginState {
     pub ctx: WasiCtx,
     pub table: ResourceTable,
+    temp_dir: Option<PathBuf>,
 }
 
 impl ParserPluginState {
     /// Creates new [`ParserPluginState`] instance from the given arguments.
     pub fn new(ctx: WasiCtx, table: ResourceTable) -> Self {
-        Self { ctx, table }
+        Self {
+            ctx,
+            table,
+            temp_dir: None,
+        }
+    }
+}
+
+impl Drop for ParserPluginState {
+    fn drop(&mut self) {
+        // Remove temp directory on drop.
+        if let Some(tmp_dir) = self.temp_dir.as_ref() {
+            if let Err(err) = std::fs::remove_dir_all(tmp_dir) {
+                log::error!(
+                    "Error while removing plugin temporary directory. Path: {}, err: {err}",
+                    tmp_dir.display()
+                );
+            }
+        }
     }
 }
 
@@ -49,5 +74,20 @@ impl logging::Host for ParserPluginState {
             Level::Debug => log::debug!(target: PARSER_LOG_TARGET, "{msg}"),
             Level::Trace => log::trace!(target: PARSER_LOG_TARGET, "{msg}"),
         }
+    }
+}
+
+impl sandbox::Host for ParserPluginState {
+    fn temp_directory(&mut self) -> Result<String, String> {
+        if let Some(tmp_path) = self.temp_dir.as_ref() {
+            return Ok(tmp_path.to_string_lossy().to_string());
+        }
+
+        let temp_dir = create_plug_temp_dir().map_err(|err| err.to_string())?;
+        let path_as_string = temp_dir.to_string_lossy().to_string();
+
+        self.temp_dir = Some(temp_dir);
+
+        Ok(path_as_string)
     }
 }

--- a/application/apps/indexer/plugins_host/src/v0_1_0/shared/mod.rs
+++ b/application/apps/indexer/plugins_host/src/v0_1_0/shared/mod.rs
@@ -3,4 +3,5 @@
 mod bindings;
 
 pub use bindings::chipmunk::shared::logging;
+pub use bindings::chipmunk::shared::sandbox;
 pub use bindings::chipmunk::shared::shared_types;

--- a/application/apps/indexer/stypes/src/plugins/extending.rs
+++ b/application/apps/indexer/stypes/src/plugins/extending.rs
@@ -153,32 +153,32 @@ impl PluginRunData {
     /// Adds a debug-level log message.
     ///
     /// # Arguments
-    /// * `msg` - The message to log. Accepts any type that implements `AsRef<str>`.
-    pub fn debug<S: AsRef<str>>(&mut self, msg: S) {
+    /// * `msg` - The message to log. Accepts any type that implements `Into<String>`.
+    pub fn debug<S: Into<String>>(&mut self, msg: S) {
         self.logs.push(PluginLogMessage::debug(msg));
     }
 
     /// Adds an info-level log message.
     ///
     /// # Arguments
-    /// * `msg` - The message to log. Accepts any type that implements `AsRef<str>`.
-    pub fn info<S: AsRef<str>>(&mut self, msg: S) {
+    /// * `msg` - The message to log. Accepts any type that implements `Into<String>`.
+    pub fn info<S: Into<String>>(&mut self, msg: S) {
         self.logs.push(PluginLogMessage::info(msg));
     }
 
     /// Adds an error-level log message.
     ///
     /// # Arguments
-    /// * `msg` - The message to log. Accepts any type that implements `AsRef<str>`.
-    pub fn err<S: AsRef<str>>(&mut self, msg: S) {
+    /// * `msg` - The message to log. Accepts any type that implements `Into<String>`.
+    pub fn err<S: Into<String>>(&mut self, msg: S) {
         self.logs.push(PluginLogMessage::err(msg));
     }
 
     /// Adds a warning-level log message.
     ///
     /// # Arguments
-    /// * `msg` - The message to log. Accepts any type that implements `AsRef<str>`.
-    pub fn warn<S: AsRef<str>>(&mut self, msg: S) {
+    /// * `msg` - The message to log. Accepts any type that implements `Into<String>`.
+    pub fn warn<S: Into<String>>(&mut self, msg: S) {
         self.logs.push(PluginLogMessage::warn(msg));
     }
 }
@@ -197,10 +197,10 @@ impl PluginLogMessage {
     /// Creates a debug-level log message.
     ///
     /// # Arguments
-    /// * `msg` - The message to log. Accepts any type that implements `AsRef<str>`.
-    pub fn debug<S: AsRef<str>>(msg: S) -> Self {
+    /// * `msg` - The message to log. Accepts any type that implements `Into<String>`.
+    pub fn debug<S: Into<String>>(msg: S) -> Self {
         Self {
-            msg: msg.as_ref().to_string(),
+            msg: msg.into(),
             level: PluginLogLevel::Debug,
             timestamp: Self::timestamp(),
         }
@@ -209,10 +209,10 @@ impl PluginLogMessage {
     /// Creates an info-level log message.
     ///
     /// # Arguments
-    /// * `msg` - The message to log. Accepts any type that implements `AsRef<str>`.
-    pub fn info<S: AsRef<str>>(msg: S) -> Self {
+    /// * `msg` - The message to log. Accepts any type that implements `Into<String>`.
+    pub fn info<S: Into<String>>(msg: S) -> Self {
         Self {
-            msg: msg.as_ref().to_string(),
+            msg: msg.into(),
             level: PluginLogLevel::Info,
             timestamp: Self::timestamp(),
         }
@@ -221,10 +221,10 @@ impl PluginLogMessage {
     /// Creates an error-level log message.
     ///
     /// # Arguments
-    /// * `msg` - The message to log. Accepts any type that implements `AsRef<str>`.
-    pub fn err<S: AsRef<str>>(msg: S) -> Self {
+    /// * `msg` - The message to log. Accepts any type that implements `Into<String>`.
+    pub fn err<S: Into<String>>(msg: S) -> Self {
         Self {
-            msg: msg.as_ref().to_string(),
+            msg: msg.into(),
             level: PluginLogLevel::Err,
             timestamp: Self::timestamp(),
         }
@@ -233,10 +233,10 @@ impl PluginLogMessage {
     /// Creates a warning-level log message.
     ///
     /// # Arguments
-    /// * `msg` - The message to log. Accepts any type that implements `AsRef<str>`.
-    pub fn warn<S: AsRef<str>>(msg: S) -> Self {
+    /// * `msg` - The message to log. Accepts any type that implements `Into<String>`.
+    pub fn warn<S: Into<String>>(msg: S) -> Self {
         Self {
-            msg: msg.as_ref().to_string(),
+            msg: msg.into(),
             level: PluginLogLevel::Warn,
             timestamp: Self::timestamp(),
         }

--- a/application/apps/rustcore/rs-bindings/Cargo.lock
+++ b/application/apps/rustcore/rs-bindings/Cargo.lock
@@ -2555,6 +2555,7 @@ dependencies = [
  "futures",
  "log",
  "parsers",
+ "rand",
  "serde",
  "serde_json",
  "sources",

--- a/application/platform/types/observe/origin/index.ts
+++ b/application/platform/types/observe/origin/index.ts
@@ -16,8 +16,7 @@ import * as Plugin from './plugin';
 import * as Parser from '../parser';
 import * as Sde from '../sde';
 
-//TODO AAZ & Dimtry: Plugin byte source integration will be postponed
-//until parser prototype is ready.
+//TODO: Plugin byte source integration will be postponed.
 export enum Context {
     File = 'File',
     Concat = 'Concat',

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -124,7 +124,7 @@ Parser plugins receive an array of bytes, attempt to parse them, and return the 
 - Create a struct that implements to the `Parser` trait defined in the [`plugins-api`](./plugins_api/) crate.
 - Use the `parser_export!()` macro to export your parser struct.
 
-The [`plugins-api`](./plugins_api/) crate also offers helper functions for logging and configuration management.
+The [`plugins-api`](./plugins_api/) crate also offers helper functions for logging, access to temp directory and configuration management.
 
 **Integration:**  
 - Create a directory at `<HOME>/.chipmunk/plugins/parser/<plugin-name>/`.
@@ -143,7 +143,7 @@ Byte-source plugins deliver arrays of bytes of a specified length during each lo
 - Create a struct that implements to the `ByteSource` trait defined in the [`plugins-api`](./plugins_api/) crate.
 - Use the `bytesource_export!()` macro to export your byte-source struct.
 
-The [`plugins-api`](./plugins_api/) crate again provides helper functions for logging and configuration management.
+The [`plugins-api`](./plugins_api/) crate again provides helper functions for logging, access to temp directory and configuration management.
 
 **Integration:**  
 - Create a directory at `<HOME>/.chipmunk/plugins/bytesource/<plugin-name>/`.

--- a/plugins/examples/dlt_parser/src/dlt/fmt.rs
+++ b/plugins/examples/dlt_parser/src/dlt/fmt.rs
@@ -324,9 +324,6 @@ impl FormattableMessage<'_> {
         match &self.message.payload {
             PayloadContent::Verbose(arguments) => {
                 self.add_app_id_context_id_and_message_type(&mut columns);
-                //TODO AAZ: Select one approach for concatenating string with benchmarks.
-                // Skip the first memory system calls.
-                // let mut payload = String::with_capacity(8);
                 let mut payload = String::new();
                 arguments.iter().for_each(|arg| {
                     _ = write!(

--- a/plugins/examples/dlt_parser/src/lib.rs
+++ b/plugins/examples/dlt_parser/src/lib.rs
@@ -98,8 +98,8 @@ impl Parser for DltParser {
             ))
         })?;
 
-        // TODO AAZ: Filter config set to none for now. Currently we have the log level
-        // but we still need other values.
+        // Filter config won't be used within this plugin. Since its main purpose is
+        // comparing performance between plugin and native DLT parser.
         let filter_config = None;
 
         let fibex_files = config::get_as_files(FIBEX_ID, &plugins_configs)?;
@@ -111,7 +111,7 @@ impl Parser for DltParser {
             None
         };
 
-        //TODO AAZ: Format Options are skipped for now.
+        // Format options won't be used within the plugin as well.
         let fmt_options = None;
 
         Ok(Self::new(

--- a/plugins/examples/file_source/src/lib.rs
+++ b/plugins/examples/file_source/src/lib.rs
@@ -73,16 +73,8 @@ impl ByteSource for FileSource {
     }
 
     fn read(&mut self, len: usize) -> Result<Vec<u8>, SourceError> {
-        //TODO AAZ: Remove unsafe code if this binary will not used for benchmarking.
         // Initialize a vector with the given length to use as buffer for reading from the file
-        let mut buf = Vec::with_capacity(len);
-
-        // SAFETY: truncate is called on the buffer after read call with the read amount of bytes.
-        // Even with unwind after panic, this shouldn't cause undefined behavior since the vector has only bytes which
-        // don't have a special drop implementation.
-        unsafe {
-            buf.set_len(len);
-        }
+        let mut buf = vec![0; len];
 
         let bytes_read = self
             .reader

--- a/plugins/examples/string_parser/src/lib.rs
+++ b/plugins/examples/string_parser/src/lib.rs
@@ -10,6 +10,7 @@ use plugins_api::{
         Parser, ParserConfig, RenderOptions,
     },
     parser_export,
+    sandbox::temp_directory,
     shared_types::{ConfigItem, ConfigSchemaItem, ConfigSchemaType, InitError, Version},
 };
 
@@ -95,7 +96,7 @@ impl Parser for StringTokenizer {
             ConfigSchemaItem::new(
                 FLOAT_ID,
                 "Example Float",
-                Some("Configuration item with flaoting number"),
+                Some("Configuration item with floating number"),
                 ConfigSchemaType::Float(1.55),
             ),
             ConfigSchemaItem::new(
@@ -168,6 +169,16 @@ impl Parser for StringTokenizer {
             general_configs.log_level
         );
 
+        // *** Demonstrates plugins temporary directory.
+        let temp_dir = temp_directory().map_err(|err| {
+            InitError::Io(format!(
+                "Getting temp directory failed. {}",
+                err.to_string()
+            ))
+        })?;
+
+        log::info!("Plugin temp directory path: {}", temp_dir.display());
+
         // *** Configurations validation using the provided helper functions ***
         let lossy = config::get_as_boolean(LOSSY_ID, &plugins_configs)?;
 
@@ -185,7 +196,7 @@ impl Parser for StringTokenizer {
                 DIRS_ID => println!("Dirs config value is: {:?}", item.value),
                 DROPDOWN_ID => println!("Drop-Down config value is: {:?}", item.value),
                 unknown => {
-                    let error_msg = format!("Unknow configuration ID: {unknown}");
+                    let error_msg = format!("Unknown configuration ID: {unknown}");
                     return Err(InitError::Config(error_msg));
                 }
             }

--- a/plugins/examples/string_parser/src/lib.rs
+++ b/plugins/examples/string_parser/src/lib.rs
@@ -14,9 +14,11 @@ use plugins_api::{
     shared_types::{ConfigItem, ConfigSchemaItem, ConfigSchemaType, InitError, Version},
 };
 
+// IDs for configurations needed for this plugin.
 const LOSSY_ID: &str = "lossy";
 const PREFIX_ID: &str = "prefix";
-// TODO AAZ: Remove after debugging.
+
+// IDs for configurations used as show-case only.
 const INTEGER_ID: &str = "integer_idx";
 const FLOAT_ID: &str = "float_idx";
 const FILES_ID: &str = "files_idx";
@@ -129,7 +131,7 @@ impl Parser for StringTokenizer {
     }
 
     fn get_render_options() -> RenderOptions {
-        // Demonstration of render options.
+        // *** Demonstration of render options ***
         let columns = vec![
             ColumnInfo::new("Length", "The length of the log message", 30),
             ColumnInfo::new("Message", "The log message", -1),

--- a/plugins/plugins_api/README.md
+++ b/plugins/plugins_api/README.md
@@ -1,11 +1,10 @@
-<!--TODO AAZ: Update links once merged into master by removing `plugins_support`-->
 # Chipmunk Plugins API Crate
 
 This crate simplifies the development of plugins for [Chipmunk](https://github.com/esrlabs/chipmunk) in Rust.  
 
 Chipmunk supports plugins using [WebAssembly (Wasm)](https://webassembly.org/) and the [WebAssembly Component Model](https://component-model.bytecodealliance.org/). It exposes its public API via the [WASM Interface Format (WIT)](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md), enabling developers to write plugins in any language that supports Wasm and the Component Model.
 
-For a detailed guide on developing plugins, refer to the [Plugins Development Guide](https://github.com/esrlabs/chipmunk/blob/plugins_support/plugins/README.md).
+For a detailed guide on developing plugins, refer to the [Plugins Development Guide](https://github.com/esrlabs/chipmunk/blob/master/plugins/README.md).
 
 ## What This Crate Provides
 
@@ -24,7 +23,7 @@ Each plugin type is associated with a feature in this crate. A feature must be e
 * To develop a parser plugin, enable the `parser` feature in `Cargo.toml`.
 * Implement `Parser` trait on your struct to define a parser plugin.
 * Use `parser_export!()` macro with your struct to generate the necessary bindings for integration with Chipmunk.
-* Please refer to the [examples](https://github.com/esrlabs/chipmunk/blob/plugins_support/plugins/examples) and [parser template](https://github.com/esrlabs/chipmunk/blob/plugins_support/plugins/templates/parser_template) provided in Chipmunk repo to get started.
+* Please refer to the [examples](https://github.com/esrlabs/chipmunk/blob/master/plugins/examples) and [parser template](https://github.com/esrlabs/chipmunk/blob/master/plugins/templates/parser_template) provided in Chipmunk repo to get started.
 
 
 ### Byte-Source Plugins:
@@ -35,4 +34,4 @@ Each plugin type is associated with a feature in this crate. A feature must be e
 * Implement `ByteSource` trait on your struct to define a byte-source plugin.
 * Use `bytesource_export!()` macro with your struct to generate the necessary bindings for integration with Chipmunk.
 <!--TODO: Update here once template for byte-source is done. -->
-* Please refer to the [examples](https://github.com/esrlabs/chipmunk/blob/plugins_support/plugins/examples) provided in Chipmunk repo to get started.
+* Please refer to the [examples](https://github.com/esrlabs/chipmunk/blob/master/plugins/examples) provided in Chipmunk repo to get started.

--- a/plugins/plugins_api/src/bytesource/mod.rs
+++ b/plugins/plugins_api/src/bytesource/mod.rs
@@ -10,6 +10,7 @@ pub mod __internal_bindings {
         with: {
             "chipmunk:shared/logging@0.1.0": crate::logging,
             "chipmunk:shared/shared-types@0.1.0": crate::shared_types,
+            "chipmunk:shared/sandbox@0.1.0": crate::sandbox,
         },
         additional_derives: [Clone],
         // Export macro is used withing the exported `bytesource_export!` macro and must be public

--- a/plugins/plugins_api/src/lib.rs
+++ b/plugins/plugins_api/src/lib.rs
@@ -10,7 +10,7 @@
 mod shared;
 pub use shared::{
     chipmunk::shared::{logging, shared_types},
-    config,
+    config, sandbox,
 };
 
 /// Contains re-exported logging macros from [`log`] crate to be used inside the plugins.

--- a/plugins/plugins_api/src/parser/mod.rs
+++ b/plugins/plugins_api/src/parser/mod.rs
@@ -15,6 +15,7 @@ pub mod __internal_bindings {
         with: {
             "chipmunk:shared/logging@0.1.0": crate::logging,
             "chipmunk:shared/shared-types@0.1.0": crate::shared_types,
+            "chipmunk:shared/sandbox@0.1.0": crate::sandbox,
         },
         additional_derives: [Clone],
         // Export macro is used withing the exported `parser_export!` macro and must be public

--- a/plugins/plugins_api/src/shared/mod.rs
+++ b/plugins/plugins_api/src/shared/mod.rs
@@ -3,6 +3,7 @@
 pub mod config;
 pub mod logging;
 pub mod plugin_logger;
+pub mod sandbox;
 
 wit_bindgen::generate!({
     path: "wit/v0.1.0",

--- a/plugins/plugins_api/src/shared/sandbox.rs
+++ b/plugins/plugins_api/src/shared/sandbox.rs
@@ -1,0 +1,13 @@
+//! Provides a sandboxed environment for managing temporary resources.  
+use std::path::PathBuf;
+
+/// Creates a temporary directory and returns its path when successful.
+///
+/// The directory is accessible for both reading and writing.
+/// It is automatically deleted when the session ends.
+pub fn temp_directory() -> Result<PathBuf, std::io::Error> {
+    match super::chipmunk::shared::sandbox::temp_directory() {
+        Ok(path) => Ok(path.into()),
+        Err(err_msg) => Err(std::io::Error::other(err_msg)),
+    }
+}

--- a/plugins/plugins_api/wit/v0.1.0/deps/bytesource/world.wit
+++ b/plugins/plugins_api/wit/v0.1.0/deps/bytesource/world.wit
@@ -5,6 +5,7 @@ package chipmunk:bytesource@0.1.0;
 /// implemented with the byte-sources plugins.
 world bytesource {
   import chipmunk:shared/logging@0.1.0;
+  import chipmunk:shared/sandbox@0.1.0;
 
   export byte-source;
 }

--- a/plugins/plugins_api/wit/v0.1.0/deps/parser/world.wit
+++ b/plugins/plugins_api/wit/v0.1.0/deps/parser/world.wit
@@ -5,6 +5,7 @@ package chipmunk:parser@0.1.0;
 /// implemented with the parser plugins.
 world parse {
   import chipmunk:shared/logging@0.1.0;
+  import chipmunk:shared/sandbox@0.1.0;
 
   export parser;
 }

--- a/plugins/plugins_api/wit/v0.1.0/deps/shared/sandbox.wit
+++ b/plugins/plugins_api/wit/v0.1.0/deps/shared/sandbox.wit
@@ -1,0 +1,13 @@
+package chipmunk:shared@0.1.0;
+
+/// Provides a sandboxed environment for managing temporary resources.  
+interface sandbox {  
+  /// Creates a temporary directory and returns its path.
+  ///
+  /// The directory is accessible for both reading and writing.
+  /// It is automatically deleted when the session ends.
+  ///
+  /// Returns an error string if the directory cannot be created due to an I/O error.  
+  temp-directory: func() -> result<string, string>;
+}
+

--- a/plugins/plugins_api/wit/v0.1.0/deps/shared/world.wit
+++ b/plugins/plugins_api/wit/v0.1.0/deps/shared/world.wit
@@ -6,4 +6,5 @@ package chipmunk:shared@0.1.0;
 world bindings {
   import shared-types;
   import logging;
+  import sandbox;
 }


### PR DESCRIPTION
This PR closes #2237 

It includes:
* Providing method from the host to creates a temporary directory for the plugins on each session with read and write access.
* Wrap the method with better types in `plugins_api` crate for plugins developers.
* Demonstrate the functionality in string parser example.
* Update plugins README
* Final refactoring & Resolve todos