### PR TITLE
Plugins & Core: Add developer documentation & Small Fix

### DIFF
--- a/application/apps/indexer/docs/README.md
+++ b/application/apps/indexer/docs/README.md
@@ -1,0 +1,6 @@
+# Chipmunk Core Documentation:
+
+This document serves as a comprehensive guide to the code architecture of the **Chipmunk Core**. It is intended for developers who wish to understand how Chipmunk processes log data, the relationships between its main components, and how to contribute to its development. Below you will find links to detailed documentation for key architectural areas within the core.
+
+- [Producer](./producer.md)
+- [Plugins](./plugins.md)

--- a/application/apps/indexer/docs/plugins.md
+++ b/application/apps/indexer/docs/plugins.md
@@ -1,0 +1,43 @@
+# Plugins in Chipmunk Host:
+
+The Chipmunk core supports plugins built with WebAssembly and the Component Model, utilizing the `wasmtime` runtime for compiling and loading plugin binaries.
+
+For a visual representation of the plugins and how they are connected within the data ingestion pipeline, please refer to the [diagram](./producer-plugins.drawio).
+
+## Plugins Runtime
+
+Chipmunk utilizes a single `wasmtime` runtime engine that is shared by all loaded plugins and the core plugin management logic. This design aligns with the recommended usage pattern for `wasmtime`.
+
+This shared runtime is very reliable. If a plugin crashes or has an error (panics), it won't crash the main runtime or stop other plugins or tasks that are running.
+
+## Plugins Manager
+
+The `PluginsManager` is a central component responsible for the life cycle of all available plugins. Its duties include scanning, loading, validating, and managing the metadata and configuration of plugins. It also provides functionality for adding and removing plugins without requiring manual file operations by the user.
+
+On startup, the `PluginsManager` scans the designated plugins directory (`<HOME>/.chipmunk/plugins`). It attempts to load and validate the WebAssembly binaries found there and extract essential information like versions and configuration schemas directly from the binaries' metadata.
+
+To optimize startup performance, the `PluginsManager` employs a caching mechanism. After the initial scan, extracted plugin metadata, configurations, and a hash of the binary are saved to a cache file (located within the plugins directory). On subsequent runs, unchanged plugins are loaded directly from this cache, avoiding the need to recompile and re-extract their information from the binary. The cache can typically be invalidated or reloaded via a UI action.
+
+The `PluginsManager` keeps track of all loaded plugins, their current state, and configurations, making them available to the rest of the Chipmunk application, such as providing loaded plugins to the `UnboundSession` view in the UI.
+
+## Plugin Hosts (Parser and Byte-Source)
+
+For each activated plugin instance (Parser or Byte-Source), a corresponding host-side "Plugin Host" struct is created. These host structs act as wrappers, encapsulating all communication with the Wasm plugin binary and managing aspects specific to that plugin type and its API version.
+
+### Parser Plugin Host
+
+The Parser Plugin Host specifically manages interactions with a Wasm Parser plugin. It internally handles communication across the Wasm boundary and translates between the plugin's version-specific data types (defined by the WIT contract for that API version) and the general data types used throughout Chipmunk. It encapsulates support for different API versions, potentially by containing version-specific bindings or logic. This host is responsible for loading and validating its specific plugin binary instance and implementing the host functions (like logging, temporary directory access) that the Wasm plugin may call. It delivers the parsed items received from the plugin according to the `Parser` trait contract used within Chipmunk.
+
+### Byte-Source Plugin Host
+
+Similar to the Parser Plugin Host, the Byte-Source Plugin Host encapsulates communication and version management for a Wasm Byte-Source plugin. Its implementation, however, leverages Chipmunk's internal `BinaryByteSource` helper struct.
+
+The host-side Byte-Source Plugin struct implements the standard Rust `Read` trait. This implementation is responsible for communicating with the Wasm plugin binary to poll and retrieve chunks of raw bytes whenever the host needs more data.
+
+Chipmunk provides a generic struct, `BinaryByteSource`, which is designed to wrap any type that implements the `std::io::Read` trait. The Byte-Source Plugin Host utilizes `BinaryByteSource`, wrapping its own `Read` implementation within it. This allows `BinaryByteSource` to provide the full implementation of the `ByteSource` trait automatically, handling complexities like offset management and stream positioning.
+
+This design ensures that the plugin developer's responsibility is focused on delivering raw bytes when requested via the WASM API (translated to the host's `Read` calls), while the host-side `BinaryByteSource` manages the lower-level details of byte-source behavior and stream management.
+
+## Async Runtime Integration
+
+`Wasmtime` needs a system to handle async tasks when talking to plugins, even in sync environment it will spawn its own tokio runtime and block on it. Chipmunk already uses `Tokio` for its own async tasks. By turning on a setting in our `wasmtime` code, we tell it to use Chipmunk's `Tokio` system instead of starting its own separate one. This helps things run smoothly and keeps all async tasks working together efficiently.

