### PR TITLE
Ensure sessions are using generics completely

### DIFF
--- a/.github/workflows/pullrequest_check.yml
+++ b/.github/workflows/pullrequest_check.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   ts_and_rust_lint:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'master'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -63,7 +63,7 @@ jobs:
         run: yarn run check
 
   integration_and_unit_tests:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'master'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/application/apps/indexer/parsers/src/dlt/descriptor.rs
+++ b/application/apps/indexer/parsers/src/dlt/descriptor.rs
@@ -48,12 +48,12 @@ impl fmt::Display for StatFields {
     }
 }
 
-impl ComponentFactory<crate::Parser> for Descriptor {
+impl ComponentFactory<crate::AllParserTypes> for Descriptor {
     fn create(
         &self,
         origin: &SessionAction,
         options: &[Field],
-    ) -> Result<Option<crate::Parser>, NativeError> {
+    ) -> Result<Option<crate::AllParserTypes>, NativeError> {
         let errors = self.validate(origin, options)?;
         if !errors.is_empty() {
             return Err(NativeError {
@@ -104,7 +104,7 @@ impl ComponentFactory<crate::Parser> for Descriptor {
             app_id_count: 0,
             context_id_count: 0,
         };
-        Ok(Some(crate::Parser::Dlt(DltParser::new(
+        Ok(Some(crate::AllParserTypes::Dlt(DltParser::new(
             Some(filter_config),
             dlt_metadata,
             None,

--- a/application/apps/indexer/parsers/src/dlt/raw/descriptor.rs
+++ b/application/apps/indexer/parsers/src/dlt/raw/descriptor.rs
@@ -10,16 +10,15 @@ const DLT_PARSER_UUID: uuid::Uuid = uuid::Uuid::from_bytes([
 #[derive(Default)]
 pub struct Descriptor {}
 
-impl ComponentFactory<crate::Parser> for Descriptor {
+impl ComponentFactory<crate::AllParserTypes> for Descriptor {
     fn create(
         &self,
         origin: &SessionAction,
         _options: &[stypes::Field],
-    ) -> Result<Option<crate::Parser>, stypes::NativeError> {
-        Ok(Some(crate::Parser::DltRaw(DltRawParser::new(!matches!(
-            origin,
-            SessionAction::Source
-        )))))
+    ) -> Result<Option<crate::AllParserTypes>, stypes::NativeError> {
+        Ok(Some(crate::AllParserTypes::DltRaw(DltRawParser::new(
+            !matches!(origin, SessionAction::Source),
+        ))))
     }
 }
 
@@ -27,7 +26,7 @@ impl ComponentDescriptor for Descriptor {
     fn is_compatible(&self, origin: &SessionAction) -> bool {
         let files = match origin {
             SessionAction::File(..) | SessionAction::Files(..) | SessionAction::Source => {
-                return false
+                return false;
             }
             SessionAction::ExportRaw(files, ..) => files,
         };

--- a/application/apps/indexer/parsers/src/lib.rs
+++ b/application/apps/indexer/parsers/src/lib.rs
@@ -1,51 +1,28 @@
 #![deny(unused_crate_dependencies)]
 
 use components::Components;
-use definitions::{LogRecordOutput, ParserError};
 pub mod dlt;
 pub mod prelude;
 pub mod someip;
 pub mod text;
 
-pub enum Parser {
+// TODO AAZ:
+// - Consider boxing the parsers since they may vary in memory print.
+// - Unusual name used here to avoid naming conflicts with types
+//   from `stypes` crate while development
+pub enum AllParserTypes {
+    //TODO AAZ: Raw parsers are separate category.
     DltRaw(dlt::raw::DltRawParser),
     Dlt(dlt::DltParser),
     SomeIp(someip::SomeipParser),
     Text(text::StringTokenizer),
 }
 
-/**
- * NOTE/TODO:
- * Using of the whole enum inside MessageProducer might give performance impact because it's massive.
- * Into MessageProducer we should put exact instances of parsers instead enum-wrapper
- */
-
-impl definitions::Parser for Parser {
-    fn parse<'a>(
-        &mut self,
-        input: &'a [u8],
-        timestamp: Option<u64>,
-    ) -> Result<(usize, Option<LogRecordOutput<'a>>), ParserError> {
-        match self {
-            Self::Dlt(inst) => inst.parse(input, timestamp),
-            Self::DltRaw(inst) => inst.parse(input, timestamp),
-            Self::SomeIp(inst) => inst.parse(input, timestamp),
-            Self::Text(inst) => inst.parse(input, timestamp),
-        }
-    }
-    fn min_msg_len(&self) -> usize {
-        match self {
-            Self::Dlt(inst) => inst.min_msg_len(),
-            Self::DltRaw(inst) => inst.min_msg_len(),
-            Self::SomeIp(inst) => inst.min_msg_len(),
-            Self::Text(inst) => inst.min_msg_len(),
-        }
-    }
-}
-
 // TODO: this registration function will fail if some of parser would not be registred. That's wrong.
 // If some of parsers are failed, another parsers should still be registred as well
-pub fn registration<S>(components: &mut Components<S, Parser>) -> Result<(), stypes::NativeError> {
+pub fn registration<S>(
+    components: &mut Components<S, AllParserTypes>,
+) -> Result<(), stypes::NativeError> {
     components.add_parser(dlt::descriptor::Descriptor::default())?;
     components.add_parser(dlt::raw::descriptor::Descriptor::default())?;
     components.add_parser(someip::descriptor::Descriptor::default())?;

--- a/application/apps/indexer/parsers/src/someip/descriptor.rs
+++ b/application/apps/indexer/parsers/src/someip/descriptor.rs
@@ -15,13 +15,13 @@ const FIELD_TZ: &str = "SOMEIP_PARSER_FIELD_TIMEZONE";
 #[derive(Default)]
 pub struct Descriptor {}
 
-impl ComponentFactory<crate::Parser> for Descriptor {
+impl ComponentFactory<crate::AllParserTypes> for Descriptor {
     fn create(
         &self,
         _origin: &SessionAction,
         _options: &[stypes::Field],
-    ) -> Result<Option<crate::Parser>, stypes::NativeError> {
-        Ok(Some(crate::Parser::SomeIp(SomeipParser::new())))
+    ) -> Result<Option<crate::AllParserTypes>, stypes::NativeError> {
+        Ok(Some(crate::AllParserTypes::SomeIp(SomeipParser::new())))
     }
 }
 

--- a/application/apps/indexer/parsers/src/text/descriptor.rs
+++ b/application/apps/indexer/parsers/src/text/descriptor.rs
@@ -11,13 +11,13 @@ const TEXT_PARSER_UUID: uuid::Uuid = uuid::Uuid::from_bytes([
 #[derive(Default)]
 pub struct Descriptor {}
 
-impl ComponentFactory<crate::Parser> for Descriptor {
+impl ComponentFactory<crate::AllParserTypes> for Descriptor {
     fn create(
         &self,
         _origin: &SessionAction,
         _options: &[stypes::Field],
-    ) -> Result<Option<crate::Parser>, stypes::NativeError> {
-        Ok(Some(crate::Parser::Text(StringTokenizer {})))
+    ) -> Result<Option<crate::AllParserTypes>, stypes::NativeError> {
+        Ok(Some(crate::AllParserTypes::Text(StringTokenizer {})))
     }
 }
 
@@ -42,7 +42,9 @@ impl ComponentDescriptor for Descriptor {
     fn ident(&self) -> stypes::Ident {
         stypes::Ident {
             name: String::from("Text Parser"),
-            desc: String::from("Text Parser is a minimal parser designed for processing plain text input. It performs no decoding or transformation and has no configuration options. Its sole purpose is to output incoming data line by line, making it suitable for logs or command outputs in textual format."),
+            desc: String::from(
+                "Text Parser is a minimal parser designed for processing plain text input. It performs no decoding or transformation and has no configuration options. Its sole purpose is to output incoming data line by line, making it suitable for logs or command outputs in textual format.",
+            ),
             io: stypes::IODataType::PlaitText,
             uuid: TEXT_PARSER_UUID,
         }

--- a/application/apps/indexer/session/src/components/mod.rs
+++ b/application/apps/indexer/session/src/components/mod.rs
@@ -51,7 +51,8 @@ impl ComponentsSession {
             UnboundedSender<stypes::CallbackOptionsEvent>,
             UnboundedReceiver<stypes::CallbackOptionsEvent>,
         ) = unbounded_channel();
-        let mut components: Components<sources::Source, parsers::Parser> = Components::new();
+        let mut components: Components<sources::AllSourceTypes, parsers::AllParserTypes> =
+            Components::new();
         // Registre parsers
         parsers::registration(&mut components)?;
         // Registre sources

--- a/application/apps/indexer/session/src/handlers/observe/mod.rs
+++ b/application/apps/indexer/session/src/handlers/observe/mod.rs
@@ -6,42 +6,67 @@ use crate::{
     state::SessionStateAPI,
 };
 use components::Components;
-use processor::producer::{sde::*, MessageProducer};
+use definitions::{ByteSource, LogRecordWriter, Parser};
+use parsers::AllParserTypes;
+use processor::producer::{MessageProducer, sde::*};
+use sources::AllSourceTypes;
 use std::sync::Arc;
 use stypes::{SessionAction, SessionSetup};
 
+//TODO AAZ: Why don't we have rx_tail here?
 pub async fn observing(
     operation_api: OperationAPI,
     state: SessionStateAPI,
     options: SessionSetup,
-    components: Arc<Components<sources::Source, parsers::Parser>>,
+    components: Arc<Components<sources::AllSourceTypes, parsers::AllParserTypes>>,
     rx_sde: Option<SdeReceiver>,
 ) -> OperationResult<()> {
     match &options.origin {
         SessionAction::File(..) => {
-            let (desciptor, source, parser) = components.setup(&options)?;
+            let (descriptor, source, parser) = components.setup(&options)?;
             let mut writer =
-                session::Writer::new(state.clone(), state.add_source(desciptor).await?);
-            let producer = MessageProducer::new(parser, source, &mut writer);
-            Ok(session::run_producer(operation_api, state, producer, None, None).await?)
+                session::Writer::new(state.clone(), state.add_source(descriptor).await?);
+            Ok(run_session(
+                source,
+                parser,
+                &mut writer,
+                operation_api,
+                state.clone(),
+                None,
+            )
+            .await?)
         }
         SessionAction::Source => {
-            let (desciptor, source, parser) = components.setup(&options)?;
+            let (descriptor, source, parser) = components.setup(&options)?;
             let mut writer =
-                session::Writer::new(state.clone(), state.add_source(desciptor).await?);
-            let producer = MessageProducer::new(parser, source, &mut writer);
-            Ok(session::run_producer(operation_api, state, producer, None, rx_sde).await?)
+                session::Writer::new(state.clone(), state.add_source(descriptor).await?);
+            Ok(run_session(
+                source,
+                parser,
+                &mut writer,
+                operation_api,
+                state.clone(),
+                rx_sde,
+            )
+            .await?)
         }
         SessionAction::Files(files) => {
             // Replacement of concat feature
             for file in files {
-                let (desciptor, source, parser) =
+                let (descriptor, source, parser) =
                     components.setup(&options.inherit(SessionAction::File(file.to_owned())))?;
                 let mut writer =
-                    session::Writer::new(state.clone(), state.add_source(desciptor).await?);
-                let producer = MessageProducer::new(parser, source, &mut writer);
-                session::run_producer(operation_api.clone(), state.clone(), producer, None, None)
-                    .await?;
+                    session::Writer::new(state.clone(), state.add_source(descriptor).await?);
+
+                run_session(
+                    source,
+                    parser,
+                    &mut writer,
+                    operation_api.clone(),
+                    state.clone(),
+                    None,
+                )
+                .await?;
             }
             Ok(Some(()))
         }
@@ -54,10 +79,130 @@ pub async fn observing(
                 }
                 let (_, source, parser) =
                     components.setup(&options.inherit(SessionAction::File(file.to_owned())))?;
-                let producer = MessageProducer::new(parser, source, &mut writer);
-                export_raw::run_producer(operation_api.clone(), producer).await?;
+
+                run_session(
+                    source,
+                    parser,
+                    &mut writer,
+                    operation_api.clone(),
+                    state.clone(),
+                    None,
+                )
+                .await?;
             }
             Ok(Some(()))
         }
     }
+}
+
+/// Matches against all sources then against all parsers to finally
+/// runs the session with full generics support.
+async fn run_session<W: LogRecordWriter>(
+    source: AllSourceTypes,
+    parser: AllParserTypes,
+    writer: &mut W,
+    operation_api: OperationAPI,
+    state: SessionStateAPI,
+    rx_sde: Option<SdeReceiver>,
+) -> OperationResult<()> {
+    match source {
+        AllSourceTypes::Raw(binary_byte_source_from_file) => {
+            run_session_by_praser(
+                binary_byte_source_from_file,
+                parser,
+                writer,
+                operation_api,
+                state,
+                rx_sde,
+            )
+            .await
+        }
+        AllSourceTypes::Pcap(pcap_legacy_byte_source_from_file) => {
+            run_session_by_praser(
+                pcap_legacy_byte_source_from_file,
+                parser,
+                writer,
+                operation_api,
+                state,
+                rx_sde,
+            )
+            .await
+        }
+        AllSourceTypes::PcapNg(pcapng_byte_source_from_file) => {
+            run_session_by_praser(
+                pcapng_byte_source_from_file,
+                parser,
+                writer,
+                operation_api,
+                state,
+                rx_sde,
+            )
+            .await
+        }
+        AllSourceTypes::Tcp(tcp_source) => {
+            run_session_by_praser(tcp_source, parser, writer, operation_api, state, rx_sde).await
+        }
+        AllSourceTypes::Udp(udp_source) => {
+            run_session_by_praser(udp_source, parser, writer, operation_api, state, rx_sde).await
+        }
+        AllSourceTypes::Serial(serial_source) => {
+            run_session_by_praser(serial_source, parser, writer, operation_api, state, rx_sde).await
+        }
+        AllSourceTypes::Process(process_source) => {
+            run_session_by_praser(process_source, parser, writer, operation_api, state, rx_sde)
+                .await
+        }
+    }
+}
+
+/// Matches against all parsers to finally run the session with full generics
+/// using the provided `ByteSource`.
+async fn run_session_by_praser<S: ByteSource, W: LogRecordWriter>(
+    source: S,
+    parser: AllParserTypes,
+    writer: &mut W,
+    operation_api: OperationAPI,
+    state: SessionStateAPI,
+    rx_sde: Option<SdeReceiver>,
+) -> OperationResult<()> {
+    match parser {
+        AllParserTypes::DltRaw(dlt_raw_parser) => {
+            //TODO AAZ: Raw parser isn't part of this here.
+            let producer = MessageProducer::new(dlt_raw_parser, source, writer);
+            export_raw::run_producer(operation_api, producer)
+                .await
+                .map(|opt| opt.map(|_| ()))
+        }
+        AllParserTypes::Dlt(dlt_parser) => {
+            run_session_full_generic(source, dlt_parser, writer, operation_api, state, rx_sde).await
+        }
+        AllParserTypes::SomeIp(someip_parser) => {
+            run_session_full_generic(source, someip_parser, writer, operation_api, state, rx_sde)
+                .await
+        }
+        AllParserTypes::Text(string_tokenizer) => {
+            run_session_full_generic(
+                source,
+                string_tokenizer,
+                writer,
+                operation_api,
+                state,
+                rx_sde,
+            )
+            .await
+        }
+    }
+}
+
+/// Runs the session with generic `ByteSource`, `Parser` and `LogRecordWriter`
+async fn run_session_full_generic<S: ByteSource, P: Parser, W: LogRecordWriter>(
+    source: S,
+    parser: P,
+    writer: &mut W,
+    operation_api: OperationAPI,
+    state: SessionStateAPI,
+    rx_sde: Option<SdeReceiver>,
+) -> OperationResult<()> {
+    let producer = MessageProducer::new(parser, source, writer);
+    session::run_producer(operation_api, state, producer, None, rx_sde).await
 }

--- a/application/apps/indexer/session/src/operations.rs
+++ b/application/apps/indexer/session/src/operations.rs
@@ -76,7 +76,7 @@ impl Operation {
 pub enum OperationKind {
     Observe(
         stypes::SessionSetup,
-        Arc<Components<sources::Source, parsers::Parser>>,
+        Arc<Components<sources::AllSourceTypes, parsers::AllParserTypes>>,
     ),
     Search {
         filters: Vec<SearchFilter>,

--- a/application/apps/indexer/session/src/session.rs
+++ b/application/apps/indexer/session/src/session.rs
@@ -32,7 +32,7 @@ pub struct Session {
     tx_operations: UnboundedSender<Operation>,
     destroyed: CancellationToken,
     destroying: CancellationToken,
-    components: Arc<Components<sources::Source, parsers::Parser>>,
+    components: Arc<Components<sources::AllSourceTypes, parsers::AllParserTypes>>,
     pub state: SessionStateAPI,
     pub tracker: OperationTrackerAPI,
 }
@@ -56,7 +56,8 @@ impl Session {
             UnboundedSender<stypes::CallbackEvent>,
             UnboundedReceiver<stypes::CallbackEvent>,
         ) = unbounded_channel();
-        let mut components: Components<sources::Source, parsers::Parser> = Components::new();
+        let mut components: Components<sources::AllSourceTypes, parsers::AllParserTypes> =
+            Components::new();
         // Registre parsers
         parsers::registration(&mut components)
             .map_err(|err| stypes::ComputationError::NativeError(err))?;

--- a/application/apps/indexer/sources/benches/bench_utls.rs
+++ b/application/apps/indexer/sources/benches/bench_utls.rs
@@ -75,7 +75,7 @@ pub struct ProducerCounter {
 /// different types of producer outputs to avoid unwanted compiler optimizations.
 pub async fn run_producer<P, B, T>(mut producer: MessageProducer<T, P, B>) -> ProducerCounter
 where
-    P: parsers::Parser<T>,
+    P: parsers::AllParserTypes<T>,
     B: sources::ByteSource,
     T: LogMessage,
 {

--- a/application/apps/indexer/sources/benches/mocks/mock_parser.rs
+++ b/application/apps/indexer/sources/benches/mocks/mock_parser.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, iter, marker::PhantomData};
 
-use parsers::{Attachment, LogMessage, Parser};
+use parsers::{AllParserTypes, Attachment, LogMessage};
 use serde::Serialize;
 use std::hint::black_box;
 
@@ -150,7 +150,7 @@ impl<T> MockParser<T> {
 
 // NOTE: Methods within trait implementation have inner non-async function that should never be
 // inline and the trait method should be always inline. This reduces the noise in the benchmarks.
-impl Parser<MockMessage> for MockParser<IterOnce> {
+impl AllParserTypes<MockMessage> for MockParser<IterOnce> {
     /// This will keep returning a valid item result withing an [`iter::once`] until the counter
     /// reaches max count then it will be return [`parsers::Error::Eof`]
     fn parse(
@@ -171,7 +171,7 @@ impl Parser<MockMessage> for MockParser<IterOnce> {
 
 // NOTE: Methods within trait implementation have inner non-async function that should never be
 // inline and the trait method should be always inline. This reduces the noise in the benchmarks.
-impl Parser<MockMessage> for MockParser<IterMany> {
+impl AllParserTypes<MockMessage> for MockParser<IterMany> {
     /// This will keep returning an iterator of multiple valid items until the counter reaches max
     /// count then it will be return [`parsers::Error::Eof`]
     fn parse(

--- a/application/apps/indexer/sources/src/binary/pcap/legacy/descriptor.rs
+++ b/application/apps/indexer/sources/src/binary/pcap/legacy/descriptor.rs
@@ -11,12 +11,12 @@ const PCAP_SOURCE_UUID: uuid::Uuid = uuid::Uuid::from_bytes([
 #[derive(Default)]
 pub struct Descriptor {}
 
-impl ComponentFactory<crate::Source> for Descriptor {
+impl ComponentFactory<crate::AllSourceTypes> for Descriptor {
     fn create(
         &self,
         origin: &SessionAction,
         _options: &[stypes::Field],
-    ) -> Result<Option<crate::Source>, stypes::NativeError> {
+    ) -> Result<Option<crate::AllSourceTypes>, stypes::NativeError> {
         let filepath = match origin {
             SessionAction::File(file) => file,
             SessionAction::Files(..) | SessionAction::Source | SessionAction::ExportRaw(.. ) => {
@@ -27,7 +27,7 @@ impl ComponentFactory<crate::Source> for Descriptor {
                 })
             }
         };
-        Ok(Some(crate::Source::Pcap(PcapLegacyByteSourceFromFile::new(filepath)?)))
+        Ok(Some(crate::AllSourceTypes::Pcap(PcapLegacyByteSourceFromFile::new(filepath)?)))
     }
 }
 

--- a/application/apps/indexer/sources/src/binary/pcap/ng/descriptor.rs
+++ b/application/apps/indexer/sources/src/binary/pcap/ng/descriptor.rs
@@ -11,12 +11,12 @@ const PCAPNG_SOURCE_UUID: uuid::Uuid = uuid::Uuid::from_bytes([
 #[derive(Default)]
 pub struct Descriptor {}
 
-impl ComponentFactory<crate::Source> for Descriptor {
+impl ComponentFactory<crate::AllSourceTypes> for Descriptor {
     fn create(
         &self,
         origin: &SessionAction,
         _options: &[stypes::Field],
-    ) -> Result<Option<crate::Source>, stypes::NativeError> {
+    ) -> Result<Option<crate::AllSourceTypes>, stypes::NativeError> {
                 let filepath = match origin {
             SessionAction::File(file) => file,
             SessionAction::Files(..) | SessionAction::Source | SessionAction::ExportRaw(..) => {
@@ -27,7 +27,7 @@ impl ComponentFactory<crate::Source> for Descriptor {
                 })
             }
         };
-        Ok(Some(crate::Source::PcapNg(PcapngByteSourceFromFile::new(filepath)?)))
+        Ok(Some(crate::AllSourceTypes::PcapNg(PcapngByteSourceFromFile::new(filepath)?)))
     }
 }
 

--- a/application/apps/indexer/sources/src/binary/raw/descriptor.rs
+++ b/application/apps/indexer/sources/src/binary/raw/descriptor.rs
@@ -10,12 +10,12 @@ const BIN_SOURCE_UUID: uuid::Uuid = uuid::Uuid::from_bytes([
 #[derive(Default)]
 pub struct Descriptor {}
 
-impl ComponentFactory<crate::Source> for Descriptor {
+impl ComponentFactory<crate::AllSourceTypes> for Descriptor {
     fn create(
         &self,
         origin: &SessionAction,
         _options: &[stypes::Field],
-    ) -> Result<Option<crate::Source>, stypes::NativeError> {
+    ) -> Result<Option<crate::AllSourceTypes>, stypes::NativeError> {
         let filename = match origin {
             SessionAction::File(filename) => filename,
             SessionAction::Files(..) | SessionAction::Source | SessionAction::ExportRaw(..) => {
@@ -28,7 +28,7 @@ impl ComponentFactory<crate::Source> for Descriptor {
                 });
             }
         };
-        Ok(Some(crate::Source::Raw(
+        Ok(Some(crate::AllSourceTypes::Raw(
             super::BinaryByteSourceFromFile::new(filename)?,
         )))
     }

--- a/application/apps/indexer/sources/src/command/descriptor.rs
+++ b/application/apps/indexer/sources/src/command/descriptor.rs
@@ -17,12 +17,12 @@ const FIELD_SHELLS: &str = "COMMAND_FIELD_SHELLS";
 #[derive(Default)]
 pub struct Descriptor {}
 
-impl ComponentFactory<crate::Source> for Descriptor {
+impl ComponentFactory<crate::AllSourceTypes> for Descriptor {
     fn create(
         &self,
         origin: &SessionAction,
         options: &[Field],
-    ) -> Result<Option<crate::Source>, NativeError> {
+    ) -> Result<Option<crate::AllSourceTypes>, NativeError> {
         let errors = self.validate(origin, options)?;
         if !errors.is_empty() {
             return Err(NativeError {
@@ -40,7 +40,7 @@ impl ComponentFactory<crate::Source> for Descriptor {
         let command: Extracted<String> = options
             .extract_by_key(FIELD_COMMAND)
             .ok_or(missed(FIELD_COMMAND))?;
-        Ok(Some(crate::Source::Process(
+        Ok(Some(crate::AllSourceTypes::Process(
             ProcessSource::new(command.value, env::current_dir().unwrap(), HashMap::new()).unwrap(),
         )))
     }

--- a/application/apps/indexer/sources/src/lib.rs
+++ b/application/apps/indexer/sources/src/lib.rs
@@ -1,5 +1,4 @@
 use components::Components;
-use definitions::{ReloadInfo, SourceError, SourceFilter};
 
 // Rust can't currently distinguish between dev and none-dev dependencies at the moment. There is
 // an open issue for this case: "https://github.com/rust-lang/rust/issues/129637"
@@ -15,7 +14,11 @@ pub mod prelude;
 pub mod serial;
 pub mod socket;
 
-pub enum Source {
+// TODO AAZ:
+// - Consider boxing the source since they may vary in memory print.
+// - Unusual name used here to avoid naming conflicts with types
+//   from `stypes` crate while development
+pub enum AllSourceTypes {
     Raw(binary::raw::BinaryByteSourceFromFile),
     Pcap(binary::pcap::legacy::PcapLegacyByteSourceFromFile),
     PcapNg(binary::pcap::ng::PcapngByteSourceFromFile),
@@ -25,89 +28,11 @@ pub enum Source {
     Process(command::ProcessSource),
 }
 
-impl definitions::ByteSource for Source {
-    fn consume(&mut self, offset: usize) {
-        match self {
-            Self::Raw(inner) => inner.consume(offset),
-            Self::Pcap(inner) => inner.consume(offset),
-            Self::PcapNg(inner) => inner.consume(offset),
-            Self::Tcp(inner) => inner.consume(offset),
-            Self::Udp(inner) => inner.consume(offset),
-            Self::Serial(inner) => inner.consume(offset),
-            Self::Process(inner) => inner.consume(offset),
-        }
-    }
-
-    fn current_slice(&self) -> &[u8] {
-        match self {
-            Self::Raw(inner) => inner.current_slice(),
-            Self::Pcap(inner) => inner.current_slice(),
-            Self::PcapNg(inner) => inner.current_slice(),
-            Self::Tcp(inner) => inner.current_slice(),
-            Self::Udp(inner) => inner.current_slice(),
-            Self::Serial(inner) => inner.current_slice(),
-            Self::Process(inner) => inner.current_slice(),
-        }
-    }
-
-    fn len(&self) -> usize {
-        match self {
-            Self::Raw(inner) => inner.len(),
-            Self::Pcap(inner) => inner.len(),
-            Self::PcapNg(inner) => inner.len(),
-            Self::Tcp(inner) => inner.len(),
-            Self::Udp(inner) => inner.len(),
-            Self::Serial(inner) => inner.len(),
-            Self::Process(inner) => inner.len(),
-        }
-    }
-
-    async fn load(
-        &mut self,
-        filter: Option<&SourceFilter>,
-    ) -> Result<Option<ReloadInfo>, SourceError> {
-        match self {
-            Self::Raw(inner) => inner.load(filter).await,
-            Self::Pcap(inner) => inner.load(filter).await,
-            Self::PcapNg(inner) => inner.load(filter).await,
-            Self::Tcp(inner) => inner.load(filter).await,
-            Self::Udp(inner) => inner.load(filter).await,
-            Self::Serial(inner) => inner.load(filter).await,
-            Self::Process(inner) => inner.load(filter).await,
-        }
-    }
-
-    async fn cancel(&mut self) -> Result<(), SourceError> {
-        match self {
-            Self::Raw(inner) => inner.cancel().await,
-            Self::Pcap(inner) => inner.cancel().await,
-            Self::PcapNg(inner) => inner.cancel().await,
-            Self::Tcp(inner) => inner.cancel().await,
-            Self::Udp(inner) => inner.cancel().await,
-            Self::Serial(inner) => inner.cancel().await,
-            Self::Process(inner) => inner.cancel().await,
-        }
-    }
-
-    async fn income(
-        &mut self,
-        msg: stypes::SdeRequest,
-    ) -> Result<stypes::SdeResponse, SourceError> {
-        match self {
-            Self::Raw(inner) => inner.income(msg).await,
-            Self::Pcap(inner) => inner.income(msg).await,
-            Self::PcapNg(inner) => inner.income(msg).await,
-            Self::Tcp(inner) => inner.income(msg).await,
-            Self::Udp(inner) => inner.income(msg).await,
-            Self::Serial(inner) => inner.income(msg).await,
-            Self::Process(inner) => inner.income(msg).await,
-        }
-    }
-}
-
 // TODO: this registration function will fail if some of source would not be registred. That's wrong.
 // If some of sources are failed, another sources should still be registred as well
-pub fn registration<P>(components: &mut Components<Source, P>) -> Result<(), stypes::NativeError> {
+pub fn registration<P>(
+    components: &mut Components<AllSourceTypes, P>,
+) -> Result<(), stypes::NativeError> {
     components.add_source(binary::raw::Descriptor::default())?;
     components.add_source(binary::pcap::legacy::Descriptor::default())?;
     components.add_source(binary::pcap::ng::Descriptor::default())?;

--- a/application/apps/indexer/sources/src/serial/descriptor.rs
+++ b/application/apps/indexer/sources/src/serial/descriptor.rs
@@ -35,12 +35,12 @@ const FIELD_PORTS_LIST: &str = "SERIAL_SOURCE_PORTS_LIST_FIELD";
 #[derive(Default)]
 pub struct Descriptor {}
 
-impl ComponentFactory<crate::Source> for Descriptor {
+impl ComponentFactory<crate::AllSourceTypes> for Descriptor {
     fn create(
         &self,
         origin: &SessionAction,
         options: &[Field],
-    ) -> Result<Option<crate::Source>, NativeError> {
+    ) -> Result<Option<crate::AllSourceTypes>, NativeError> {
         let errors = self.validate(origin, options)?;
         if !errors.is_empty() {
             return Err(NativeError {
@@ -89,7 +89,9 @@ impl ComponentFactory<crate::Source> for Descriptor {
                 .ok_or(missed(FIELD_EXCLUSIVE))?
                 .value,
         };
-        Ok(Some(crate::Source::Serial(SerialSource::new(config)?)))
+        Ok(Some(crate::AllSourceTypes::Serial(SerialSource::new(
+            config,
+        )?)))
     }
 }
 

--- a/application/apps/indexer/sources/src/socket/tcp/descriptor.rs
+++ b/application/apps/indexer/sources/src/socket/tcp/descriptor.rs
@@ -18,12 +18,12 @@ const FIELD_IP_ADDR: &str = "TCP_SOURCE_FIELD_IP_ADDR";
 #[derive(Default)]
 pub struct Descriptor {}
 
-impl ComponentFactory<crate::Source> for Descriptor {
+impl ComponentFactory<crate::AllSourceTypes> for Descriptor {
     fn create(
         &self,
         origin: &SessionAction,
         options: &[Field],
-    ) -> Result<Option<crate::Source>, NativeError> {
+    ) -> Result<Option<crate::AllSourceTypes>, NativeError> {
         let errors = self.validate(origin, options)?;
         if !errors.is_empty() {
             return Err(NativeError {
@@ -42,7 +42,9 @@ impl ComponentFactory<crate::Source> for Descriptor {
             .extract_by_key(FIELD_IP_ADDR)
             .ok_or(missed(FIELD_IP_ADDR))?
             .value;
-        Ok(Some(crate::Source::Tcp(TcpSource::new(&addr, None, None)?)))
+        Ok(Some(crate::AllSourceTypes::Tcp(TcpSource::new(
+            &addr, None, None,
+        )?)))
     }
 }
 

--- a/application/apps/indexer/sources/src/socket/udp/descriptor.rs
+++ b/application/apps/indexer/sources/src/socket/udp/descriptor.rs
@@ -17,12 +17,12 @@ const FIELD_MULTICAST_ADDR: &str = "UDP_SOURCE_FIELD_MULTICAST_ADDR";
 #[derive(Default)]
 pub struct Descriptor {}
 
-impl ComponentFactory<crate::Source> for Descriptor {
+impl ComponentFactory<crate::AllSourceTypes> for Descriptor {
     fn create(
         &self,
         origin: &SessionAction,
         options: &[Field],
-    ) -> Result<Option<crate::Source>, NativeError> {
+    ) -> Result<Option<crate::AllSourceTypes>, NativeError> {
         let errors = self.validate(origin, options)?;
         if !errors.is_empty() {
             return Err(NativeError {
@@ -72,7 +72,7 @@ impl ComponentFactory<crate::Source> for Descriptor {
                 },
             })
         }
-        Ok(Some(crate::Source::Udp(
+        Ok(Some(crate::AllSourceTypes::Udp(
             UdpSource::new(addr, multicasts).map_err(|err| NativeError {
                 kind: NativeErrorKind::Io,
                 severity: Severity::ERROR,


### PR DESCRIPTION
This PR includes:

* Move matching against parsers and sources to before starting sessions to make sure that producer sessions and making use of generics completely
* Rename parsers and sources enum temporally to avoid conflicts with stypes
* Include SDE in session
* TODOs in code

It also includes skipping CI checks for PRs which aren't targeting master branch