### PR TITLE
Core: Fix Warnings in Cargo.toml File after update to 2024

### DIFF
--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-edition = "2024"
+resolver = "3"
 
 members = [
     "addons/dlt-tools",
@@ -55,6 +55,13 @@ proptest = "1.6"
 insta.opt-level = 3
 similar.opt-level = 3
 
+# Proptest and its random number generator can be CPU intensive, therefore setting their optimizations level 
+# to max will have significant performance improvement for the tests.
+[profile.test.package.proptest]
+opt-level = 3
+
+[profile.test.package.rand_chacha]
+opt-level = 3
 
 # only uncomment when profiling
 # [profile.release]

--- a/application/apps/indexer/stypes/Cargo.toml
+++ b/application/apps/indexer/stypes/Cargo.toml
@@ -44,10 +44,3 @@ uuid = { workspace = true, features = ["serde", "v4"] }
 remove_dir_all = "1.0"
 ts-rs = { version = "10.1", features = ["uuid-impl"] }
 
-# Proptest and its random number generator can be CPU intensive, therefore setting their optimizations level 
-# to max will have significant performance improvement for the tests.
-[profile.test.package.proptest]
-opt-level = 3
-
-[profile.test.package.rand_chacha]
-opt-level = 3


### PR DESCRIPTION
This PR fixes warnings on cargo.toml files level. Those updates weren't visible in development cli tool so we didn't catch them.

It provides:
* Workspace doesn't have edition config. However it demands to specify which resolve to use.
* Move Proptest profiles configurations because they are allowed on workspace root level only