### PR TITLE
Plugins: Validate plugins against invalid or malicious configurations 

### DIFF
--- a/application/apps/indexer/plugins_host/src/plugins_manager/load.rs
+++ b/application/apps/indexer/plugins_host/src/plugins_manager/load.rs
@@ -1,7 +1,7 @@
 use std::{
     fs::{self, read_to_string},
     io,
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 
 use stypes::{
@@ -9,9 +9,12 @@ use stypes::{
     PluginRunData,
 };
 
+use crate::plugins_manager::validator::{
+    PluginFilesStatus, validate_plugin_info, validate_plugins_metadata,
+};
 use crate::{
     PluginHostError, PluginType, PluginsByteSource, PluginsParser,
-    plugins_manager::paths::extract_plugin_file_paths, plugins_shared::plugin_errors::PluginError,
+    plugins_manager::validator::validate_plugin_files, plugins_shared::plugin_errors::PluginError,
 };
 
 use super::{
@@ -129,13 +132,7 @@ pub async fn load_plugin(
 
             rd.err(err_msg);
             return Ok(PluginEntityState::Invalid(
-                ExtendedInvalidPluginEntity::new(
-                    InvalidPluginEntity {
-                        dir_path: plug_dir,
-                        plugin_type: plug_type,
-                    },
-                    rd,
-                ),
+                ExtendedInvalidPluginEntity::new(InvalidPluginEntity::new(plug_dir, plug_type), rd),
             ));
         }
     };
@@ -156,10 +153,7 @@ pub async fn load_plugin(
                 rd.err(err_msg);
                 return Ok(PluginEntityState::Invalid(
                     ExtendedInvalidPluginEntity::new(
-                        InvalidPluginEntity {
-                            dir_path: plug_dir,
-                            plugin_type: plug_type,
-                        },
+                        InvalidPluginEntity::new(plug_dir, plug_type),
                         rd,
                     ),
                 ));
@@ -171,12 +165,8 @@ pub async fn load_plugin(
             PluginType::ByteSource => PluginsByteSource::get_info(wasm_file).await,
         };
 
-        match plug_info_res {
-            Ok(info) => {
-                cache_manager
-                    .update_plugin(&plug_dir, cache::CachedPluginState::Installed(info.clone()))?;
-                info
-            }
+        let info = match plug_info_res {
+            Ok(info) => info,
             // Stop the whole loading on engine errors
             Err(PluginError::PluginHostError(PluginHostError::EngineError(err))) => {
                 return Err(err.into());
@@ -190,10 +180,30 @@ pub async fn load_plugin(
                     .update_plugin(&plug_dir, cache::CachedPluginState::Invalid(err_msg))?;
                 return Ok(PluginEntityState::Invalid(
                     ExtendedInvalidPluginEntity::new(
-                        InvalidPluginEntity {
-                            dir_path: plug_dir,
-                            plugin_type: plug_type,
-                        },
+                        InvalidPluginEntity::new(plug_dir, plug_type),
+                        rd,
+                    ),
+                ));
+            }
+        };
+
+        match validate_plugin_info(&info) {
+            Ok(()) => {
+                cache_manager
+                    .update_plugin(&plug_dir, cache::CachedPluginState::Installed(info.clone()))?;
+                info
+            }
+            Err(err) => {
+                let err_msg = format!("Validating plugin infos failed. Error: {err}");
+                log::warn!("{err_msg}");
+                rd.err(&err_msg);
+
+                cache_manager
+                    .update_plugin(&plug_dir, cache::CachedPluginState::Invalid(err_msg))?;
+
+                return Ok(PluginEntityState::Invalid(
+                    ExtendedInvalidPluginEntity::new(
+                        InvalidPluginEntity::new(plug_dir, plug_type),
                         rd,
                     ),
                 ));
@@ -201,40 +211,44 @@ pub async fn load_plugin(
         }
     };
 
-    let plug_metadata = match metadata_file {
+    let plug_metadata_opt = match metadata_file {
         Some(file) => match parse_metadata(&file) {
-            Ok(metadata) => {
-                rd.info("Metadata file found and load");
-                metadata
-            }
+            Ok(metadata) => match validate_plugins_metadata(&metadata) {
+                Ok(()) => {
+                    rd.info("Metadata file found and load");
+                    Some(metadata)
+                }
+                Err(err) => {
+                    let err_msg = format!("Plugins metadata are invalid. Error: {err}");
+                    log::warn!("{err_msg}");
+                    rd.warn(err_msg);
+                    None
+                }
+            },
             Err(err_msg) => {
                 rd.err(format!(
                     "Parsing metadata file failed with error: {err_msg}"
                 ));
-                let dir_name = plug_dir
-                    .file_name()
-                    .and_then(|p| p.to_str())
-                    .unwrap_or("Unknown");
-
-                PluginMetadata {
-                    title: dir_name.into(),
-                    description: None,
-                }
+                None
             }
         },
         None => {
             rd.warn("Metadata file not found");
-            let dir_name = plug_dir
-                .file_name()
-                .and_then(|p| p.to_str())
-                .unwrap_or("Unknown");
-
-            PluginMetadata {
-                title: dir_name.into(),
-                description: None,
-            }
+            None
         }
     };
+
+    let plug_metadata = plug_metadata_opt.unwrap_or_else(|| {
+        let dir_name = plug_dir
+            .file_name()
+            .and_then(|p| p.to_str())
+            .unwrap_or("Unknown");
+
+        PluginMetadata {
+            title: dir_name.into(),
+            description: None,
+        }
+    });
 
     rd.info("Plugin has been load, checked and accepted");
     Ok(PluginEntityState::Valid(ExtendedPluginEntity::new(
@@ -256,79 +270,6 @@ fn get_dirs(dir_path: &PathBuf) -> Result<impl Iterator<Item = PathBuf>, io::Err
         .filter(|path| path.is_dir());
 
     Ok(dirs)
-}
-
-/// Represents the result of scanning a plugin directory,  
-/// providing details about detected files and validation status.
-#[derive(Debug, Clone)]
-pub enum PluginFilesStatus {
-    /// Represents valid plugin with its infos and metadata.
-    Valid {
-        /// The path for the plugin wasm file.
-        wasm_path: PathBuf,
-        /// Metadata of the plugins found in plugins metadata toml file.
-        metadata_file: Option<PathBuf>,
-        /// Path for plugin README markdown file.
-        readme_file: Option<PathBuf>,
-    },
-    /// Represents an invalid plugin with infos about validation error.
-    Invalid {
-        /// Error message explaining why the plugin is invalid.
-        err_msg: String,
-    },
-}
-
-/// Scans and validates the plugin directory, ensuring all required files exist  
-/// and collecting paths of relevant plugin-related files (both mandatory and optional).
-///
-/// * `plugin_dir`: Path for the plugin directory.
-pub fn validate_plugin_files(plugin_dir: &Path) -> Result<PluginFilesStatus, PluginsManagerError> {
-    use PluginFilesStatus as Re;
-
-    if !plugin_dir.exists() {
-        let err_msg = format!(
-            "Plugin directory doesn't exist. Path: {}",
-            plugin_dir.display()
-        );
-        return Ok(Re::Invalid { err_msg });
-    }
-
-    let Some(plugin_files) = extract_plugin_file_paths(plugin_dir) else {
-        let err_msg = format!(
-            "Extracting plugins files from its directory failed. Plugin directory: {}",
-            plugin_dir.display()
-        );
-        return Ok(Re::Invalid { err_msg });
-    };
-
-    let wasm_path = if plugin_files.wasm_file.exists() {
-        plugin_files.wasm_file
-    } else {
-        let err_msg = format!(
-            "Plugin WASM file not found. Path {}",
-            plugin_files.wasm_file.display()
-        );
-
-        return Ok(Re::Invalid { err_msg });
-    };
-
-    let metadata_file = plugin_files
-        .metadata_file
-        .exists()
-        .then_some(plugin_files.metadata_file);
-
-    let readme_file = plugin_files
-        .readme_file
-        .exists()
-        .then_some(plugin_files.readme_file);
-
-    let res = Re::Valid {
-        wasm_path,
-        metadata_file,
-        readme_file,
-    };
-
-    Ok(res)
 }
 
 /// Parser the plugin metadata from the provided toml file.

--- a/application/apps/indexer/plugins_host/src/plugins_manager/mod.rs
+++ b/application/apps/indexer/plugins_host/src/plugins_manager/mod.rs
@@ -7,12 +7,13 @@ mod load;
 pub mod paths;
 #[cfg(test)]
 mod tests;
+mod validator;
 
 use std::path::{Path, PathBuf};
 
 use crate::plugins_shared::load::{WasmComponentInfo, load_and_inspect};
 use cache::CacheManager;
-use load::{PluginEntityState, PluginFilesStatus, load_plugin, validate_plugin_files};
+use load::{PluginEntityState, load_plugin};
 use paths::extract_plugin_file_paths;
 use stypes::{
     ExtendedInvalidPluginEntity, ExtendedPluginEntity, InvalidPluginEntity, PluginEntity,
@@ -20,6 +21,7 @@ use stypes::{
 };
 
 pub use errors::{PluginsCacheError, PluginsManagerError};
+use validator::{PluginFilesStatus, validate_plugin_files};
 
 /// Plugins manager responsible of loading the plugins, providing their states, info and metadata.
 #[derive(Debug)]

--- a/application/apps/indexer/plugins_host/src/plugins_manager/tests.rs
+++ b/application/apps/indexer/plugins_host/src/plugins_manager/tests.rs
@@ -92,16 +92,8 @@ fn create_manager() -> PluginsManager {
     ];
 
     let mut invalid_plugins: Vec<ExtendedInvalidPluginEntity> = vec![
-        InvalidPluginEntity {
-            dir_path: INV_PARSER_PATH.into(),
-            plugin_type: PluginType::Parser,
-        }
-        .into(),
-        InvalidPluginEntity {
-            dir_path: INV_SOURCE_PATH.into(),
-            plugin_type: PluginType::ByteSource,
-        }
-        .into(),
+        InvalidPluginEntity::new(INV_PARSER_PATH.into(), PluginType::Parser).into(),
+        InvalidPluginEntity::new(INV_SOURCE_PATH.into(), PluginType::ByteSource).into(),
     ];
     invalid_plugins[0].run_data.err("error");
     invalid_plugins[1].run_data.err("error");

--- a/application/apps/indexer/plugins_host/src/plugins_manager/validator.rs
+++ b/application/apps/indexer/plugins_host/src/plugins_manager/validator.rs
@@ -1,0 +1,560 @@
+//! Module to provide various validation for plugin files, configurations and metadata.
+//! It validates plugin files and ensure plugins configurations and metadata are valid and
+//! don't contain malicious texts.
+
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
+
+use stypes::{ColumnsRenderOptions, PluginInfo, PluginMetadata, RenderOptions};
+
+use crate::plugins_manager::paths::extract_plugin_file_paths;
+
+use super::PluginsManagerError;
+
+/// Maximum length for configuration IDs before considered malicious.
+const MAX_ID_TEXT_LENGTH: usize = 1024;
+
+/// Maximum length for title texts before considered malicious.
+const MAX_TITLE_TEXT_LENGTH: usize = 2 * 1024;
+
+/// Maximum length for description texts before considered malicious.
+const MAX_DESCRIPTION_TEXT_LENGTH: usize = 10 * 1024;
+
+/// Maximum length of collections provided by plugins before considered malicious.
+const MAX_COLLECTIONS_LENGTH: usize = 100;
+
+/// Scans and validates the plugin directory, ensuring all required files exist  
+/// and collecting paths of relevant plugin-related files (both mandatory and optional).
+///
+/// * `plugin_dir`: Path for the plugin directory.
+pub fn validate_plugin_files(plugin_dir: &Path) -> Result<PluginFilesStatus, PluginsManagerError> {
+    use PluginFilesStatus as Re;
+
+    if !plugin_dir.exists() {
+        let err_msg = format!(
+            "Plugin directory doesn't exist. Path: {}",
+            plugin_dir.display()
+        );
+        return Ok(Re::Invalid { err_msg });
+    }
+
+    let Some(plugin_files) = extract_plugin_file_paths(plugin_dir) else {
+        let err_msg = format!(
+            "Extracting plugins files from its directory failed. Plugin directory: {}",
+            plugin_dir.display()
+        );
+        return Ok(Re::Invalid { err_msg });
+    };
+
+    let wasm_path = if plugin_files.wasm_file.exists() {
+        plugin_files.wasm_file
+    } else {
+        let err_msg = format!(
+            "Plugin WASM file not found. Path {}",
+            plugin_files.wasm_file.display()
+        );
+
+        return Ok(Re::Invalid { err_msg });
+    };
+
+    let metadata_file = plugin_files
+        .metadata_file
+        .exists()
+        .then_some(plugin_files.metadata_file);
+
+    let readme_file = plugin_files
+        .readme_file
+        .exists()
+        .then_some(plugin_files.readme_file);
+
+    let res = Re::Valid {
+        wasm_path,
+        metadata_file,
+        readme_file,
+    };
+
+    Ok(res)
+}
+
+/// Represents the result of scanning a plugin directory,  
+/// providing details about detected files and validation status.
+#[derive(Debug, Clone)]
+pub enum PluginFilesStatus {
+    /// Represents valid plugin with its infos and metadata.
+    Valid {
+        /// The path for the plugin wasm file.
+        wasm_path: PathBuf,
+        /// Metadata of the plugins found in plugins metadata toml file.
+        metadata_file: Option<PathBuf>,
+        /// Path for plugin README markdown file.
+        readme_file: Option<PathBuf>,
+    },
+    /// Represents an invalid plugin with infos about validation error.
+    Invalid {
+        /// Error message explaining why the plugin is invalid.
+        err_msg: String,
+    },
+}
+
+/// Validates the provided plugin info against invalid or malicious infos.
+pub fn validate_plugin_info(info: &PluginInfo) -> Result<(), String> {
+    // Note: Pattern match is reminder to validate newly added items.
+    let PluginInfo {
+        wasm_file_path: _,
+        api_version: _,
+        plugin_version: _,
+        config_schemas,
+        render_options,
+    } = info;
+
+    if config_schemas.len() > MAX_COLLECTIONS_LENGTH {
+        return Err(format!(
+            "Configurations Schema items count is greater than {MAX_COLLECTIONS_LENGTH}"
+        ));
+    }
+
+    let mut id_sets = HashSet::with_capacity(config_schemas.len());
+
+    for conf in config_schemas {
+        if conf.id.len() > MAX_ID_TEXT_LENGTH {
+            return Err(format!(
+                "Configuration ID is longer than {MAX_ID_TEXT_LENGTH} bytes"
+            ));
+        }
+
+        if !id_sets.insert(conf.id.as_str()) {
+            return Err(format!("Configuration ID '{}' is duplicated", conf.id));
+        }
+
+        if conf.title.len() > MAX_TITLE_TEXT_LENGTH {
+            return Err(format!(
+                "Configuration title is longer than {MAX_TITLE_TEXT_LENGTH} bytes"
+            ));
+        }
+        if conf
+            .description
+            .as_ref()
+            .is_some_and(|desc| desc.len() > MAX_DESCRIPTION_TEXT_LENGTH)
+        {
+            return Err(format!(
+                "Configuration description is longer than {MAX_DESCRIPTION_TEXT_LENGTH} bytes"
+            ));
+        }
+    }
+
+    match render_options {
+        RenderOptions::Parser(parser_render_options) => {
+            if let Some(columns_opts) = parser_render_options.columns_options.as_ref() {
+                let ColumnsRenderOptions {
+                    columns,
+                    min_width: _,
+                    max_width: _,
+                } = columns_opts;
+
+                if columns.len() > MAX_COLLECTIONS_LENGTH {
+                    return Err(format!(
+                        "Columns info items count in render options is greater than {MAX_COLLECTIONS_LENGTH}"
+                    ));
+                }
+
+                for col in columns {
+                    if col.caption.len() > MAX_TITLE_TEXT_LENGTH {
+                        return Err(format!(
+                            "Column caption in render options is longer than {MAX_TITLE_TEXT_LENGTH} bytes"
+                        ));
+                    }
+                    if col.description.len() > MAX_DESCRIPTION_TEXT_LENGTH {
+                        return Err(format!(
+                            "Column description in render options is longer than {MAX_DESCRIPTION_TEXT_LENGTH}"
+                        ));
+                    }
+                }
+            }
+        }
+        RenderOptions::ByteSource => {}
+    }
+
+    Ok(())
+}
+
+pub fn validate_plugins_metadata(metadata: &PluginMetadata) -> Result<(), String> {
+    // Note: Pattern match is reminder to validate newly added items.
+    let PluginMetadata { title, description } = metadata;
+
+    if title.len() > MAX_TITLE_TEXT_LENGTH {
+        return Err(format!(
+            "Plugin Title is longer than {MAX_TITLE_TEXT_LENGTH} bytes"
+        ));
+    }
+
+    if description
+        .as_ref()
+        .is_some_and(|desc| desc.len() > MAX_DESCRIPTION_TEXT_LENGTH)
+    {
+        return Err(format!(
+            "Plugin description is longer than {MAX_DESCRIPTION_TEXT_LENGTH} bytes"
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use stypes::{
+        ColumnInfo, ColumnsRenderOptions, PluginConfigSchemaItem, PluginConfigSchemaType,
+        SemanticVersion,
+    };
+
+    use super::*;
+
+    fn version() -> SemanticVersion {
+        SemanticVersion::new(0, 1, 0)
+    }
+
+    #[test]
+    fn valid_configs_pass() {
+        let valid_info = PluginInfo {
+            wasm_file_path: Default::default(),
+            api_version: version(),
+            plugin_version: version(),
+            config_schemas: vec![
+                PluginConfigSchemaItem::new(
+                    "id",
+                    "title",
+                    Some("description"),
+                    PluginConfigSchemaType::Boolean(false),
+                ),
+                PluginConfigSchemaItem::new(
+                    "id_2",
+                    "title_2",
+                    None,
+                    PluginConfigSchemaType::Boolean(true),
+                ),
+            ],
+
+            render_options: RenderOptions::Parser(Box::new(stypes::ParserRenderOptions {
+                columns_options: None,
+            })),
+        };
+
+        assert!(validate_plugin_info(&valid_info).is_ok());
+    }
+
+    #[test]
+    fn valid_render_pass() {
+        let valid_info = PluginInfo {
+            wasm_file_path: Default::default(),
+            api_version: version(),
+            plugin_version: version(),
+            config_schemas: vec![],
+            render_options: RenderOptions::Parser(Box::new(stypes::ParserRenderOptions {
+                columns_options: Some(ColumnsRenderOptions {
+                    columns: vec![
+                        ColumnInfo {
+                            caption: String::from("Caption_1"),
+                            description: String::from("Description_1"),
+                            width: 12,
+                        },
+                        ColumnInfo {
+                            caption: String::from("Caption_2"),
+                            description: String::from("Description_2"),
+                            width: 16,
+                        },
+                    ],
+                    min_width: 0,
+                    max_width: 10,
+                }),
+            })),
+        };
+
+        assert!(validate_plugin_info(&valid_info).is_ok());
+    }
+
+    #[test]
+    fn duplicated_configs_id_fail() {
+        let id = "same id";
+
+        let invalid_info = PluginInfo {
+            wasm_file_path: Default::default(),
+            api_version: version(),
+            plugin_version: version(),
+            config_schemas: vec![
+                PluginConfigSchemaItem::new(
+                    id,
+                    "title",
+                    Some("description"),
+                    PluginConfigSchemaType::Boolean(false),
+                ),
+                PluginConfigSchemaItem::new(
+                    id,
+                    "title_2",
+                    Some("description_2"),
+                    PluginConfigSchemaType::Boolean(true),
+                ),
+            ],
+
+            render_options: RenderOptions::Parser(Box::new(stypes::ParserRenderOptions {
+                columns_options: None,
+            })),
+        };
+
+        assert!(validate_plugin_info(&invalid_info).is_err());
+    }
+
+    #[test]
+    fn invalid_configs_count_fail() {
+        let mut configs = Vec::with_capacity(MAX_COLLECTIONS_LENGTH + 1);
+        for id in 0..MAX_COLLECTIONS_LENGTH + 1 {
+            configs.push(PluginConfigSchemaItem::new(
+                format!("ID_{id}"),
+                "title".into(),
+                Some("description".into()),
+                PluginConfigSchemaType::Boolean(false),
+            ));
+        }
+
+        let invalid_info = PluginInfo {
+            wasm_file_path: Default::default(),
+            api_version: version(),
+            plugin_version: version(),
+            config_schemas: configs,
+
+            render_options: RenderOptions::Parser(Box::new(stypes::ParserRenderOptions {
+                columns_options: None,
+            })),
+        };
+
+        assert!(validate_plugin_info(&invalid_info).is_err());
+    }
+
+    /// Provides a string longer that the provided limit
+    fn get_too_long(limit: usize) -> String {
+        "a".repeat(limit + 1)
+    }
+
+    #[test]
+    fn invalid_configs_id_fail() {
+        let id = get_too_long(MAX_ID_TEXT_LENGTH);
+
+        let invalid_info = PluginInfo {
+            wasm_file_path: Default::default(),
+            api_version: version(),
+            plugin_version: version(),
+            config_schemas: vec![
+                PluginConfigSchemaItem::new(
+                    id.as_str(),
+                    "title",
+                    Some("description"),
+                    PluginConfigSchemaType::Boolean(false),
+                ),
+                PluginConfigSchemaItem::new(
+                    "id_2",
+                    "title_2",
+                    Some("description_2"),
+                    PluginConfigSchemaType::Boolean(true),
+                ),
+            ],
+
+            render_options: RenderOptions::Parser(Box::new(stypes::ParserRenderOptions {
+                columns_options: None,
+            })),
+        };
+
+        assert!(validate_plugin_info(&invalid_info).is_err());
+    }
+
+    #[test]
+    fn invalid_configs_title_fail() {
+        let title = get_too_long(MAX_TITLE_TEXT_LENGTH);
+
+        let invalid_info = PluginInfo {
+            wasm_file_path: Default::default(),
+            api_version: version(),
+            plugin_version: version(),
+            config_schemas: vec![
+                PluginConfigSchemaItem::new(
+                    "id",
+                    title.as_str(),
+                    Some("description"),
+                    PluginConfigSchemaType::Boolean(false),
+                ),
+                PluginConfigSchemaItem::new(
+                    "id_2",
+                    "title_2",
+                    Some("description_2"),
+                    PluginConfigSchemaType::Boolean(true),
+                ),
+            ],
+
+            render_options: RenderOptions::Parser(Box::new(stypes::ParserRenderOptions {
+                columns_options: None,
+            })),
+        };
+
+        assert!(validate_plugin_info(&invalid_info).is_err());
+    }
+
+    #[test]
+    fn invalid_configs_desc_fail() {
+        let description = get_too_long(MAX_DESCRIPTION_TEXT_LENGTH);
+
+        let invalid_info = PluginInfo {
+            wasm_file_path: Default::default(),
+            api_version: version(),
+            plugin_version: version(),
+            config_schemas: vec![
+                PluginConfigSchemaItem::new(
+                    "id",
+                    "title",
+                    Some(description.as_str()),
+                    PluginConfigSchemaType::Boolean(false),
+                ),
+                PluginConfigSchemaItem::new(
+                    "id_2",
+                    "title_2",
+                    Some("description_2"),
+                    PluginConfigSchemaType::Boolean(true),
+                ),
+            ],
+
+            render_options: RenderOptions::Parser(Box::new(stypes::ParserRenderOptions {
+                columns_options: None,
+            })),
+        };
+
+        assert!(validate_plugin_info(&invalid_info).is_err());
+    }
+
+    #[test]
+    fn invalid_columns_len_fail() {
+        let column = ColumnInfo {
+            caption: String::from("c"),
+            description: String::from("d"),
+            width: 12,
+        };
+
+        let columns = vec![column; MAX_COLLECTIONS_LENGTH + 1];
+
+        let invalid_info = PluginInfo {
+            wasm_file_path: Default::default(),
+            api_version: version(),
+            plugin_version: version(),
+            config_schemas: vec![],
+            render_options: RenderOptions::Parser(Box::new(stypes::ParserRenderOptions {
+                columns_options: Some(ColumnsRenderOptions {
+                    columns,
+                    min_width: 0,
+                    max_width: 10,
+                }),
+            })),
+        };
+
+        assert!(validate_plugin_info(&invalid_info).is_err());
+    }
+
+    #[test]
+    fn invalid_column_caption_fail() {
+        let caption = get_too_long(MAX_TITLE_TEXT_LENGTH);
+
+        let invalid_info = PluginInfo {
+            wasm_file_path: Default::default(),
+            api_version: version(),
+            plugin_version: version(),
+            config_schemas: vec![],
+            render_options: RenderOptions::Parser(Box::new(stypes::ParserRenderOptions {
+                columns_options: Some(ColumnsRenderOptions {
+                    columns: vec![
+                        ColumnInfo {
+                            caption,
+                            description: String::from("Description_1"),
+                            width: 12,
+                        },
+                        ColumnInfo {
+                            caption: String::from("Caption_2"),
+                            description: String::from("Description_2"),
+                            width: 16,
+                        },
+                    ],
+                    min_width: 0,
+                    max_width: 10,
+                }),
+            })),
+        };
+
+        assert!(validate_plugin_info(&invalid_info).is_err());
+    }
+
+    #[test]
+    fn invalid_column_description_fail() {
+        let description = get_too_long(MAX_DESCRIPTION_TEXT_LENGTH);
+
+        let invalid_info = PluginInfo {
+            wasm_file_path: Default::default(),
+            api_version: version(),
+            plugin_version: version(),
+            config_schemas: vec![],
+            render_options: RenderOptions::Parser(Box::new(stypes::ParserRenderOptions {
+                columns_options: Some(ColumnsRenderOptions {
+                    columns: vec![
+                        ColumnInfo {
+                            caption: String::from("Caption_1"),
+                            description,
+                            width: 12,
+                        },
+                        ColumnInfo {
+                            caption: String::from("Caption_2"),
+                            description: String::from("Description_2"),
+                            width: 16,
+                        },
+                    ],
+                    min_width: 0,
+                    max_width: 10,
+                }),
+            })),
+        };
+
+        assert!(validate_plugin_info(&invalid_info).is_err());
+    }
+
+    #[test]
+    fn valid_metadata_pass() {
+        let valid_meta = PluginMetadata {
+            title: String::from("Title_1"),
+            description: Some(String::from("Description_1")),
+        };
+
+        assert!(validate_plugins_metadata(&valid_meta).is_ok());
+
+        let valid_meta = PluginMetadata {
+            title: String::from("Title_1"),
+            description: None,
+        };
+
+        assert!(validate_plugins_metadata(&valid_meta).is_ok());
+    }
+
+    #[test]
+    fn invalid_metadata_title_fail() {
+        let title = get_too_long(MAX_TITLE_TEXT_LENGTH);
+        let invalid_meta = PluginMetadata {
+            title,
+            description: Some(String::from("Description_1")),
+        };
+
+        assert!(validate_plugins_metadata(&invalid_meta).is_err());
+    }
+
+    #[test]
+    fn invalid_metadata_description_fail() {
+        let description = get_too_long(MAX_DESCRIPTION_TEXT_LENGTH);
+        let invalid_meta = PluginMetadata {
+            title: String::from("Title_1"),
+            description: Some(description),
+        };
+
+        assert!(validate_plugins_metadata(&invalid_meta).is_err());
+    }
+}

--- a/application/apps/indexer/stypes/src/plugins/extending.rs
+++ b/application/apps/indexer/stypes/src/plugins/extending.rs
@@ -245,3 +245,13 @@ impl PluginLogMessage {
         }
     }
 }
+
+impl InvalidPluginEntity {
+    /// Creates a new instance of [`InvalidPluginEntity`] with the provided arguments.
+    pub fn new(dir_path: PathBuf, plugin_type: PluginType) -> Self {
+        Self {
+            dir_path,
+            plugin_type,
+        }
+    }
+}

--- a/application/apps/indexer/stypes/src/plugins/proptest.rs
+++ b/application/apps/indexer/stypes/src/plugins/proptest.rs
@@ -245,10 +245,7 @@ impl Arbitrary for InvalidPluginEntity {
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         (any::<PathBuf>(), any::<PluginType>())
-            .prop_map(|(dir_path, plugin_type)| Self {
-                dir_path,
-                plugin_type,
-            })
+            .prop_map(|(dir_path, plugin_type)| Self::new(dir_path, plugin_type))
             .boxed()
     }
 }


### PR DESCRIPTION
This PR closes #2328 

It provides validations for the configurations and metadata provided by the plugins.

We are checking against the following:
* Plugins configuration items or rendering columns can't be greater than 100 item.
* Plugins configurations ID texts can be greater than 1 Kilobytes.
* Plugins titles, the title of its configuration items or the columns captions can't be greater than 2 Kilobytes.
* Plugins description, the description of the configurations or the rendering columns can't be greater than 10 Kilobytes.

This PR introduces small refactoring regarding moving all validations into one module and some cleaning up. Also it includes unit tests for all new validations