### PR TITLE
Clippy Fixes: Uninlined Format Arguments

### DIFF
--- a/application/apps/indexer/addons/someip-tools/src/lib.rs
+++ b/application/apps/indexer/addons/someip-tools/src/lib.rs
@@ -22,11 +22,7 @@ pub enum Error {
 
 impl nom::error::ParseError<&[u8]> for Error {
     fn from_error_kind(input: &[u8], kind: nom::error::ErrorKind) -> Self {
-        Error::Parse(format!(
-            "Nom error: {:?} ({} bytes left)",
-            kind,
-            input.len()
-        ))
+        Error::Parse(format!("Nom error: {kind:?} ({} bytes left)", input.len()))
     }
 
     fn append(_: &[u8], _: nom::error::ErrorKind, other: Self) -> Self {
@@ -52,11 +48,11 @@ pub fn parse_prefix(input: &[u8]) -> Result<(&[u8], std::string::String), Error>
                 port,
                 Direction::try_from(direction)
                     .ok()
-                    .map_or_else(String::default, |s| format!(" {}", s)),
+                    .map_or_else(String::default, |s| format!(" {s}")),
                 instance,
                 Proto::try_from(proto)
                     .ok()
-                    .map_or_else(String::default, |s| format!(" {}", s))
+                    .map_or_else(String::default, |s| format!(" {s}"))
             )
         },
     )(input)

--- a/application/apps/indexer/addons/text_grep/src/lib.rs
+++ b/application/apps/indexer/addons/text_grep/src/lib.rs
@@ -226,7 +226,7 @@ fn process_file(
                 Ok(true)
             }),
         )
-        .map_err(|e| GrepError::FileProcessingError(format!("Error processing file: {}", e)))?;
+        .map_err(|e| GrepError::FileProcessingError(format!("Error processing file: {e}")))?;
 
     // Alter pattern_counts to have original patterns without (?i)
     let mut altered_pattern_counts = HashMap::new();

--- a/application/apps/indexer/parsers/src/dlt/fmt.rs
+++ b/application/apps/indexer/parsers/src/dlt/fmt.rs
@@ -300,7 +300,7 @@ impl Serialize for FormattableMessage<'_> {
                 state.serialize_field("message-type", &ext_header_msg_type)?;
                 let arg_string = slices
                     .iter()
-                    .map(|slice| format!("{:02X?}", slice))
+                    .map(|slice| format!("{slice:02X?}"))
                     .collect::<Vec<String>>()
                     .join("|");
                 state.serialize_field("payload", &arg_string)?;
@@ -414,7 +414,7 @@ impl FormattableMessage<'_> {
             PayloadContent::NetworkTrace(slices) => {
                 let payload_string = slices
                     .iter()
-                    .map(|slice| format!("{:02X?}", slice))
+                    .map(|slice| format!("{slice:02X?}"))
                     .collect::<Vec<String>>()
                     .join("|");
                 Ok(PrintableMessage::new(
@@ -620,10 +620,10 @@ impl fmt::Display for FormattableMessage<'_> {
                                         .ok()
                                         .map_or_else(String::default, |p| format!("{} ", p.1))
                                 });
-                                return write!(f, "SOME/IP {}{:?}", prefix, message);
+                                return write!(f, "SOME/IP {prefix}{message:?}");
                             }
                             Err(error) => {
-                                return write!(f, "SOME/IP '{}' {:02X?}", error, slice);
+                                return write!(f, "SOME/IP '{error}' {slice:02X?}");
                             }
                         }
                     }
@@ -631,7 +631,7 @@ impl fmt::Display for FormattableMessage<'_> {
 
                 slices
                     .iter()
-                    .try_for_each(|slice| write!(f, "{}{:02X?}", DLT_ARGUMENT_SENTINAL, slice))
+                    .try_for_each(|slice| write!(f, "{DLT_ARGUMENT_SENTINAL}{slice:02X?}"))
             }
         }
     }

