### PR TITLE
Adding time measures in dev mode

### DIFF
--- a/application/apps/indexer/session/src/lib.rs
+++ b/application/apps/indexer/session/src/lib.rs
@@ -8,7 +8,7 @@ pub mod tail;
 pub mod tracker;
 pub mod unbound;
 
-use std::sync::Mutex;
+use std::{env, sync::Mutex, time::Instant};
 use tokio::sync::mpsc;
 
 extern crate lazy_static;
@@ -21,4 +21,32 @@ lazy_static::lazy_static! {
         let (tx, rx) = mpsc::unbounded_channel();
         Mutex::new((tx, Some(rx)))
     };
+}
+
+/// A Timer that can be used to monitor performance in dev-mode.
+struct Timer<'a> {
+    what: &'a str,
+    start: Option<Instant>,
+}
+
+impl<'a> Timer<'a> {
+    /// Creates a new timer.
+    fn new(what: &'a str) -> Self {
+        Timer {
+            what,
+            start: if env::var("CHIPMUNK_DEVELOPING_MODE").is_ok() {
+                Some(std::time::Instant::now())
+            } else {
+                None
+            },
+        }
+    }
+
+    /// Prints timer result to console if dev-mode is on.
+    fn done(&mut self) {
+        if let Some(time) = self.start {
+            println!("🕑 {} took: {:?}", self.what, time.elapsed());
+            self.start = None;
+        }
+    }
 }

--- a/application/apps/indexer/session/src/unbound/commands/dlt.rs
+++ b/application/apps/indexer/session/src/unbound/commands/dlt.rs
@@ -14,6 +14,7 @@ pub fn stats(
 ) -> Result<stypes::CommandOutcome<stypes::DltStatisticInfo>, stypes::ComputationError> {
     let mut stat = StatisticInfo::new();
     let mut error: Option<String> = None;
+    let mut timer = crate::Timer::new("collect statistics");
     file_paths.iter().for_each(|file_path| {
         if error.is_some() {
             return;
@@ -37,6 +38,7 @@ pub fn stats(
             }
         }
     });
+    timer.done();
     if let Some(err) = error {
         return Err(stypes::ComputationError::IoOperation(err));
     }


### PR DESCRIPTION
This PR adds time measures to console output for statistics and message producer in unbound session, if developing-mode is enabled with: `export CHIPMUNK_DEVELOPING_MODE=on`