### PR TITLE
Core: Remove unsafe code blocks & Add TODOs

### DIFF
--- a/application/apps/indexer/parsers/src/dlt/fmt.rs
+++ b/application/apps/indexer/parsers/src/dlt/fmt.rs
@@ -42,13 +42,6 @@ pub const DLT_COLUMN_SENTINAL: char = '\u{0004}';
 /// Separator to used between the arguments in the payload of DLT [`FormattableMessage`].
 pub const DLT_ARGUMENT_SENTINAL: char = '\u{0005}';
 
-const DLT_NEWLINE_SENTINAL_SLICE: &[u8] = &[0x6];
-
-lazy_static::lazy_static! {
-    static ref DLT_NEWLINE_SENTINAL_STR: &'static str =
-        unsafe { str::from_utf8_unchecked(DLT_NEWLINE_SENTINAL_SLICE) };
-}
-
 fn try_new_from_fibex_message_info(message_info: &str) -> Option<MessageType> {
     Some(MessageType::Log(match message_info {
         "DLT_LOG_FATAL" => LogLevel::Fatal,

--- a/application/apps/indexer/parsers/src/someip.rs
+++ b/application/apps/indexer/parsers/src/someip.rs
@@ -111,6 +111,7 @@ impl FibexMetadata {
     }
 }
 
+//TODO: Unsafe without Safety comments.
 unsafe impl Send for FibexMetadata {}
 unsafe impl Sync for FibexMetadata {}
 
@@ -277,9 +278,6 @@ impl SomeipParser {
         }
     }
 }
-
-unsafe impl Send for SomeipParser {}
-unsafe impl Sync for SomeipParser {}
 
 impl SingleParser<SomeipLogMessage> for SomeipParser {
     const MIN_MSG_LEN: usize = MIN_MSG_LEN;

--- a/application/apps/indexer/sources/src/serial/serialport.rs
+++ b/application/apps/indexer/sources/src/serial/serialport.rs
@@ -219,12 +219,6 @@ impl ByteSource for SerialSource {
     }
 }
 
-#[cfg(target_os = "windows")]
-unsafe impl Send for SerialSource {}
-
-#[cfg(target_os = "windows")]
-unsafe impl Sync for SerialSource {}
-
 /*
 #[tokio::test]
 async fn test_serial() {


### PR DESCRIPTION
This PR is a draft until it's tested on Windows.

I scanned the source code in Chipmunk core for unsafe blocks that aren't documented and change the following:
- Unsafe blocks that aren't needed anymore has be removed.
- TODO has been added for an undocumented unsafe code block in SomeIP & DLT parsers used to implement `Send` and `Sync` for metadata struct. I assume that this code could produce an undefined behavior because the error message mention using `Rc<RefCell<>>` within the struct which can't be Send and Sync