### PR TITLE
Plugins: Minor Changes & Refactoring & Cleanup

### DIFF
--- a/application/apps/indexer/session/src/handlers/export_raw.rs
+++ b/application/apps/indexer/session/src/handlers/export_raw.rs
@@ -134,10 +134,6 @@ async fn export<S: ByteSource>(
 ) -> Result<Option<usize>, stypes::NativeError> {
     match parser {
         stypes::ParserType::Plugin(settings) => {
-            println!("------------------------------------------------------");
-            println!("-------------    WASM parser used    -----------------");
-            println!("------------------------------------------------------");
-            println!("DEBUG: Plugin Path: {}", settings.plugin_path.display());
             let parser = PluginsParser::initialize(
                 &settings.plugin_path,
                 &settings.general_settings,

--- a/application/apps/indexer/session/src/handlers/observing/mod.rs
+++ b/application/apps/indexer/session/src/handlers/observing/mod.rs
@@ -134,7 +134,6 @@ async fn run_producer<T: LogMessage, P: Parser<T>, S: ByteSource>(
     operation_api.processing();
     let cancel = operation_api.cancellation_token();
     let cancel_on_tail = cancel.clone();
-    let timer = std::time::Instant::now();
     while let Some(next) = select! {
         next_from_stream = async {
             match timeout(Duration::from_millis(FLUSH_TIMEOUT_IN_MS as u64), producer.read_next_segment()).await {
@@ -185,17 +184,6 @@ async fn run_producer<T: LogMessage, P: Parser<T>, S: ByteSource>(
                         }
                         MessageStreamItem::Done => {
                             trace!("observe, message stream is done");
-
-                            //TODO AAZ: Remove benchmarks when not needed anymore.
-                            let elapsed = timer.elapsed();
-                            println!("---------------------------------------------------------");
-                            println!("---------------------------------------------------------");
-                            println!("---------------------------------------------------------");
-                            println!("File Read Took: {}", elapsed.as_millis());
-                            println!("---------------------------------------------------------");
-                            println!("---------------------------------------------------------");
-                            println!("---------------------------------------------------------");
-
                             state.flush_session_file().await?;
                             state.file_read().await?;
                         }

--- a/application/apps/indexer/sources/src/producer.rs
+++ b/application/apps/indexer/sources/src/producer.rs
@@ -206,6 +206,7 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
                     }
                 }
                 Err(ParserError::Unrecoverable(err)) => {
+                    //TODO: Errors like this must be visible to users.
                     // Current producer loop swallows the errors after logging them,
                     // returning that the session is ended after encountering such errors.
                     error!("Parsing failed: Error {err}");

--- a/plugins/examples/dlt_parser/Cargo.lock
+++ b/plugins/examples/dlt_parser/Cargo.lock
@@ -113,29 +113,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "derive_more"
-version = "0.99.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn",
-]
 
 [[package]]
 name = "displaydoc"
@@ -150,19 +131,17 @@ dependencies = [
 
 [[package]]
 name = "dlt-core"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b304e32f1164b8c2ef1dc746b32d321f25f88a32672f0f5bcba2df0f70a3b70"
+checksum = "b17be7d54b4bb66239b48be3d87f94fa75ff8afa0d072a92c34c9291075e4580"
 dependencies = [
  "byteorder",
  "bytes",
- "derive_more",
- "lazy_static",
+ "futures",
  "log",
  "memchr",
  "nom",
  "quick-xml",
- "rustc-hash",
  "thiserror",
 ]
 
@@ -504,12 +483,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,21 +696,6 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustversion"

--- a/plugins/examples/dlt_parser/Cargo.toml
+++ b/plugins/examples/dlt_parser/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Ammar Abou Zor <ammar.abou.zor@accenture.com>"]
 description = "An example of a Chipmunk parser that replicate the dlt parser that is built-in into Chipmunk"
 
 [dependencies]
-plugins_api = {path = "../../plugins_api", features = ["parser"]}
-dlt-core = "0.18"
+plugins_api = {path = "../../plugins_api", features = ["parser"] }
+dlt-core = { version = "0.20", features = ["fibex"] }
 chrono = "0.4"
 chrono-tz = "0.10"
 humantime = "2.1"

--- a/plugins/examples/dlt_parser/src/dlt/mod.rs
+++ b/plugins/examples/dlt_parser/src/dlt/mod.rs
@@ -39,9 +39,7 @@ impl DltParser {
 
 fn dlt_error_into_parse(error: DltParseError) -> ParseError {
     match error {
-        DltParseError::Unrecoverable(e) | DltParseError::ParsingHickup(e) => {
-            ParseError::Unrecoverable(e)
-        }
+        DltParseError::Unrecoverable(e) | DltParseError::ParsingHickup(e) => ParseError::Parse(e),
         DltParseError::IncompleteParse { needed: _ } => ParseError::Incomplete,
     }
 }


### PR DESCRIPTION
This PR:
* Differentiate max allowed consecutive errors limit between parse and incomplete errors after making producer loop dropping one byte at a time for parse errors. For the same reason limits has been increased
* Remove all debug and benchmarking code and all remaining TODOs.
* Dlt plugin: Fix error mapping since dlt unrecoverable error has different meaning in the plugin context.
* Reference latest version of dlt_core in DLT plugin