### PR TITLE
Trait `SingleParser` with blank implementation for Parser

### DIFF
--- a/application/apps/indexer/addons/dlt-tools/src/lib.rs
+++ b/application/apps/indexer/addons/dlt-tools/src/lib.rs
@@ -42,6 +42,7 @@ pub async fn scan_dlt_ft(
                 None,
                 with_storage_header,
             );
+
             let mut producer = MessageProducer::new(parser, source);
 
             let mut canceled = false;


### PR DESCRIPTION
This PR closes #2260 

It includes:
* Providing a trait for parsers who parse one item at a time to be used with the current built-in parsers. 
* The new trait `SingleParser` provides blanket implementation for Parser trait with all types implementing it.
* Apply the new trait on all built-in parsers adjusting their unit tests accordingly.