--- a/application/apps/indexer/docs/producer-plugins.drawio
+++ b/application/apps/indexer/docs/producer-plugins.drawio
@@ -1,0 +1,214 @@
+<mxfile host="Electron" agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/26.2.15 Chrome/134.0.6998.205 Electron/35.2.1 Safari/537.36" version="26.2.15">
+  <diagram id="10rGNm2G9dO2MdtsBHka" name="Page-1">
+    <mxGraphModel dx="2421" dy="1412" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="HwE0Uis-9YOzALKcXGha-4" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="HwE0Uis-9YOzALKcXGha-1" target="HwE0Uis-9YOzALKcXGha-5" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="120" y="440" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-1" value="Message Producer&amp;nbsp;" style="swimlane;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+          <mxGeometry x="210" y="340" width="200" height="180" as="geometry" />
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-2" value="Parser" style="rounded=0;whiteSpace=wrap;html=1;" parent="HwE0Uis-9YOzALKcXGha-1" vertex="1">
+          <mxGeometry x="35" y="50" width="130" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-3" value="Byte-Source" style="rounded=0;whiteSpace=wrap;html=1;" parent="HwE0Uis-9YOzALKcXGha-1" vertex="1">
+          <mxGeometry x="35" y="110" width="130" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-5" value="&lt;b&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Sessions&lt;/font&gt;&lt;/b&gt;" style="ellipse;shape=cloud;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+          <mxGeometry x="30" y="385" width="130" height="90" as="geometry" />
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="HwE0Uis-9YOzALKcXGha-2" target="HwE0Uis-9YOzALKcXGha-8" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="530" y="210" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-32" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="HwE0Uis-9YOzALKcXGha-8" target="HwE0Uis-9YOzALKcXGha-33" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="800" y="280" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="700" y="220" />
+              <mxPoint x="700" y="335" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-25" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="HwE0Uis-9YOzALKcXGha-8" target="HwE0Uis-9YOzALKcXGha-28">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="700" y="220" />
+              <mxPoint x="700" y="117" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-26" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="HwE0Uis-9YOzALKcXGha-8" target="HwE0Uis-9YOzALKcXGha-23">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="700" y="220" />
+              <mxPoint x="700" y="40" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-8" value="Parser Trait" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+          <mxGeometry x="510" y="190" width="140" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-9" value="Parse(bytes) -&amp;gt; Items" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" parent="HwE0Uis-9YOzALKcXGha-8" vertex="1">
+          <mxGeometry y="30" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-27" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="HwE0Uis-9YOzALKcXGha-13" target="r193wCqsOFdQ62rSLlC8-11">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-28" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="HwE0Uis-9YOzALKcXGha-13" target="r193wCqsOFdQ62rSLlC8-12">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-29" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="HwE0Uis-9YOzALKcXGha-13" target="r193wCqsOFdQ62rSLlC8-13">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-30" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="HwE0Uis-9YOzALKcXGha-13" target="r193wCqsOFdQ62rSLlC8-19">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-31" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="HwE0Uis-9YOzALKcXGha-13" target="r193wCqsOFdQ62rSLlC8-22">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-32" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="HwE0Uis-9YOzALKcXGha-13" target="r193wCqsOFdQ62rSLlC8-21">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-34" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="HwE0Uis-9YOzALKcXGha-13" target="r193wCqsOFdQ62rSLlC8-15">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-13" value="Byte-Source Trait" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=30;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+          <mxGeometry x="510" y="590" width="140" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-14" value="current_slice()-&amp;gt;&amp;amp;[u8]" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" parent="HwE0Uis-9YOzALKcXGha-13" vertex="1">
+          <mxGeometry y="30" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-15" value="(async) load()" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" parent="HwE0Uis-9YOzALKcXGha-13" vertex="1">
+          <mxGeometry y="60" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-16" value="consume()" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" parent="HwE0Uis-9YOzALKcXGha-13" vertex="1">
+          <mxGeometry y="90" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-18" value="(async) sde_income()" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" parent="HwE0Uis-9YOzALKcXGha-13" vertex="1">
+          <mxGeometry y="120" width="140" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-12" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" parent="1" source="HwE0Uis-9YOzALKcXGha-3" target="HwE0Uis-9YOzALKcXGha-13" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="580" y="620" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-31" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1.002;exitY=0.419;exitDx=0;exitDy=0;exitPerimeter=0;" parent="1" source="HwE0Uis-9YOzALKcXGha-8" target="HwE0Uis-9YOzALKcXGha-30" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="650" y="220" />
+              <mxPoint x="700" y="220" />
+              <mxPoint x="700" y="190" />
+            </Array>
+            <mxPoint x="700" y="115.02857142857135" as="sourcePoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-23" value="DLT" style="rounded=1;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+          <mxGeometry x="740" y="20" width="110" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-28" value="&lt;div&gt;SomeIP&lt;/div&gt;" style="whiteSpace=wrap;html=1;rounded=1;" parent="1" vertex="1">
+          <mxGeometry x="740" y="95" width="110" height="45" as="geometry" />
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-30" value="String Tokenizer" style="whiteSpace=wrap;html=1;rounded=1;" parent="1" vertex="1">
+          <mxGeometry x="740" y="170" width="110" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-2" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1" source="HwE0Uis-9YOzALKcXGha-33" target="r193wCqsOFdQ62rSLlC8-1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="920" y="335" />
+              <mxPoint x="920" y="290" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="HwE0Uis-9YOzALKcXGha-33" value="Parser Plugins&amp;nbsp;&lt;div&gt;Host&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+          <mxGeometry x="740" y="310" width="110" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-1" value="API Version&amp;nbsp;&lt;div&gt;0.1.0&lt;/div&gt;" style="whiteSpace=wrap;html=1;rounded=1;" vertex="1" parent="1">
+          <mxGeometry x="970" y="270" width="100" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-3" value="API Version&amp;nbsp;&lt;div&gt;...&lt;/div&gt;" style="whiteSpace=wrap;html=1;rounded=1;" vertex="1" parent="1">
+          <mxGeometry x="970" y="360" width="100" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-4" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" target="r193wCqsOFdQ62rSLlC8-3" parent="1" source="HwE0Uis-9YOzALKcXGha-33">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="850" y="405" as="sourcePoint" />
+            <Array as="points">
+              <mxPoint x="920" y="335" />
+              <mxPoint x="920" y="380" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-11" value="BinaryByteSource&lt;div&gt;(Binary Files)&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="750" y="480" width="130" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-12" value="&lt;div&gt;TCP&lt;/div&gt;" style="whiteSpace=wrap;html=1;rounded=1;" vertex="1" parent="1">
+          <mxGeometry x="750" y="555" width="130" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-13" value="UDB" style="whiteSpace=wrap;html=1;rounded=1;" vertex="1" parent="1">
+          <mxGeometry x="750" y="630" width="130" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-14" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" source="r193wCqsOFdQ62rSLlC8-15" target="r193wCqsOFdQ62rSLlC8-16" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="920" y="985" />
+              <mxPoint x="920" y="960" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-15" value="Byte-Source&lt;div&gt;Plugins Host&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="750" y="960" width="130" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-16" value="API Version&amp;nbsp;&lt;div&gt;0.1.0&lt;/div&gt;" style="whiteSpace=wrap;html=1;rounded=1;" vertex="1" parent="1">
+          <mxGeometry x="970" y="940" width="100" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-17" value="API Version&amp;nbsp;&lt;div&gt;...&lt;/div&gt;" style="whiteSpace=wrap;html=1;rounded=1;" vertex="1" parent="1">
+          <mxGeometry x="970" y="1010" width="100" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-18" value="" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" source="r193wCqsOFdQ62rSLlC8-15" target="r193wCqsOFdQ62rSLlC8-17" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="860" y="1055" as="sourcePoint" />
+            <Array as="points">
+              <mxPoint x="920" y="985" />
+              <mxPoint x="920" y="1030" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-19" value="Process Command" style="whiteSpace=wrap;html=1;rounded=1;" vertex="1" parent="1">
+          <mxGeometry x="750" y="705" width="130" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-21" value="PCap Legacy" style="whiteSpace=wrap;html=1;rounded=1;" vertex="1" parent="1">
+          <mxGeometry x="750" y="850" width="130" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-22" value="PCapNG" style="whiteSpace=wrap;html=1;rounded=1;" vertex="1" parent="1">
+          <mxGeometry x="750" y="775" width="130" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-35" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&lt;b&gt;WasmTime Runtime&lt;/b&gt;&lt;/font&gt;&lt;div&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&lt;b&gt;Engine&lt;/b&gt;&lt;/font&gt;&lt;/div&gt;&lt;div&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&lt;b&gt;(Single Instance)&lt;/b&gt;&lt;/font&gt;&lt;/div&gt;" style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;" vertex="1" parent="1">
+          <mxGeometry x="1160" y="595" width="170" height="130" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-39" value="" style="endArrow=none;dashed=1;html=1;rounded=0;exitX=1;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;startArrow=classic;startFill=1;" edge="1" parent="1" source="HwE0Uis-9YOzALKcXGha-33" target="r193wCqsOFdQ62rSLlC8-35">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1030" y="690" as="sourcePoint" />
+            <mxPoint x="1080" y="640" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-40" value="" style="endArrow=none;dashed=1;html=1;rounded=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0;exitDx=0;exitDy=0;startArrow=classic;startFill=1;" edge="1" parent="1" source="r193wCqsOFdQ62rSLlC8-15" target="r193wCqsOFdQ62rSLlC8-35">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="960" y="810" as="sourcePoint" />
+            <mxPoint x="1080" y="685" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-42" value="&lt;b&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Plugins Manager&lt;/font&gt;&lt;/b&gt;" style="ellipse;shape=cloud;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="1310" y="330" width="210" height="115" as="geometry" />
+        </mxCell>
+        <mxCell id="r193wCqsOFdQ62rSLlC8-44" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.55;entryY=0.95;entryDx=0;entryDy=0;entryPerimeter=0;dashed=1;" edge="1" parent="1" source="r193wCqsOFdQ62rSLlC8-35" target="r193wCqsOFdQ62rSLlC8-42">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/application/apps/indexer/docs/producer.md
+++ b/application/apps/indexer/docs/producer.md
@@ -1,0 +1,24 @@
+# Message Producer
+
+The `MessageProducer` struct serves as a key component within the Chipmunk core, responsible for orchestrating the data ingestion pipeline. Its primary role is to connect a source providing raw bytes (implementing the `ByteSource` trait) with a mechanism for interpreting those bytes (implementing the `Parser` trait), managing the entire cycle from polling data to parsing it and delivering the results for further processing within Chipmunk.
+
+The `MessageProducer` is designed to be generic over different implementations of the `ByteSource` and `Parser` traits, allowing for flexible combinations of data sources and parsing formats based on specific session requirements.
+
+Implementations for `ByteSource` and `Parser` can be either **built-in** components provided by the Chipmunk core or provided dynamically via the **plugin system** based on WebAssembly and the Component Model.
+
+Chipmunk currently includes the following built-in parsers:
+
+- DLT
+- SomeIP
+- StringTokenizer
+
+And a variety of built-in byte-sources:
+
+- BinaryByteSource (For files with binary format)
+- TCP
+- UDP
+- Process Commands
+- PCapNG
+- PCap Legacy
+
+For a visual representation of how the Message Producer connects Byte Sources and Parsers, please refer to the [diagram](./producer-plugins.drawio).


### PR DESCRIPTION
This PR provides developer documentation in Chipmunk Core for the following:
* Message Producer structs and its relations with multiple parser and byte-sources traits.
* Plugins implementation in Chipmunk host.
* A diagram with `drawio` demonstrating Message Producer with all parsers and byte-sources (Built-in and Plugins) and The plugins Manager and Runtime

This PR also provides a small fix to avoid giving read access to the same directory multiple time in a case of multiple files sharing the same parent directory that are needed by the plugin  