### PR TITLE
Logging: Update Configuration + Version Control + Documentation + Cleanp

### DIFF
--- a/application/apps/rustcore/rs-bindings/log4rs.yaml
+++ b/application/apps/rustcore/rs-bindings/log4rs.yaml
@@ -1,4 +1,4 @@
-# chipmunk_logconf_version: 1.0
+# chipmunk_logconf_version: $LOG_CONFIG_VERSION
 refresh_rate: 30 seconds
 
 # The "appenders" map contains the set of appenders, indexed by their names.
@@ -11,12 +11,14 @@ appenders:
     indexer-root:
         kind: file
         path: $INDEXER_LOG_PATH
+        append: false
         encoder:
             kind: pattern
             pattern: "[{l}] [{t}: {M}] {d}:: {m}{n}\n"
     startup-appender:
         kind: file
         path: $LAUNCHER_LOG_PATH
+        append: false
         encoder:
             kind: pattern
             pattern: "{d} [{M}] {l}:: {m}\n"
@@ -28,14 +30,11 @@ root:
     # level: info
     # level: debug
     # level: trace
+    appenders:
+        - indexer-root
+        - stdout
 
 loggers:
-    session:
-        level: warn
-        appenders:
-            - indexer-root
-            - stdout
-        additive: false
     launcher:
         level: warn
         appenders:

--- a/docs/contributing/welcome.md
+++ b/docs/contributing/welcome.md
@@ -15,3 +15,24 @@ sh developing/scripts/check.sh
 
 If the script indicates success (e.g., prints success messages), you have all necessary prerequisites and can proceed to [installing dependencies](/chipmunk/contributing/preparing). 
 If the script reports that prerequisites are missing, please install them before continuing with the setup.
+
+
+## Chipmunk Logs & Configurations
+
+Chipmunk's log files and their associated configuration files are located within the Chipmunk home directory:
+
+### Log Files:
+
+* **chipmunk.log:** Logs for the Chipmunk Electron frontend.
+* **chipmunk.indexer.log:** Logs for the Chipmunk Rust backend (indexer).
+* **chipmunk.updater.log:** Logs for the Chipmunk updater binary.
+* **chipmunk.launcher.log:** Logs for the Chipmunk application during backend initialization and communication channel setup.
+
+### Configuration Files:
+
+Chipmunk's backend logging is configured using the [log4rs](https://docs.rs/log4rs/latest/log4rs/index.html) crate. To adjust log levels, appenders, or other logging settings, modify the relevant YAML configuration files.
+
+The following log configuration files are available:
+
+* **log4rs.yaml:** Configuration file for the Rust backend. (Note: Please keep the first line of this file unchanged, as it is used for version control of log files.)
+* **log4rs_updater.yaml:** Configuration file for the updater tool.

--- a/docs/plugins/development-guide.md
+++ b/docs/plugins/development-guide.md
@@ -186,3 +186,4 @@ For a working example of a parser plugin configuration, refer to the [DLT parser
 - **Cargo Component:** [cargo component GitHub Repository](https://github.com/bytecodealliance/cargo-component)
 - **Wasm-tools:** [Wasm-tools GitHub Repository](https://github.com/bytecodealliance/wasm-tools)
 - **Plugins API Crate Documentation:** [Plugins API](./plugins-api.md)
+- **Chipmiunk Contribution:** [Contribution Page](../contributing/welcome.md)


### PR DESCRIPTION
This PR closes #2344 

It fixes the logging configuration on the backend providing:

### Logging in Rust Core:
* Change logging configurations as following:
  - All rust modules will write logs with level WARN to stdout and to `chipmunk.indexer.log`
  - Log files will be truncated at the start to avoid taking space on host machine since log files will never get cleaned up.
  - Although it's possible to manage rolling log files with log4rs, it will be effect the performance unnecessarily because it will do
    checks after each logs.
  - Update version of the log configurations file.
* Introduce version validation in log initialization to ensure old log conifg files will get updated.
* Remove panics on errors in logging code since it will return Result
* Add documentation to logging module.
* Remove unused and commented out code for logging module.

### Contribution Documentation
* Add logging section to contribution page providing developers with the needed information to find the logs and to configure them
* Link contribution page to plugins development page