### PR TITLE
Up to 3.16.6

### DIFF
--- a/application/client/package.json
+++ b/application/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chipmunk",
-  "version": "3.16.5",
+  "version": "3.16.6",
   "description": "Logs analyzer tool",
   "author": "Dmitry Astafyev",
   "scripts": {

--- a/application/holder/package.json
+++ b/application/holder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chipmunk",
-  "version": "3.16.5",
+  "version": "3.16.6",
   "chipmunk": {
     "versions": {}
   },

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 ## Changes
 - Refactoring an infrastructure of parsers
 
+# 3.16.5 (28.03.2025)
+
 ## Changes
 - Upgrade DLT parser version
 - Add TCP reconnection support

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,10 @@
-# 3.16.5 (28.03.2025)
+# 3.16.6 (06.04.2025)
+
+## Fixes
+- Fix sticky scrolling issue
+
+## Changes
+- Refactoring an infrastructure of parsers
 
 ## Changes
 - Upgrade DLT parser version


### PR DESCRIPTION
# 3.16.6 (06.04.2025)

## Fixes
- Fix sticky scrolling issue

## Changes
- Refactoring an infrastructure of parsers