--- a/application/apps/indexer/parsers/src/someip.rs
+++ b/application/apps/indexer/parsers/src/someip.rs
@@ -210,7 +210,7 @@ impl SomeipParser {
         match Message::from_slice(input) {
             Ok(Message::Sd(header, payload)) => {
                 let len = header.message_len();
-                debug!("at {} : SD Message ({} bytes)", time, len);
+                debug!("at {time} : SD Message ({len} bytes)");
                 Ok((
                     if input.len() - len < Header::LENGTH {
                         input.len()
@@ -226,7 +226,7 @@ impl SomeipParser {
 
             Ok(Message::Rpc(header, payload)) => {
                 let len = header.message_len();
-                debug!("at {} : RPC Message ({:?} bytes)", time, len);
+                debug!("at {time} : RPC Message ({len:?} bytes)");
                 Ok((
                     if input.len() - len < Header::LENGTH {
                         input.len()
@@ -242,7 +242,7 @@ impl SomeipParser {
 
             Ok(Message::CookieClient) => {
                 let len = Header::LENGTH;
-                debug!("at {} : MCC Message", time);
+                debug!("at {time} : MCC Message");
                 Ok((
                     if input.len() - len < Header::LENGTH {
                         input.len()
@@ -258,7 +258,7 @@ impl SomeipParser {
 
             Ok(Message::CookieServer) => {
                 let len = Header::LENGTH;
-                debug!("at {} : MCS Message", time);
+                debug!("at {time} : MCS Message");
                 Ok((
                     if input.len() - len < Header::LENGTH {
                         input.len()
@@ -276,7 +276,7 @@ impl SomeipParser {
                 someip_messages::Error::NotEnoughData { .. } => Err(Error::Incomplete),
                 e => {
                     let msg = e.to_string();
-                    error!("at {} : {}", time, msg);
+                    error!("at {time} : {msg}");
                     Err(Error::Parse(msg))
                 }
             },

--- a/application/apps/indexer/processor/src/grabber/factory.rs
+++ b/application/apps/indexer/processor/src/grabber/factory.rs
@@ -37,7 +37,7 @@ pub fn create_lazy_grabber(input_p: &Path) -> Result<Grabber, GrabError> {
             let source = TextFileSource::new(input_p);
             let grabber = Grabber::lazy(source).map_err(|e| {
                 let err_msg = format!("Could not create grabber: {e}");
-                warn!("{}", err_msg);
+                warn!("{err_msg}");
                 GrabError::Config(err_msg)
             })?;
             Ok(grabber)

--- a/application/apps/indexer/processor/src/grabber/mod.rs
+++ b/application/apps/indexer/processor/src/grabber/mod.rs
@@ -392,7 +392,7 @@ pub struct FilePart {
 /// It will also return how many lines are in this byte-range and how many need to be skipped
 /// at the beginning and dropped the end to get only the desired content
 pub(crate) fn identify_byte_range(slots: &[Slot], lines: &LineRange) -> Option<FilePart> {
-    trace!("identify byte range for: {:?} (range {:?})", slots, lines);
+    trace!("identify byte range for: {slots:?} (range {lines:?})");
     if lines.is_empty() {
         return None;
     }

--- a/application/apps/indexer/processor/src/text_source.rs
+++ b/application/apps/indexer/processor/src/text_source.rs
@@ -226,7 +226,7 @@ impl TextFileSource {
         }
         use std::io::prelude::*;
         let file_part = identify_byte_range(&metadata.slots, line_range).ok_or_else(|| {
-            error!("Error identifying byte range for range {:?}", line_range);
+            error!("Error identifying byte range for range {line_range:?}");
             debug!("Available slots: {:?}", metadata.slots);
             GrabError::InvalidRange {
                 range: line_range.clone(),

--- a/application/apps/indexer/session/src/handlers/observe.rs
+++ b/application/apps/indexer/session/src/handlers/observe.rs
@@ -16,7 +16,7 @@ pub async fn start_observing(
         settings.load_fibex_metadata();
     };
     if let Err(err) = state.add_executed_observe(options.clone()).await {
-        error!("Fail to store observe options: {:?}", err);
+        error!("Fail to store observe options: {err:?}");
     }
     match &options.origin {
         stypes::ObserveOrigin::File(uuid, file_origin, filename) => {

--- a/application/apps/indexer/session/src/operations.rs
+++ b/application/apps/indexer/session/src/operations.rs
@@ -31,7 +31,7 @@ impl OperationStat {
         let timestamp = match start.duration_since(UNIX_EPOCH) {
             Ok(timestamp) => timestamp.as_micros() as u64,
             Err(err) => {
-                error!("Failed to get timestamp: {}", err);
+                error!("Failed to get timestamp: {err}");
                 0
             }
         };
@@ -47,7 +47,7 @@ impl OperationStat {
         let timestamp = match start.duration_since(UNIX_EPOCH) {
             Ok(timestamp) => timestamp.as_micros() as u64,
             Err(err) => {
-                error!("Failed to get timestamp: {}", err);
+                error!("Failed to get timestamp: {err}");
                 0
             }
         };
@@ -204,7 +204,7 @@ impl OperationAPI {
     pub fn emit(&self, event: stypes::CallbackEvent) {
         let event_log = format!("{event:?}");
         if let Err(err) = self.tx_callback_events.send(event) {
-            error!("Fail to send event {}; error: {}", event_log, err)
+            error!("Fail to send event {event_log}; error: {err}")
         }
     }
 
@@ -257,10 +257,10 @@ impl OperationAPI {
         };
         if !self.state_api.is_closing() && !self.cancellation_token().is_cancelled() {
             if let Err(err) = self.tracker_api.remove_operation(self.id()).await {
-                error!("Failed to remove operation; error: {:?}", err);
+                error!("Failed to remove operation; error: {err:?}");
             }
         }
-        debug!("Operation \"{}\" ({}) finished", alias, self.id());
+        debug!("Operation \"{alias}\" ({}) finished", self.id());
         self.emit(event);
         // Confirm finishing of operation
         self.done_token.cancel();
@@ -529,13 +529,13 @@ pub async fn run(
         }
     }
     if let Err(err) = state_api.close_session().await {
-        error!("Failed to close session: {:?}", err);
+        error!("Failed to close session: {err:?}");
     }
     if let Err(err) = tracker_api.shutdown() {
-        error!("Failed to shutdown tracker: {:?}", err);
+        error!("Failed to shutdown tracker: {err:?}");
     }
     if let Err(err) = state_api.shutdown() {
-        error!("Fail to shutdown state; error: {:?}", err);
+        error!("Fail to shutdown state; error: {err:?}");
     }
     debug!("operations task finished");
 }

--- a/application/apps/indexer/session/src/session.rs
+++ b/application/apps/indexer/session/src/session.rs
@@ -134,11 +134,11 @@ impl Session {
         f: impl Future<Output = Result<(), stypes::NativeError>> + Send + 'static,
     ) {
         if let Err(err) = f.await {
-            error!("State loop exits with error:: {:?}", err);
+            error!("State loop exits with error:: {err:?}");
             if let Err(err) =
                 Session::send_stop_signal(Uuid::new_v4(), tx_operations, None, destroying).await
             {
-                error!("Fail to send stop signal (on {} fail):: {:?}", name, err);
+                error!("Fail to send stop signal (on {name} fail):: {err:?}");
             }
         }
     }

--- a/application/apps/indexer/session/src/state/mod.rs
+++ b/application/apps/indexer/session/src/state/mod.rs
@@ -337,7 +337,7 @@ impl SessionState {
                 ))?;
                 tx_callback_events.send(stypes::CallbackEvent::SearchMapUpdated(Some(updates)))?;
             }
-            Some(Err(err)) => error!("Fail to append search: {}", err),
+            Some(Err(err)) => error!("Fail to append search: {err}"),
             None => (),
         }
         match self

--- a/application/apps/indexer/session/src/state/session_file.rs
+++ b/application/apps/indexer/session/src/state/session_file.rs
@@ -292,7 +292,7 @@ impl SessionFile {
 
         // Remove session main file.
         let filename = self.filename()?;
-        debug!("cleaning up files: {:?}", filename);
+        debug!("cleaning up files: {filename:?}");
         if filename.exists() {
             std::fs::remove_file(&filename).map_err(|e| stypes::NativeError {
                 severity: stypes::Severity::ERROR,

--- a/application/apps/indexer/session/src/tracker.rs
+++ b/application/apps/indexer/session/src/tracker.rs
@@ -205,17 +205,14 @@ pub async fn run(
             }
             TrackerCommand::RemoveOperation((uuid, tx_response)) => {
                 if let Err(err) = state.canceled_operation(uuid).await {
-                    error!(
-                        "fail to notify state about canceled operation {}; err: {:?}",
-                        uuid, err
-                    );
+                    error!("fail to notify state about canceled operation {uuid}; err: {err:?}");
                 }
                 if tracker.debug {
                     let str_uuid = uuid.to_string();
                     if let Some(index) = tracker.stat.iter().position(|op| op.uuid == str_uuid) {
                         tracker.stat[index].done();
                     } else {
-                        error!("fail to find operation in stat: {}", str_uuid);
+                        error!("fail to find operation in stat: {str_uuid}");
                     }
                 }
                 progress.stopped(&uuid);
@@ -231,8 +228,7 @@ pub async fn run(
             TrackerCommand::CancelOperation((uuid, tx_response)) => {
                 if let Err(err) = state.canceling_operation(uuid).await {
                     error!(
-                        "Failed to notify state about cancelation operation {}; err: {:?}",
-                        uuid, err
+                        "Failed to notify state about cancelation operation {uuid}; err: {err:?}"
                     );
                 }
                 tx_response
@@ -242,14 +238,13 @@ pub async fn run(
                         {
                             if !done_token.is_cancelled() {
                                 operation_cancalation_token.cancel();
-                                debug!("Waiting for operation {} would confirm done-state", uuid);
+                                debug!("Waiting for operation {uuid} would confirm done-state");
                                 done_token.cancelled().await;
                                 progress.stopped(&uuid);
                             }
                             if let Err(err) = state.canceled_operation(uuid).await {
                                 error!(
-                                    "Failed to notify state about canceled operation {}; err: {:?}",
-                                    uuid, err
+                                    "Failed to notify state about canceled operation {uuid}; err: {err:?}"
                                 );
                             }
                             true
@@ -267,7 +262,7 @@ pub async fn run(
                 {
                     if !done_token.is_cancelled() {
                         operation_cancalation_token.cancel();
-                        debug!("waiting for operation {} would confirm done-state", uuid);
+                        debug!("waiting for operation {uuid} would confirm done-state");
                         if timeout(
                             Duration::from_millis(CANCEL_OPERATION_TIMEOUT),
                             done_token.cancelled(),

--- a/application/apps/indexer/sources/src/binary/pcap/legacy.rs
+++ b/application/apps/indexer/sources/src/binary/pcap/legacy.rs
@@ -56,7 +56,7 @@ impl<R: Read + Send + Sync> ByteSource for PcapLegacyByteSource<R> {
                         other_type => {
                             debug_block(other_type);
                             skipped += consumed;
-                            debug!("skipped in total {} bytes", skipped);
+                            debug!("skipped in total {skipped} bytes");
                             self.pcap_reader.consume(consumed);
                             continue;
                         }
@@ -67,7 +67,7 @@ impl<R: Read + Send + Sync> ByteSource for PcapLegacyByteSource<R> {
                     return Ok(None);
                 }
                 Err(PcapError::Incomplete(size)) => {
-                    trace!("reloading from pcap file, Incomplete ({})", size);
+                    trace!("reloading from pcap file, Incomplete ({size})");
                     self.pcap_reader
                         .refill()
                         .expect("refill pcap reader failed");
@@ -75,7 +75,7 @@ impl<R: Read + Send + Sync> ByteSource for PcapLegacyByteSource<R> {
                 }
                 Err(e) => {
                     let m = format!("{e}");
-                    error!("reloading from pcap file, {}", m);
+                    error!("reloading from pcap file, {m}");
                     return Err(SourceError::Unrecoverable(m));
                 }
             }
@@ -89,8 +89,7 @@ impl<R: Read + Send + Sync> ByteSource for PcapLegacyByteSource<R> {
                     Some(TransportSlice::Tcp(slice)) => slice.payload(),
                     None => {
                         return Err(SourceError::Unrecoverable(format!(
-                            "ethernet frame with unknown payload: {:02X?}",
-                            raw_data
+                            "ethernet frame with unknown payload: {raw_data:02X?}"
                         )));
                     }
                 };
@@ -138,7 +137,7 @@ impl<R: Read + Send + Sync> ByteSource for PcapLegacyByteSource<R> {
             ))),
         };
         // bytes are copied into buffer and can be dropped by pcap reader
-        trace!("consume {} processed bytes", consumed);
+        trace!("consume {consumed} processed bytes");
         self.pcap_reader.consume(consumed);
         res
     }

--- a/application/apps/indexer/sources/src/binary/pcap/ng.rs
+++ b/application/apps/indexer/sources/src/binary/pcap/ng.rs
@@ -40,8 +40,8 @@ impl<R: Read + Send + Sync> ByteSource for PcapngByteSource<R> {
                 Ok((bytes_read, block)) => {
                     self.total += bytes_read;
                     trace!(
-                        "PcapngByteSource::reload, bytes_read: {} (total: {})",
-                        bytes_read, self.total
+                        "PcapngByteSource::reload, bytes_read: {bytes_read} (total: {})",
+                        self.total
                     );
                     consumed = bytes_read;
                     match block {
@@ -60,7 +60,7 @@ impl<R: Read + Send + Sync> ByteSource for PcapngByteSource<R> {
                         other_type => {
                             debug_block(other_type);
                             skipped += consumed;
-                            debug!("skipped in total {} bytes", skipped);
+                            debug!("skipped in total {skipped} bytes");
                             self.pcapng_reader.consume(consumed);
                             continue;
                         }
@@ -71,7 +71,7 @@ impl<R: Read + Send + Sync> ByteSource for PcapngByteSource<R> {
                     return Ok(None);
                 }
                 Err(PcapError::Incomplete(size)) => {
-                    trace!("reloading from pcap file, Incomplete ({})", size);
+                    trace!("reloading from pcap file, Incomplete ({size})");
                     self.pcapng_reader
                         .refill()
                         .expect("refill pcapng reader failed");
@@ -79,7 +79,7 @@ impl<R: Read + Send + Sync> ByteSource for PcapngByteSource<R> {
                 }
                 Err(e) => {
                     let m = format!("{e}");
-                    error!("reloading from pcap file, {}", m);
+                    error!("reloading from pcap file, {m}");
                     return Err(SourceError::Unrecoverable(m));
                 }
             }
@@ -93,8 +93,7 @@ impl<R: Read + Send + Sync> ByteSource for PcapngByteSource<R> {
                     Some(TransportSlice::Tcp(slice)) => slice.payload(),
                     None => {
                         return Err(SourceError::Unrecoverable(format!(
-                            "ethernet frame with unknown payload: {:02X?}",
-                            raw_data
+                            "ethernet frame with unknown payload: {raw_data:02X?}"
                         )));
                     }
                 };
@@ -142,7 +141,7 @@ impl<R: Read + Send + Sync> ByteSource for PcapngByteSource<R> {
             ))),
         };
         // bytes are copied into buffer and can be dropped by pcap reader
-        trace!("consume {} processed bytes", consumed);
+        trace!("consume {consumed} processed bytes");
         self.pcapng_reader.consume(consumed);
         res
     }

--- a/application/apps/indexer/sources/src/binary/raw.rs
+++ b/application/apps/indexer/sources/src/binary/raw.rs
@@ -48,9 +48,8 @@ impl<R: Read + Send> ByteSource for BinaryByteSource<R> {
         };
         let newly_loaded_bytes = available.saturating_sub(initial_buf_len);
         trace!(
-            "after: capacity: {} (newly loaded: {})",
-            self.reader.capacity(),
-            newly_loaded_bytes
+            "after: capacity: {} (newly loaded: {newly_loaded_bytes})",
+            self.reader.capacity()
         );
         if available == 0 {
             trace!("0, Ok(None)");
@@ -68,7 +67,7 @@ impl<R: Read + Send> ByteSource for BinaryByteSource<R> {
         self.reader.buffer()
     }
     fn consume(&mut self, offset: usize) {
-        trace!("consume {} bytes", offset);
+        trace!("consume {offset} bytes");
         self.reader.consume(offset);
     }
 

--- a/application/apps/indexer/sources/src/producer.rs
+++ b/application/apps/indexer/sources/src/producer.rs
@@ -112,16 +112,15 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
                             // Reset skipped bytes since it had been counted here.
                             skipped_bytes = 0;
                             debug!(
-                            "Extracted a valid message, consumed {} bytes (total used {} bytes)",
-                            consumed, total_used_bytes
-                        );
+                            "Extracted a valid message, consumed {consumed} bytes (total used {total_used_bytes} bytes)"
+                            );
                             total_consumed += consumed;
                             self.buffer
                                 .push((total_used_bytes, MessageStreamItem::Item(m)));
                         }
                         (consumed, None) => {
                             total_consumed += consumed;
-                            trace!("None, consumed {} bytes", consumed);
+                            trace!("None, consumed {consumed} bytes");
                             let total_used_bytes = consumed + skipped_bytes;
                             // Reset skipped bytes since it had been counted here.
                             skipped_bytes = 0;
@@ -163,10 +162,7 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
                     }
                 }
                 Err(ParserError::Eof) => {
-                    trace!(
-                        "EOF reached...no more messages (skipped_bytes={})",
-                        skipped_bytes
-                    );
+                    trace!("EOF reached...no more messages (skipped_bytes={skipped_bytes})");
                     self.done = true;
 
                     return None;
@@ -262,7 +258,7 @@ impl<T: LogMessage, P: Parser<T>, D: ByteSource> MessageProducer<T, P, D> {
             }
             Err(e) => {
                 // In error case we don't need to consider the available bytes.
-                warn!("Error reloading content: {}", e);
+                warn!("Error reloading content: {e}");
                 None
             }
         }

--- a/application/apps/indexer/sources/src/socket/tcp.rs
+++ b/application/apps/indexer/sources/src/socket/tcp.rs
@@ -113,7 +113,7 @@ impl ByteSource for TcpSource {
             debug!("Socket ready to read");
             match self.socket.try_read(&mut self.tmp_buffer) {
                 Ok(len) => {
-                    trace!("---> Received {} bytes", len);
+                    trace!("---> Received {len} bytes");
                     if len == 0 {
                         // No data were received -> Server may be temporally down
                         // then try to reconnect.

--- a/application/apps/indexer/sources/src/socket/udp.rs
+++ b/application/apps/indexer/sources/src/socket/udp.rs
@@ -51,8 +51,7 @@ impl UdpSource {
                         return Err(UdpSourceError::Join(e.to_string()));
                     }
                     debug!(
-                        "Joining UDP multicast group: socket.join_multicast_v4({}, {})",
-                        addr, inter
+                        "Joining UDP multicast group: socket.join_multicast_v4({addr}, {inter})"
                     );
                 }
                 IpAddr::V6(addr) => {

--- a/application/apps/indexer/stypes/src/callback/formating.rs
+++ b/application/apps/indexer/stypes/src/callback/formating.rs
@@ -30,7 +30,7 @@ impl std::fmt::Display for CallbackEvent {
             Self::SearchMapUpdated(_) => write!(f, "SearchMapUpdated"),
             Self::SearchValuesUpdated(_) => write!(f, "SearchValuesUpdated"),
             Self::AttachmentsUpdated { len, attachment: _ } => {
-                write!(f, "AttachmentsUpdated: {}", len)
+                write!(f, "AttachmentsUpdated: {len}")
             }
             Self::Progress {
                 uuid: _,

--- a/application/apps/precompiled/updater/src/env/release_files.rs
+++ b/application/apps/precompiled/updater/src/env/release_files.rs
@@ -87,7 +87,7 @@ impl ReleaseFiles {
                 })?;
                 log::info!("- [removed]: {path:?}");
             } else {
-                log::warn!("- [not found]: {:?}", path);
+                log::warn!("- [not found]: {path:?}");
             }
         }
         Ok(())

--- a/application/apps/precompiled/updater/src/env/sys.rs
+++ b/application/apps/precompiled/updater/src/env/sys.rs
@@ -10,7 +10,7 @@ fn spawn(exe: &str, args: &[&str]) -> Result<Child> {
     Command::new(exe)
         .args(args)
         .spawn()
-        .map_err(|e| anyhow!("could not spawn {} as a process ({})", exe, e))
+        .map_err(|e| anyhow!("could not spawn {exe} as a process ({e})"))
 }
 
 pub fn start(app: PathBuf) -> Result<()> {
@@ -19,7 +19,7 @@ pub fn start(app: PathBuf) -> Result<()> {
     } else {
         app
     };
-    log::debug!("restarting app: {:?}", to_be_started);
+    log::debug!("restarting app: {to_be_started:?}");
     if !to_be_started.exists() {
         Err(anyhow!("Failed to restart, couldn't find executable file"))
     } else {
@@ -30,7 +30,7 @@ pub fn start(app: PathBuf) -> Result<()> {
                 .expect("process for starting could not be spawned"),
             &[],
         )
-        .map_err(|e| anyhow!("Fail to start app due error: {}", e))
+        .map_err(|e| anyhow!("Fail to start app due error: {e}"))
         .map(|_| ())
     }
 }

--- a/application/apps/precompiled/updater/src/updater/macos.rs
+++ b/application/apps/precompiled/updater/src/updater/macos.rs
@@ -48,10 +48,7 @@ impl Updater for PlatformUpdater {
                 &renamed_app_name,
             )
             .map_err(|e| UpdateError::IO(format!("Fail to do renaming: {e}")))?;
-            log::debug!(
-                "Chipmunk application has been renamed to {:?}",
-                renamed_app_name
-            );
+            log::debug!("Chipmunk application has been renamed to {renamed_app_name:?}");
         }
         // Copy files
         let mut options = dir::CopyOptions::new();

--- a/application/apps/rustcore/rs-bindings/src/js/session/mod.rs
+++ b/application/apps/rustcore/rs-bindings/src/js/session/mod.rs
@@ -23,7 +23,7 @@ impl RustSession {
             Ok(uuid) => uuid,
             Err(err) => {
                 // TODO: Should be replaced with error
-                panic!("Fail to convert UUID = {}; error:{}", id, err);
+                panic!("Fail to convert UUID = {id}; error:{err}");
             }
         };
         Self {
@@ -466,9 +466,7 @@ impl RustSession {
             .ok_or(stypes::ComputationError::SessionUnavailable)?;
         info!(
             target: targets::SESSION,
-            "Search (operation: {}) will be done withing next filters: {:?}",
-            operation_id,
-            filters
+            "Search (operation: {operation_id}) will be done withing next filters: {filters:?}"
         );
         session.apply_search_filters(
             operations::uuid_from_str(&operation_id)?,
@@ -488,9 +486,7 @@ impl RustSession {
             .ok_or(stypes::ComputationError::SessionUnavailable)?;
         info!(
             target: targets::SESSION,
-            "Search values (operation: {}) will be done withing next filters: {:?}",
-            operation_id,
-            filters
+            "Search values (operation: {operation_id}) will be done withing next filters: {filters:?}"
         );
         session.apply_search_values_filters(operations::uuid_from_str(&operation_id)?, filters)
     }
@@ -525,9 +521,7 @@ impl RustSession {
             .ok_or(stypes::ComputationError::SessionUnavailable)?;
         info!(
             target: targets::SESSION,
-            "Extract (operation: {}) will be done withing next filters: {:?}",
-            operation_id,
-            filters
+            "Extract (operation: {operation_id}) will be done withing next filters: {filters:?}"
         );
         session.extract_matches(
             operations::uuid_from_str(&operation_id)?,
@@ -556,10 +550,7 @@ impl RustSession {
                     } else {
                         warn!(
                             target: targets::SESSION,
-                            "Invalid range (operation: {}): from = {}; to = {}",
-                            operation_id,
-                            from,
-                            to
+                            "Invalid range (operation: {operation_id}): from = {from}; to = {to}"
                         );
                     }
                 }
@@ -567,7 +558,7 @@ impl RustSession {
         }
         info!(
             target: targets::SESSION,
-            "Map requested (operation: {}). Range: {:?}", operation_id, range
+            "Map requested (operation: {operation_id}). Range: {range:?}"
         );
         session.get_map(
             operations::uuid_from_str(&operation_id)?,
@@ -600,7 +591,7 @@ impl RustSession {
         };
         info!(
             target: targets::SESSION,
-            "Values requested (operation: {}). Range: {:?}", operation_id, range
+            "Values requested (operation: {operation_id}). Range: {range:?}"
         );
         session.get_values(
             operations::uuid_from_str(&operation_id)?,

--- a/application/apps/rustcore/wasm-bindings/src/matcher.rs
+++ b/application/apps/rustcore/wasm-bindings/src/matcher.rs
@@ -38,7 +38,7 @@ impl Matcher {
                 self.search(String::new(), None);
                 Ok(self.items_initial.len() - 1)
             }
-            Err(err) => Err(format!("Parsing item into JSON String failed: {}", err)),
+            Err(err) => Err(format!("Parsing item into JSON String failed: {err}")),
         }
     }
 
@@ -51,7 +51,7 @@ impl Matcher {
                 self.search(String::new(), None);
                 Ok(from)
             }
-            Err(err) => Err(format!("Parsing item into JSON String failed: {}", err)),
+            Err(err) => Err(format!("Parsing item into JSON String failed: {err}")),
         }
     }
 
@@ -75,19 +75,19 @@ impl Matcher {
             for (key, value) in item {
                 if query.is_empty() {
                     temp_hashmap.insert(key.clone(), value.clone());
-                    temp_hashmap.insert(format!("html_{}", key), value.to_string());
+                    temp_hashmap.insert(format!("html_{key}"), value.to_string());
                     total_score += (self.items_initial.len() - index) as i64;
                 } else {
                     match self.matcher.fuzzy_indices(value.as_str(), &query) {
                         Some(score) => {
                             let tagged_match = self.tag_match(value.to_owned(), score.1, &tag);
                             temp_hashmap.insert(key.clone(), value.to_owned());
-                            temp_hashmap.insert(format!("html_{}", key), tagged_match);
+                            temp_hashmap.insert(format!("html_{key}"), tagged_match);
                             total_score += score.0;
                         }
                         None => {
                             temp_hashmap.insert(key.clone(), value.clone());
-                            temp_hashmap.insert(format!("html_{}", key), value.to_string());
+                            temp_hashmap.insert(format!("html_{key}"), value.to_string());
                         }
                     }
                 }
@@ -120,8 +120,8 @@ impl Matcher {
 
     fn tag_match(&self, mut value: String, indexes: Vec<usize>, tag: &Option<String>) -> String {
         let tag = tag.to_owned().unwrap_or_else(|| "span".to_string());
-        let op_tag = format!("<{}>", tag);
-        let ed_tag = format!("</{}>", tag);
+        let op_tag = format!("<{tag}>");
+        let ed_tag = format!("</{tag}>");
         let value_clone = value.clone();
         let value_bytes = value_clone.as_bytes();
         let mut index = indexes.iter().rev();
@@ -139,7 +139,7 @@ impl Matcher {
                     Ok(substring) => {
                         value.replace_range(
                             prev..start + 1,
-                            format!("{}{}{}", op_tag, substring, ed_tag).as_str(),
+                            format!("{op_tag}{substring}{ed_tag}").as_str(),
                         );
                         start = curr;
                         prev = curr;
@@ -154,7 +154,7 @@ impl Matcher {
             Ok(substring) => {
                 value.replace_range(
                     prev..start + 1,
-                    format!("{}{}{}", op_tag, substring, ed_tag).as_str(),
+                    format!("{op_tag}{substring}{ed_tag}").as_str(),
                 );
                 value
             }
@@ -186,10 +186,10 @@ fn test(query: String, tag: Option<String>, expected: Vec<HashMap<&str, &str>>) 
         match serde_wasm_bindgen::to_value(&item) {
             Ok(item) => {
                 if let Err(err) = matcher.set_item(item) {
-                    panic!("{}", err)
+                    panic!("{err}")
                 }
             }
-            Err(err) => panic!("{}", err),
+            Err(err) => panic!("{err}"),
         }
     }
     matcher.search(query, tag);
@@ -197,7 +197,7 @@ fn test(query: String, tag: Option<String>, expected: Vec<HashMap<&str, &str>>) 
         for (&key, &value) in map {
             match matcher.get_html_of(index, key.to_string()) {
                 Some(html) => assert_eq!(html, value),
-                None => panic!("Failed to get html of {}", key),
+                None => panic!("Failed to get html of {key}"),
             }
         }
     }

--- a/cli/chipmunk-cli/src/main.rs
+++ b/cli/chipmunk-cli/src/main.rs
@@ -34,7 +34,7 @@ async fn cancel_listener(cancel_token: CancellationToken) {
                 cancel_count += 1;
             }
             Err(err) => {
-                eprintln!("Unable to listen for shutdown signal: {}", err);
+                eprintln!("Unable to listen for shutdown signal: {err}");
                 std::process::exit(1)
             }
         }

--- a/cli/development-cli/dir_checksum/src/hash_digest.rs
+++ b/cli/development-cli/dir_checksum/src/hash_digest.rs
@@ -20,7 +20,7 @@ impl FromStr for HashDigest {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let hash = blake3::Hash::from_hex(s).map_err(|e| format!("Invalid Input. Error: {}", e))?;
+        let hash = blake3::Hash::from_hex(s).map_err(|e| format!("Invalid Input. Error: {e}"))?;
 
         Ok(Self { hash })
     }

--- a/cli/development-cli/src/jobs_runner/jobs_resolver.rs
+++ b/cli/development-cli/src/jobs_runner/jobs_resolver.rs
@@ -71,9 +71,7 @@ pub fn resolve(
 
             assert!(
                 jobs_tree.insert(job_def, dep_jobs).is_none(),
-                "JobDefinition is added to tree more than once. Target: {}, Job: {}",
-                target,
-                job
+                "JobDefinition is added to tree more than once. Target: {target}, Job: {job}",
             );
         }
     }

--- a/cli/development-cli/src/main.rs
+++ b/cli/development-cli/src/main.rs
@@ -287,7 +287,7 @@ async fn main_process(command: Command) -> Result<(), Error> {
                 }
             }
             Err(err) => {
-                eprintln!("Error: {:?}", err);
+                eprintln!("Error: {err:?}");
                 eprintln!("---------------------------------------------------------------------");
                 success = false;
             }

--- a/cli/development-cli/src/release/codesign/macos.rs
+++ b/cli/development-cli/src/release/codesign/macos.rs
@@ -207,7 +207,7 @@ pub fn notarize(config: &MacOsConfig) -> anyhow::Result<()> {
     })?;
 
     let release_file_name = release_file_name()?;
-    let archname = format!("{}.tgz", release_file_name);
+    let archname = format!("{release_file_name}.tgz");
 
     let cli_archname = format!("{}.tgz", cli_release_file_name()?);
 

--- a/cli/development-cli/src/release/compress.rs
+++ b/cli/development-cli/src/release/compress.rs
@@ -21,7 +21,7 @@ use super::env_utls::is_arm_archit;
 /// used on releases.
 pub async fn compress() -> anyhow::Result<()> {
     let release_file_name = release_file_name()?;
-    let archname = format!("{}.tgz", release_file_name);
+    let archname = format!("{release_file_name}.tgz");
 
     let mut tar_cmd = format!("tar -czf ../{archname} ");
 
@@ -138,7 +138,7 @@ fn chipmunk_version() -> anyhow::Result<String> {
 pub async fn compress_cli() -> anyhow::Result<()> {
     let release_file_name = cli_release_file_name()?;
 
-    let arch_name = format!("{}.tgz", release_file_name);
+    let arch_name = format!("{release_file_name}.tgz");
 
     let tar_cmd = format!(
         "tar -czf {arch_name} --directory={binary_path} {binary_name}",

--- a/cli/development-cli/src/target/mod.rs
+++ b/cli/development-cli/src/target/mod.rs
@@ -581,7 +581,7 @@ impl Target {
             fstools::rm_folder(job_def, &path)?;
         }
 
-        let job = format!("Clean {}", self);
+        let job = format!("Clean {self}");
 
         let logs = tracker.get_logs(job_def).await?.unwrap_or_default();
 


### PR DESCRIPTION
This PR applies clippy fix for Uninlined arguments in format macros among all rust projects and crates within Chipmunk.

This fix introduced into stable rust in version 1.88