### PR TITLE
Dev CLI: Fix Arguments Conflict & Unit Test for CLI Arguments

### DIFF
--- a/cli/development-cli/CHANGELOG.md
+++ b/cli/development-cli/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.5.2
+
+## Fixes:
+
+* Remove short-form CLI arguments for skipping environment checks to prevent conflicts with other arguments.
+
 # 0.5.1
 
 ## Changes:

--- a/cli/development-cli/Cargo.lock
+++ b/cli/development-cli/Cargo.lock
@@ -159,7 +159,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cargo-chipmunk"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/development-cli/Cargo.toml
+++ b/cli/development-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-chipmunk"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Ammar Abou Zor <ammar.abou.zor@accenture.com>"]
 edition = "2024"
 description = "CLI Tool for chipmunk application development"

--- a/cli/development-cli/src/cli_args.rs
+++ b/cli/development-cli/src/cli_args.rs
@@ -235,3 +235,15 @@ pub enum UserConfigCommand {
     /// Creates user configurations file if doesn't exist then writes the default configurations to it.
     WriteDefaultToFile,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Ensure the CLI configurations are valid.
+    #[test]
+    fn verify_cli() {
+        use clap::CommandFactory;
+        CargoCli::command().debug_assert();
+    }
+}

--- a/cli/development-cli/src/cli_args.rs
+++ b/cli/development-cli/src/cli_args.rs
@@ -98,7 +98,7 @@ pub enum Command {
         #[arg(short, long, help = UI_LOG_OPTION_HELP_TEXT, value_enum)]
         ui_mode: Option<UiMode>,
 
-        #[arg(short, long, help = SKIP_ENV_CHECKS_TEXT, default_value_t = false)]
+        #[arg(long = "skip-check", help = SKIP_ENV_CHECKS_TEXT, default_value_t = false)]
         skip_env_checks: bool,
     },
     /// Build all or the specified targets
@@ -117,7 +117,7 @@ pub enum Command {
         #[arg(short, long, help = UI_LOG_OPTION_HELP_TEXT, value_enum)]
         ui_mode: Option<UiMode>,
 
-        #[arg(short, long, help = SKIP_ENV_CHECKS_TEXT, default_value_t = false)]
+        #[arg(long = "skip-check", help = SKIP_ENV_CHECKS_TEXT, default_value_t = false)]
         skip_env_checks: bool,
 
         #[arg(short, long, help = ADDITIONAL_FEATURES_HELP_TEXT)]
@@ -132,7 +132,7 @@ pub enum Command {
         #[arg(short, long, help = UI_LOG_OPTION_HELP_TEXT, value_enum)]
         ui_mode: Option<UiMode>,
 
-        #[arg(short, long, help = SKIP_ENV_CHECKS_TEXT, default_value_t = false)]
+        #[arg(long = "skip-check", help = SKIP_ENV_CHECKS_TEXT, default_value_t = false)]
         skip_env_checks: bool,
     },
     /// Run tests for all or the specified targets
@@ -151,7 +151,7 @@ pub enum Command {
         #[arg(short, long, help = UI_LOG_OPTION_HELP_TEXT, value_enum)]
         ui_mode: Option<UiMode>,
 
-        #[arg(short, long, help = SKIP_ENV_CHECKS_TEXT, default_value_t = false)]
+        #[arg(long = "skip-check", help = SKIP_ENV_CHECKS_TEXT, default_value_t = false)]
         skip_env_checks: bool,
 
         /// Accepts the new results in all snapshot tests.
@@ -175,7 +175,7 @@ pub enum Command {
         #[arg(short, long, help = UI_LOG_OPTION_HELP_TEXT, value_enum)]
         ui_mode: Option<UiMode>,
 
-        #[arg(short, long, help = SKIP_ENV_CHECKS_TEXT, default_value_t = false)]
+        #[arg(long = "skip-check", help = SKIP_ENV_CHECKS_TEXT, default_value_t = false)]
         skip_env_checks: bool,
 
         #[arg(short, long, help = ADDITIONAL_FEATURES_HELP_TEXT)]


### PR DESCRIPTION
This PR provide the following:
* The short-form of the CLI argument for skip environment checks `-s` conflicts with the short one for test `spces` on the command test.
* The short form is removed on all commands to keep it consistent and to avoid introducing breaking changes on test command.
* Add unit test to verify that the defined CLI arguments and commands are valid and don't have any conflicts.