### PR TITLE
Provide Invert Flag in Search Filters

### DIFF
--- a/application/apps/indexer/processor/src/search/filter.rs
+++ b/application/apps/indexer/processor/src/search/filter.rs
@@ -8,15 +8,23 @@ pub struct SearchFilter {
     is_regex: bool,
     ignore_case: bool,
     is_word: bool,
+    pub invert: bool,
 }
 
 impl SearchFilter {
-    pub fn new(value: String, is_regex: bool, ignore_case: bool, is_word: bool) -> Self {
+    pub fn new(
+        value: String,
+        is_regex: bool,
+        ignore_case: bool,
+        is_word: bool,
+        invert: bool,
+    ) -> Self {
         SearchFilter {
             value,
             is_regex,
             ignore_case,
             is_word,
+            invert,
         }
     }
 
@@ -26,6 +34,7 @@ impl SearchFilter {
             is_regex: false,
             ignore_case: false,
             is_word: false,
+            invert: false,
         }
     }
 
@@ -57,11 +66,17 @@ impl SearchFilter {
         self.is_word = word;
         self
     }
+
+    #[must_use]
+    pub fn invert(mut self, invert: bool) -> Self {
+        self.invert = invert;
+        self
+    }
 }
 
 pub fn get_filter_error(filter: &SearchFilter) -> Option<String> {
-    let regex_as_str = as_regex(filter);
-    Regex::from_str(&regex_as_str).map_or_else(|err| Some(err.to_string()), |_| None)
+    let regex_info = as_regex(filter);
+    Regex::from_str(&regex_info).map_or_else(|err| Some(err.to_string()), |_| None)
 }
 
 pub fn as_regex(filter: &SearchFilter) -> String {
@@ -73,15 +88,17 @@ pub fn as_regex(filter: &SearchFilter) -> String {
     } else {
         regex::escape(&filter.value)
     };
-    format!("{ignore_case_start}{word_marker}{subject}{word_marker}{ignore_case_end}",)
+
+    format!("{ignore_case_start}{word_marker}{subject}{word_marker}{ignore_case_end}")
 }
 
 pub fn as_alias(filter: &SearchFilter) -> String {
     let word_marker = if filter.is_word { "1" } else { "0" };
     let ignore_case = if filter.ignore_case { "1" } else { "0" };
     let is_regex = if filter.is_regex { "1" } else { "0" };
+    let invert = if filter.invert { "1" } else { "0" };
     format!(
-        "{}:{}{}{}",
-        filter.value, is_regex, ignore_case, word_marker
+        "{}:{}{}{}{}",
+        filter.value, is_regex, ignore_case, word_marker, invert
     )
 }

--- a/application/apps/indexer/processor/src/search/searchers/linear.rs
+++ b/application/apps/indexer/processor/src/search/searchers/linear.rs
@@ -8,6 +8,8 @@ use std::str::FromStr;
 pub struct LineSearcher {
     /// A compiled regular expression used for matching lines.
     re: Regex,
+    /// invert the match result.
+    invert: bool,
 }
 
 impl LineSearcher {
@@ -27,6 +29,7 @@ impl LineSearcher {
             re: Regex::from_str(&regex_as_str).map_err(|err| {
                 SearchError::Regex(format!("Failed to create regex for {regex_as_str}: {err}"))
             })?,
+            invert: filter.invert,
         })
     }
 
@@ -41,6 +44,7 @@ impl LineSearcher {
     /// * `true` - If the line matches the regular expression.
     /// * `false` - Otherwise.
     pub fn is_match(&self, ln: &str) -> bool {
-        self.re.is_match(ln)
+        let do_match = self.re.is_match(ln);
+        if self.invert { !do_match } else { do_match }
     }
 }

--- a/application/apps/indexer/processor/src/search/searchers/tests_linear.rs
+++ b/application/apps/indexer/processor/src/search/searchers/tests_linear.rs
@@ -19,36 +19,99 @@ fn test_linear() -> Result<(), std::io::Error> {
             SearchFilter::plain(r"[Err]")
                 .regex(false)
                 .ignore_case(true)
-                .word(false),
+                .word(false)
+                .invert(false),
             &[3, 4],
         ),
         (
             SearchFilter::plain(r"[err]")
                 .regex(false)
                 .ignore_case(true)
-                .word(false),
+                .word(false)
+                .invert(false),
             &[3, 4],
         ),
         (
             SearchFilter::plain(r"[err]")
                 .regex(false)
                 .ignore_case(false)
-                .word(false),
+                .word(false)
+                .invert(false),
             &[4],
         ),
         (
             SearchFilter::plain(r"\[Warn\]")
                 .regex(true)
                 .ignore_case(true)
-                .word(false),
+                .word(false)
+                .invert(false),
             &[1, 7],
         ),
         (
             SearchFilter::plain(r"warn")
                 .regex(true)
                 .ignore_case(false)
-                .word(false),
+                .word(false)
+                .invert(false),
             &[7],
+        ),
+    ];
+    for (filter, matches) in cases.into_iter() {
+        let searcher =
+            LineSearcher::new(&filter).map_err(|err| std::io::Error::other(err.to_string()))?;
+        for (n, smpl) in SAMPLES.iter().enumerate() {
+            if searcher.is_match(smpl) {
+                assert!(matches.contains(&n));
+            } else {
+                assert!(!matches.contains(&n));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_linear_invert() -> Result<(), std::io::Error> {
+    let cases: Vec<(SearchFilter, &[usize])> = vec![
+        (
+            SearchFilter::plain(r"[Err]")
+                .regex(false)
+                .ignore_case(true)
+                .word(false)
+                .invert(true),
+            &[0, 1, 2, 5, 6, 7],
+        ),
+        (
+            SearchFilter::plain(r"[err]")
+                .regex(false)
+                .ignore_case(true)
+                .word(false)
+                .invert(true),
+            &[0, 1, 2, 5, 6, 7],
+        ),
+        (
+            SearchFilter::plain(r"[err]")
+                .regex(false)
+                .ignore_case(false)
+                .word(false)
+                .invert(true),
+            &[0, 1, 2, 3, 5, 6, 7],
+        ),
+        (
+            SearchFilter::plain(r"\[Warn\]")
+                .regex(true)
+                .ignore_case(true)
+                .word(false)
+                .invert(true),
+            &[0, 2, 3, 4, 5, 6],
+        ),
+        (
+            SearchFilter::plain(r"warn")
+                .regex(true)
+                .ignore_case(false)
+                .word(false)
+                .invert(true),
+            &[0, 1, 2, 3, 4, 5, 6],
         ),
     ];
     for (filter, matches) in cases.into_iter() {

--- a/application/apps/indexer/processor/src/search/searchers/values.rs
+++ b/application/apps/indexer/processor/src/search/searchers/values.rs
@@ -9,7 +9,7 @@ use std::{
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-use super::{BaseSearcher, SearchState};
+use super::{BaseSearcher, SearchState, SearchTerms};
 
 pub type OperationResults = Result<(Range<usize>, HashMap<u8, Vec<(u64, f64)>>), SearchError>;
 
@@ -46,6 +46,7 @@ fn is_valid(filter: &str) -> bool {
 }
 
 #[derive(Debug)]
+/// Value Search is used for charts only and it works with include regex only.
 pub struct ValueSearchState {
     pub file_path: PathBuf,
     pub uuid: Uuid,
@@ -92,8 +93,10 @@ impl SearchState for ValueSearchState {
             errors: HashMap::new(),
         }
     }
-    fn get_terms(&self) -> Vec<String> {
-        self.terms.iter().map(|f| as_regex(f)).collect()
+    fn get_terms(&self) -> SearchTerms {
+        // Value Searcher works in charts with include regex only.
+        let include = self.terms.iter().map(|f| as_regex(f)).collect();
+        SearchTerms::new(include, Vec::new())
     }
 }
 

--- a/application/apps/rustcore/rs-bindings/src/js/converting/filter.rs
+++ b/application/apps/rustcore/rs-bindings/src/js/converting/filter.rs
@@ -59,11 +59,21 @@ impl JSValue<'_> for WrappedSearchFilter {
                     return Err(e);
                 }
             };
+            let invert: bool = match js_obj.get_property("invert") {
+                Ok(Some(value)) => value.as_value()?,
+                Ok(None) => {
+                    return Err(NjError::Other("[invert] property is not found".to_owned()));
+                }
+                Err(e) => {
+                    return Err(e);
+                }
+            };
             Ok(WrappedSearchFilter(SearchFilter::new(
                 value,
                 is_regex,
                 ignore_case,
                 is_word,
+                invert,
             )))
         } else {
             Err(NjError::Other("not valid format".to_owned()))

--- a/application/apps/rustcore/ts-bindings/spec/_session.benchmark.spec.ts
+++ b/application/apps/rustcore/ts-bindings/spec/_session.benchmark.spec.ts
@@ -224,7 +224,12 @@ describe('Benchmark Tests', function () {
                                     await search.search([
                                         {
                                             filter: 'HTTP',
-                                            flags: { reg: true, word: true, cases: false },
+                                            flags: {
+                                                reg: true,
+                                                word: true,
+                                                cases: false,
+                                                invert: false,
+                                            },
                                         },
                                     ]);
                                     let items = await stream.grabIndexed(0, countMatches);
@@ -258,7 +263,12 @@ describe('Benchmark Tests', function () {
                                         .search([
                                             {
                                                 filter: 'http',
-                                                flags: { reg: true, word: false, cases: false },
+                                                flags: {
+                                                    reg: true,
+                                                    word: false,
+                                                    cases: false,
+                                                    invert: false,
+                                                },
                                             },
                                         ])
                                         .catch(finish.bind(null, session, done));
@@ -280,15 +290,30 @@ describe('Benchmark Tests', function () {
                                         .search([
                                             {
                                                 filter: 'http://www.almhuette-raith.at',
-                                                flags: { reg: true, word: false, cases: false },
+                                                flags: {
+                                                    reg: true,
+                                                    word: false,
+                                                    cases: false,
+                                                    invert: false,
+                                                },
                                             },
                                             {
                                                 filter: 'com.apple.hiservices-xpcservice',
-                                                flags: { reg: true, word: false, cases: false },
+                                                flags: {
+                                                    reg: true,
+                                                    word: false,
+                                                    cases: false,
+                                                    invert: false,
+                                                },
                                             },
                                             {
                                                 filter: 'Google Chrome Helper',
-                                                flags: { reg: true, word: false, cases: false },
+                                                flags: {
+                                                    reg: true,
+                                                    word: false,
+                                                    cases: false,
+                                                    invert: false,
+                                                },
                                             },
                                         ])
                                         .catch(finish.bind(null, session, done));

--- a/application/apps/rustcore/ts-bindings/spec/session.cancel.spec.ts
+++ b/application/apps/rustcore/ts-bindings/spec/session.cancel.spec.ts
@@ -130,7 +130,7 @@ describe('Cancel', function () {
                     .search([
                         {
                             filter,
-                            flags: { reg: true, word: false, cases: false },
+                            flags: { reg: true, word: false, cases: false, invert: false },
                         },
                     ])
                     .canceled(() => {

--- a/application/apps/rustcore/ts-bindings/spec/session.errors.spec.ts
+++ b/application/apps/rustcore/ts-bindings/spec/session.errors.spec.ts
@@ -22,7 +22,7 @@ describe('Errors', () => {
                 .search([
                     {
                         filter: 'match',
-                        flags: { reg: true, word: true, cases: false },
+                        flags: { reg: true, word: true, cases: false, invert: false },
                     },
                 ])
                 .then((_found: number) =>
@@ -117,7 +117,7 @@ describe('Errors', () => {
                         .search([
                             {
                                 filter: 'match',
-                                flags: { reg: true, word: false, cases: false },
+                                flags: { reg: true, word: false, cases: false, invert: false },
                             },
                         ])
                         .then((found: number) => {
@@ -319,7 +319,7 @@ describe('Errors', () => {
                         .search([
                             {
                                 filter: 'invalid search { condition',
-                                flags: { reg: true, word: false, cases: false },
+                                flags: { reg: true, word: false, cases: false, invert: false },
                             },
                         ])
                         .then((_) => {

--- a/application/apps/rustcore/ts-bindings/spec/session.exporting.spec.ts
+++ b/application/apps/rustcore/ts-bindings/spec/session.exporting.spec.ts
@@ -225,7 +225,7 @@ describe('Exporting', function () {
                         .search([
                             {
                                 filter: '__\\d+__',
-                                flags: { reg: true, word: false, cases: false },
+                                flags: { reg: true, word: false, cases: false, invert: false },
                             },
                         ])
                         .then((_found) => {

--- a/application/apps/rustcore/ts-bindings/spec/session.extract.spec.ts
+++ b/application/apps/rustcore/ts-bindings/spec/session.extract.spec.ts
@@ -16,133 +16,133 @@ const config = readConfigurationFile().get().tests.extract;
 describe('Extracting', function () {
     it(config.regular.list[1], function () {
         return runners.withSession(config.regular, 1, async (logger, done, comps) => {
-                let controlSum = 0;
-                const tmpobj = createSampleFile(5000, logger, (i: number) => {
-                    const value = i % 100 === 0 || i <= 5 ? i : -1;
-                    controlSum += value !== -1 ? value : 0;
-                    return `[${i}]:: ${
-                        value !== -1 ? `some CPU=${value}% line data\n` : `some line data\n`
-                    }`;
-                });
+            let controlSum = 0;
+            const tmpobj = createSampleFile(5000, logger, (i: number) => {
+                const value = i % 100 === 0 || i <= 5 ? i : -1;
+                controlSum += value !== -1 ? value : 0;
+                return `[${i}]:: ${
+                    value !== -1 ? `some CPU=${value}% line data\n` : `some line data\n`
+                }`;
+            });
 
-                comps.stream
-                    .observe(
-                        new Factory.File()
-                            .asText()
-                            .type(Factory.FileType.Text)
-                            .file(tmpobj.name)
-                            .get()
-                            .sterilized(),
-                    )
-                    .on('processing', () => {
-                        const filter = 'cpu=(\\d{1,})';
-                        comps.search
-                            .extract([
-                                {
-                                    filter,
-                                    flags: { reg: true, word: false, cases: false },
-                                },
-                            ])
-                            .then((results) => {
-                                expect(results.length).toEqual(55);
-                                for (let pos = 0; pos <= 5; pos += 1) {
-                                    expect(results[pos].position).toEqual(pos);
-                                }
-                                for (let pos = 1; pos <= 49; pos += 1) {
-                                    expect(results[pos + 5].position).toEqual(pos * 100);
-                                }
-                                let calculated = 0;
-                                results.forEach((res) => {
-                                    expect(res.values.length).toEqual(1);
-                                    expect(res.values[0].filter.filter).toEqual(filter);
-                                    calculated += parseInt(res.values[0].values[0], 10);
+            comps.stream
+                .observe(
+                    new Factory.File()
+                        .asText()
+                        .type(Factory.FileType.Text)
+                        .file(tmpobj.name)
+                        .get()
+                        .sterilized(),
+                )
+                .on('processing', () => {
+                    const filter = 'cpu=(\\d{1,})';
+                    comps.search
+                        .extract([
+                            {
+                                filter,
+                                flags: { reg: true, word: false, cases: false, invert: false },
+                            },
+                        ])
+                        .then((results) => {
+                            expect(results.length).toEqual(55);
+                            for (let pos = 0; pos <= 5; pos += 1) {
+                                expect(results[pos].position).toEqual(pos);
+                            }
+                            for (let pos = 1; pos <= 49; pos += 1) {
+                                expect(results[pos + 5].position).toEqual(pos * 100);
+                            }
+                            let calculated = 0;
+                            results.forEach((res) => {
+                                expect(res.values.length).toEqual(1);
+                                expect(res.values[0].filter.filter).toEqual(filter);
+                                calculated += parseInt(res.values[0].values[0], 10);
+                            });
+                            expect(calculated).toEqual(controlSum);
+                            comps.search
+                                .len()
+                                .then((len: number) => {
+                                    expect(len).toEqual(0);
+                                    finish(comps.session, done);
+                                })
+                                .catch((err: Error) => {
+                                    finish(comps.session, done, err);
                                 });
-                                expect(calculated).toEqual(controlSum);
-                                comps.search
-                                    .len()
-                                    .then((len: number) => {
-                                        expect(len).toEqual(0);
-                                        finish(comps.session, done);
-                                    })
-                                    .catch((err: Error) => {
-                                        finish(comps.session, done, err);
-                                    });
-                            })
-                            .catch(finish.bind(null, comps.session, done));
-                    })
-                    .catch(finish.bind(null, comps.session, done));
+                        })
+                        .catch(finish.bind(null, comps.session, done));
+                })
+                .catch(finish.bind(null, comps.session, done));
         });
     });
 
     it(config.regular.list[2], function () {
         return runners.withSession(config.regular, 2, async (logger, done, comps) => {
-                let controlSumA = 0;
-                let controlSumB = 0;
-                const tmpobj = createSampleFile(5000, logger, (i: number) => {
-                    const a = i % 100 === 0 || i <= 5 ? i : -1;
-                    controlSumA += a !== -1 ? a : 0;
-                    const b = a === -1 && i % 20 === 0 ? i : -1;
-                    controlSumB += b !== -1 ? b : 0;
-                    return `[${i}]:: ${
-                        a !== -1
-                            ? `some CPU=${a}% line data\n`
-                            : b === -1
-                            ? `some line data\n`
-                            : `some TEMP=${b}C line data\n`
-                    }`;
-                });
-                comps.stream
-                    .observe(
-                        new Factory.File()
-                            .asText()
-                            .type(Factory.FileType.Text)
-                            .file(tmpobj.name)
-                            .get()
-                            .sterilized(),
-                    )
-                    .on('processing', () => {
-                        const filterA = 'cpu=(\\d{1,})';
-                        const filterB = 'temp=(\\d{1,})';
-                        comps.search
-                            .extract([
-                                {
-                                    filter: filterA,
-                                    flags: { reg: true, word: false, cases: false },
-                                },
-                                {
-                                    filter: filterB,
-                                    flags: { reg: true, word: false, cases: false },
-                                },
-                            ])
-                            .then((results) => {
-                                let calculatedA = 0;
-                                let calculatedB = 0;
-                                results.forEach((res) => {
-                                    res.values.forEach((match) => {
-                                        expect(match.values.length).toEqual(1);
-                                        if (match.filter.filter === filterA) {
-                                            calculatedA += parseInt(match.values[0], 10);
-                                        }
-                                        if (match.filter.filter === filterB) {
-                                            calculatedB += parseInt(match.values[0], 10);
-                                        }
-                                    });
+            let controlSumA = 0;
+            let controlSumB = 0;
+            const tmpobj = createSampleFile(5000, logger, (i: number) => {
+                const a = i % 100 === 0 || i <= 5 ? i : -1;
+                controlSumA += a !== -1 ? a : 0;
+                const b = a === -1 && i % 20 === 0 ? i : -1;
+                controlSumB += b !== -1 ? b : 0;
+                return `[${i}]:: ${
+                    a !== -1
+                        ? `some CPU=${a}% line data\n`
+                        : b === -1
+                          ? `some line data\n`
+                          : `some TEMP=${b}C line data\n`
+                }`;
+            });
+            comps.stream
+                .observe(
+                    new Factory.File()
+                        .asText()
+                        .type(Factory.FileType.Text)
+                        .file(tmpobj.name)
+                        .get()
+                        .sterilized(),
+                )
+                .on('processing', () => {
+                    const filterA = 'cpu=(\\d{1,})';
+                    const filterB = 'temp=(\\d{1,})';
+                    comps.search
+                        .extract([
+                            {
+                                filter: filterA,
+                                flags: { reg: true, word: false, cases: false, invert: false },
+                            },
+                            {
+                                filter: filterB,
+                                flags: { reg: true, word: false, cases: false, invert: false },
+                            },
+                        ])
+                        .then((results) => {
+                            let calculatedA = 0;
+                            let calculatedB = 0;
+                            results.forEach((res) => {
+                                res.values.forEach((match) => {
+                                    expect(match.values.length).toEqual(1);
+                                    if (match.filter.filter === filterA) {
+                                        calculatedA += parseInt(match.values[0], 10);
+                                    }
+                                    if (match.filter.filter === filterB) {
+                                        calculatedB += parseInt(match.values[0], 10);
+                                    }
                                 });
-                                expect(calculatedA).toEqual(controlSumA);
-                                expect(calculatedB).toEqual(controlSumB);
-                                comps.search
-                                    .len()
-                                    .then((len: number) => {
-                                        expect(len).toEqual(0);
-                                        finish(comps.session, done);
-                                    })
-                                    .catch((err: Error) => {
-                                        finish(comps.session, done, err);
-                                    });
-                            })
-                            .catch(finish.bind(null, comps.session, done));
-                    })
-                    .catch(finish.bind(null, comps.session, done));
+                            });
+                            expect(calculatedA).toEqual(controlSumA);
+                            expect(calculatedB).toEqual(controlSumB);
+                            comps.search
+                                .len()
+                                .then((len: number) => {
+                                    expect(len).toEqual(0);
+                                    finish(comps.session, done);
+                                })
+                                .catch((err: Error) => {
+                                    finish(comps.session, done, err);
+                                });
+                        })
+                        .catch(finish.bind(null, comps.session, done));
+                })
+                .catch(finish.bind(null, comps.session, done));
         });
     });
 });

--- a/application/apps/rustcore/ts-bindings/spec/session.indexes.spec.ts
+++ b/application/apps/rustcore/ts-bindings/spec/session.indexes.spec.ts
@@ -49,7 +49,7 @@ describe('Indexes', function () {
                         await comps.search.search([
                             {
                                 filter: 'match A',
-                                flags: { reg: true, word: true, cases: false },
+                                flags: { reg: true, word: true, cases: false, invert: false },
                             },
                         ]);
                         let items = await comps.stream.grabIndexed(0, countMatches);

--- a/application/apps/rustcore/ts-bindings/spec/session.map.spec.ts
+++ b/application/apps/rustcore/ts-bindings/spec/session.map.spec.ts
@@ -50,7 +50,7 @@ describe('Map', function () {
                             .search([
                                 {
                                     filter: 'match',
-                                    flags: { reg: false, word: false, cases: false },
+                                    flags: { reg: false, word: false, cases: false, invert: false },
                                 },
                             ])
                             .then((_) => {
@@ -114,7 +114,7 @@ describe('Map', function () {
                             .search([
                                 {
                                     filter: 'match',
-                                    flags: { reg: false, word: false, cases: false },
+                                    flags: { reg: false, word: false, cases: false, invert: false },
                                 },
                             ])
                             .then((_) => {
@@ -170,7 +170,7 @@ describe('Map', function () {
                     .observe(
                         new Factory.File()
                             .asText()
-                            .type(Factory.FileType.Text)
+                           .type(Factory.FileType.Text)
                             .file(tmpobj.name)
                             .get()
                             .sterilized(),
@@ -180,15 +180,15 @@ describe('Map', function () {
                             .search([
                                 {
                                     filter: 'match',
-                                    flags: { reg: false, word: false, cases: true },
+                                    flags: { reg: false, word: false, cases: true , invert: false },
                                 },
                                 {
                                     filter: 'not',
-                                    flags: { reg: false, word: false, cases: false },
+                                    flags: { reg: false, word: false, cases: false , invert: false },
                                 },
                                 {
                                     filter: 'line',
-                                    flags: { reg: false, word: false, cases: true },
+                                    flags: { reg: false, word: false, cases: true , invert: false },
                                 },
                             ])
                             .then((_) => {
@@ -296,7 +296,7 @@ describe('Map', function () {
                             .search([
                                 {
                                     filter: 'file.txt',
-                                    flags: { reg: false, word: false, cases: false },
+                                    flags: { reg: false, word: false, cases: false, invert: false },
                                 },
                             ])
                             .then((_) => {
@@ -360,7 +360,7 @@ describe('Map', function () {
                             .search([
                                 {
                                     filter: '1:1',
-                                    flags: { reg: false, word: false, cases: false },
+                                    flags: { reg: false, word: false, cases: false, invert: false },
                                 },
                             ])
                             .then((_) => {
@@ -426,7 +426,7 @@ describe('Map', function () {
                             .search([
                                 {
                                     filter: '0.0:1',
-                                    flags: { reg: false, word: false, cases: false },
+                                    flags: { reg: false, word: false, cases: false, invert: false },
                                 },
                             ])
                             .then((_) => {
@@ -492,7 +492,7 @@ describe('Map', function () {
                             .search([
                                 {
                                     filter: 'word(0.0:1',
-                                    flags: { reg: false, word: false, cases: false },
+                                    flags: { reg: false, word: false, cases: false, invert: false },
                                 },
                             ])
                             .then((_) => {

--- a/application/apps/rustcore/ts-bindings/spec/session.search.spec.ts
+++ b/application/apps/rustcore/ts-bindings/spec/session.search.spec.ts
@@ -39,7 +39,7 @@ describe('Search', function () {
                         .search([
                             {
                                 filter: 'match',
-                                flags: { reg: true, word: false, cases: false },
+                                flags: { reg: true, word: false, cases: false, invert: false },
                             },
                         ])
                         .then((_) => {
@@ -207,15 +207,15 @@ describe('Search', function () {
                         .search([
                             {
                                 filter: 'match A',
-                                flags: { reg: true, word: false, cases: false },
+                                flags: { reg: true, word: false, cases: false, invert: false },
                             },
                             {
                                 filter: 'match B',
-                                flags: { reg: true, word: false, cases: false },
+                                flags: { reg: true, word: false, cases: false, invert: false },
                             },
                             {
                                 filter: '666',
-                                flags: { reg: true, word: false, cases: false },
+                                flags: { reg: true, word: false, cases: false, invert: false },
                             },
                         ])
                         .then((result) => {
@@ -323,7 +323,7 @@ describe('Search', function () {
                         .search([
                             {
                                 filter: 'not relevant search',
-                                flags: { reg: true, word: false, cases: false },
+                                flags: { reg: true, word: false, cases: false, invert: false },
                             },
                         ])
                         .then((found) => {
@@ -360,7 +360,7 @@ describe('Search', function () {
                         .search([
                             {
                                 filter: 'match',
-                                flags: { reg: true, word: false, cases: false },
+                                flags: { reg: true, word: false, cases: false, invert: false },
                             },
                         ])
                         .then((_) => {
@@ -483,7 +483,7 @@ describe('Search', function () {
                         .search([
                             {
                                 filter: 'match',
-                                flags: { reg: true, word: true, cases: false },
+                                flags: { reg: true, word: true, cases: false, invert: false },
                             },
                         ])
                         .then((_) => {
@@ -606,11 +606,11 @@ describe('Search', function () {
                         .search([
                             {
                                 filter: 'match A',
-                                flags: { reg: true, word: false, cases: false },
+                                flags: { reg: true, word: false, cases: false, invert: false },
                             },
                             {
                                 filter: 'match [A,B]',
-                                flags: { reg: true, word: false, cases: false },
+                                flags: { reg: true, word: false, cases: false, invert: false },
                             },
                         ])
                         .then((_) => {
@@ -718,7 +718,7 @@ describe('Search', function () {
                             .search([
                                 {
                                     filter,
-                                    flags: { reg: true, word: false, cases: false },
+                                    flags: { reg: true, word: false, cases: false, invert: false },
                                 },
                             ])
                             .then((_) => {
@@ -813,7 +813,7 @@ describe('Search', function () {
                         .search([
                             {
                                 filter: 'match',
-                                flags: { reg: true, word: false, cases: false },
+                                flags: { reg: true, word: false, cases: false, invert: false },
                             },
                         ])
                         .then((_) => {
@@ -821,7 +821,7 @@ describe('Search', function () {
                                 .searchNestedMatch(
                                     {
                                         filter: 'Nested',
-                                        flags: { reg: true, cases: false, word: false },
+                                        flags: { reg: true, cases: false, word: false, invert: false },
                                     },
                                     10,
                                     false,

--- a/application/apps/rustcore/ts-bindings/spec/session.stream.spec.ts
+++ b/application/apps/rustcore/ts-bindings/spec/session.stream.spec.ts
@@ -326,7 +326,7 @@ if (process.platform === 'win32') {
                             .search([
                                 {
                                     filter,
-                                    flags: { reg: true, word: false, cases: false },
+                                    flags: { reg: true, word: false, cases: false, invert: false },
                                 },
                             ])
                             .then(() => {

--- a/application/apps/rustcore/ts-bindings/src/api/jobs.ts
+++ b/application/apps/rustcore/ts-bindings/src/api/jobs.ts
@@ -229,6 +229,7 @@ export class Jobs extends Base {
                 is_regex: filter.flags.reg,
                 ignore_case: !filter.flags.cases,
                 is_word: filter.flags.word,
+                invert: filter.flags.invert,
             }),
             sequence,
             'getRegexError',

--- a/application/apps/rustcore/ts-bindings/src/native/native.jobs.ts
+++ b/application/apps/rustcore/ts-bindings/src/native/native.jobs.ts
@@ -48,6 +48,7 @@ export abstract class JobsNative {
             is_regex: boolean;
             ignore_case: boolean;
             is_word: boolean;
+            invert: boolean;
         },
     ): Promise<Uint8Array>;
     public abstract installedPluginsList(sequence: number): Promise<Uint8Array>;

--- a/application/apps/rustcore/ts-bindings/src/native/native.session.ts
+++ b/application/apps/rustcore/ts-bindings/src/native/native.session.ts
@@ -284,6 +284,7 @@ export abstract class RustSessionNative {
             is_regex: boolean;
             ignore_case: boolean;
             is_word: boolean;
+            invert: boolean;
         }>,
         operationUuid: string,
     ): Promise<void>;
@@ -294,6 +295,7 @@ export abstract class RustSessionNative {
             is_regex: boolean;
             ignore_case: boolean;
             is_word: boolean;
+            invert: boolean;
         },
         from: number,
         rev: boolean,
@@ -312,6 +314,7 @@ export abstract class RustSessionNative {
             is_regex: boolean;
             ignore_case: boolean;
             is_word: boolean;
+            invert: boolean;
         }>,
         operationUuid: string,
     ): Promise<void>;
@@ -829,6 +832,7 @@ export class RustSessionWrapper extends RustSession {
                                 is_regex: filter.flags.reg,
                                 ignore_case: !filter.flags.cases,
                                 is_word: filter.flags.word,
+                                invert: filter.flags.invert,
                             };
                         }),
                         operationUuid,
@@ -857,6 +861,7 @@ export class RustSessionWrapper extends RustSession {
                             is_regex: filter.flags.reg,
                             ignore_case: !filter.flags.cases,
                             is_word: filter.flags.word,
+                            invert: filter.flags.invert,
                         },
                         from,
                         rev,
@@ -907,6 +912,7 @@ export class RustSessionWrapper extends RustSession {
                                 is_regex: filter.flags.reg,
                                 ignore_case: !filter.flags.cases,
                                 is_word: filter.flags.word,
+                                invert: filter.flags.invert,
                             };
                         }),
                         operationUuid,

--- a/application/apps/rustcore/wasm-bindings/spec/filter.spec.ts
+++ b/application/apps/rustcore/wasm-bindings/spec/filter.spec.ts
@@ -1,4 +1,3 @@
-
 describe('test', function () {
     let wasm: typeof import('../pkg');
     beforeAll(async function () {
@@ -11,7 +10,8 @@ describe('test', function () {
         const caseSensitive = true;
         const wholeWord = false;
         const regex = true;
-        const result = get_filter_error(filter, caseSensitive, wholeWord, regex);
+        const invert = false;
+        const result = get_filter_error(filter, caseSensitive, wholeWord, regex, invert);
         expect(result).toBeUndefined();
         done();
     });
@@ -22,7 +22,8 @@ describe('test', function () {
         const caseSensitive = false;
         const wholeWord = true;
         const regex = true;
-        const result = get_filter_error(filter, caseSensitive, wholeWord, regex);
+        const invert = false;
+        const result = get_filter_error(filter, caseSensitive, wholeWord, regex, invert);
         expect(typeof result).toEqual('string');
         done();
     });
@@ -33,7 +34,8 @@ describe('test', function () {
         const caseSensitive = true;
         const wholeWord = false;
         const regex = false;
-        const result = get_filter_error(filter, caseSensitive, wholeWord, regex);
+        const invert = false;
+        const result = get_filter_error(filter, caseSensitive, wholeWord, regex, invert);
         expect(result).toBeUndefined();
         done();
     });
@@ -44,7 +46,8 @@ describe('test', function () {
         const caseSensitive = false;
         const wholeWord = false;
         const regex = true;
-        const result = get_filter_error(filter, caseSensitive, wholeWord, regex);
+        const invert = false;
+        const result = get_filter_error(filter, caseSensitive, wholeWord, regex, invert);
         expect(result).toBeUndefined();
         done();
     });

--- a/application/apps/rustcore/wasm-bindings/src/filter.rs
+++ b/application/apps/rustcore/wasm-bindings/src/filter.rs
@@ -11,12 +11,22 @@ pub fn get_filter_error(
     case_sensitive: bool,
     whole_word: bool,
     regex: bool,
+    invert: bool,
 ) -> Option<String> {
-    let regex_as_str = filter_as_regex(filter, case_sensitive, whole_word, regex);
+    let regex_as_str = filter_as_regex(filter, case_sensitive, whole_word, regex, invert);
     Regex::from_str(&regex_as_str).map_or_else(|err| Some(err.to_string()), |_| None)
 }
 
-fn filter_as_regex(filter: String, case_sensitive: bool, whole_word: bool, regex: bool) -> String {
+fn filter_as_regex(
+    filter: String,
+    case_sensitive: bool,
+    whole_word: bool,
+    regex: bool,
+    _invert: bool,
+) -> String {
+    // Note:
+    // invert isn't included in regex because it needs look-around support,
+    // which isn't supported in rust.
     let word_marker = if whole_word { "\\b" } else { "" };
     let ignore_case_start = if case_sensitive { "(?i)" } else { "" };
     let ignore_case_end = if case_sensitive { "(?-i)" } else { "" };
@@ -35,8 +45,9 @@ fn plain_string_regex_on() {
     let case_sesitive = false;
     let whole_word = false;
     let regex = true;
+    let invert = false;
     assert_eq!(
-        get_filter_error(filter, case_sesitive, whole_word, regex),
+        get_filter_error(filter, case_sesitive, whole_word, regex, invert),
         None
     );
 }
@@ -48,8 +59,9 @@ fn plain_string_regex_off() {
     let case_sesitive = false;
     let whole_word = false;
     let regex = false;
+    let invert = false;
     assert_eq!(
-        get_filter_error(filter, case_sesitive, whole_word, regex),
+        get_filter_error(filter, case_sesitive, whole_word, regex, invert),
         None
     );
 }
@@ -61,8 +73,9 @@ fn valid_regex() {
     let case_sesitive = false;
     let whole_word = false;
     let regex = true;
+    let invert = false;
     assert_eq!(
-        get_filter_error(filter, case_sesitive, whole_word, regex),
+        get_filter_error(filter, case_sesitive, whole_word, regex, invert),
         None
     );
 }
@@ -74,7 +87,8 @@ fn invalid_regex() {
     let case_sesitive = false;
     let whole_word = false;
     let regex = true;
-    match get_filter_error(filter, case_sesitive, whole_word, regex) {
+    let invert = false;
+    match get_filter_error(filter, case_sesitive, whole_word, regex, invert) {
         Some(result) => assert_eq!(
             result,
             "regex parse error:\n    \\[Warn(\\]\n          ^\nerror: unclosed group"

--- a/application/client/src/app/module/util.ts
+++ b/application/client/src/app/module/util.ts
@@ -5,9 +5,12 @@ export function getFilterError(
     caseSensitive: boolean,
     wholeWord: boolean,
     regex: boolean,
+    invert: boolean,
 ): string | undefined {
     try {
-        const result = wasm.getBindings().get_filter_error(filter, caseSensitive, wholeWord, regex);
+        const result = wasm
+            .getBindings()
+            .get_filter_error(filter, caseSensitive, wholeWord, regex, invert);
         return typeof result !== 'string' ? undefined : result;
     } catch (_e) {
         return undefined;

--- a/application/client/src/app/service/history/collections.ts
+++ b/application/client/src/app/service/history/collections.ts
@@ -305,7 +305,7 @@ export class Collections implements EntryConvertable, Equal<Collections>, Empty 
                 .elements()
                 .map((request) => {
                     const def = request.definition;
-                    return `${def.filter.filter}${def.filter.flags.cases}${def.filter.flags.word}${def.filter.flags.reg}${def.colors.color}${def.colors.background}${def.active}`;
+                    return `${def.filter.filter}${def.filter.flags.cases}${def.filter.flags.word}${def.filter.flags.reg}${def.filter.flags.invert}${def.colors.color}${def.colors.background}${def.active}`;
                 })
                 .join(';') +
             this.collections.charts
@@ -325,7 +325,7 @@ export class Collections implements EntryConvertable, Equal<Collections>, Empty 
             )
                 .map((request: FilterRequest) => {
                     const def = request.definition;
-                    return `${def.filter.filter}${def.filter.flags.cases}${def.filter.flags.word}${def.filter.flags.reg}${def.colors.color}${def.colors.background}${def.active}`;
+                    return `${def.filter.filter}${def.filter.flags.cases}${def.filter.flags.word}${def.filter.flags.reg}${def.filter.flags.invert}${def.colors.color}${def.colors.background}${def.active}`;
                 })
                 .join(';') +
             (

--- a/application/client/src/app/service/session/dependencies/search/charts/request.ts
+++ b/application/client/src/app/service/session/dependencies/search/charts/request.ts
@@ -95,13 +95,13 @@ export class ChartRequest
     static isValid(filter: string | undefined): boolean {
         return filter === undefined
             ? false
-            : getFilterError(filter, false, false, true) === undefined
-            ? regexFilters.hasGroups(filter)
-            : false;
+            : getFilterError(filter, false, false, true, false) === undefined
+              ? regexFilters.hasGroups(filter)
+              : false;
     }
 
     static getValidationError(filter: string): string | undefined {
-        let error: string | undefined = getFilterError(filter, false, false, true);
+        let error: string | undefined = getFilterError(filter, false, false, true, false);
         if (error !== undefined) {
             const match: RegExpMatchArray | null = error.match(/error:.+/i);
             if (match !== null && match[0] !== undefined) {
@@ -315,11 +315,13 @@ export class ChartRequest
             reg: true,
             word: false,
             cases: false,
+            invert: false,
         });
         this._safeRegExp = regexFilters.getMarkerRegExp(serializeHtml(this.definition.filter), {
             reg: true,
             word: false,
             cases: false,
+            invert: false,
         });
         this._hash = `${this.definition.filter}${this.definition.color}${
             this.definition.widths.line

--- a/application/client/src/app/service/session/dependencies/search/disabled/request.ts
+++ b/application/client/src/app/service/session/dependencies/search/disabled/request.ts
@@ -69,7 +69,7 @@ export class DisabledRequest
 
     public isSame(disabled: DisabledRequest): boolean {
         const getFilterHash = (f: FilterRequest) => {
-            return `${f.definition.filter.filter}|${f.definition.filter.flags.cases}|${f.definition.filter.flags.reg}|${f.definition.filter.flags.word}`;
+            return `${f.definition.filter.filter}|${f.definition.filter.flags.cases}|${f.definition.filter.flags.reg}|${f.definition.filter.flags.word}|${f.definition.filter.flags.invert}`;
         };
         const left = disabled.entity();
         const right = this.entity();

--- a/application/client/src/app/service/session/dependencies/search/state.ts
+++ b/application/client/src/app/service/session/dependencies/search/state.ts
@@ -67,6 +67,7 @@ export class State {
             cases: false,
             word: false,
             reg: true,
+            invert: false,
         },
     };
 

--- a/application/client/src/app/ui/views/sidebar/search/charts/provider.ts
+++ b/application/client/src/app/ui/views/sidebar/search/charts/provider.ts
@@ -176,7 +176,12 @@ export class ProviderCharts extends Provider<ChartRequest> {
                                     .filters()
                                     .addFromFilter({
                                         filter: entity.as().filter(),
-                                        flags: { reg: true, word: false, cases: false },
+                                        flags: {
+                                            reg: true,
+                                            word: false,
+                                            cases: false,
+                                            invert: false,
+                                        },
                                     })
                             ) {
                                 return;
@@ -261,7 +266,7 @@ export class ProviderCharts extends Provider<ChartRequest> {
             .state()
             .setActive({
                 filter: entity.extract().definition.filter,
-                flags: { reg: true, word: false, cases: false },
+                flags: { reg: true, word: false, cases: false, invert: false },
             })
             .catch((error: Error) => {
                 this.logger.error(`Fail to make search: ${error.message}`);

--- a/application/client/src/app/ui/views/sidebar/search/disabled/provider.ts
+++ b/application/client/src/app/ui/views/sidebar/search/disabled/provider.ts
@@ -198,7 +198,7 @@ export class ProviderDisabled extends Provider<DisabledRequest> {
                 .state()
                 .setActive({
                     filter: entity.definition.filter,
-                    flags: { reg: true, word: false, cases: false },
+                    flags: { reg: true, word: false, cases: false, invert: false },
                 })
                 .catch((error: Error) => {
                     this.logger.error(`Fail to make search: ${error.message}`);

--- a/application/client/src/app/ui/views/sidebar/search/filters/filter/component.ts
+++ b/application/client/src/app/ui/views/sidebar/search/filters/filter/component.ts
@@ -33,6 +33,7 @@ export class Filter extends EntityItem<ProviderFilters, FilterRequest> implement
                 cases: this.state.filter.flags.cases,
                 word: this.state.filter.flags.word,
                 reg: this.state.filter.flags.reg,
+                invert: this.state.filter.flags.invert,
             },
         });
     }

--- a/application/client/src/app/ui/views/sidebar/search/filters/filter/state.ts
+++ b/application/client/src/app/ui/views/sidebar/search/filters/filter/state.ts
@@ -117,6 +117,7 @@ export class State {
                 cases: this.filter.flags.cases,
                 word: this.filter.flags.word,
                 reg: true,
+                invert: this.filter.flags.invert,
             },
         });
     }

--- a/application/client/src/app/ui/views/sidebar/search/filters/filter/template.html
+++ b/application/client/src/app/ui/views/sidebar/search/filters/filter/template.html
@@ -16,4 +16,5 @@
     <span [attr.class]="'small-icon-button codicon codicon-case-sensitive ' + (state.filter.flags.cases ? 'active' : 'inactive')" (click)="_ng_flagsToggle($event, EFlag.cases)"></span>
     <span [attr.class]="'small-icon-button codicon codicon-whole-word ' + (state.filter.flags.word ? 'active' : 'inactive')" (click)="_ng_flagsToggle($event, EFlag.word)"></span>
     <span [attr.class]="'small-icon-button codicon codicon-regex ' + (state.filter.flags.reg ? 'active' : state.isValidRegex ? 'inactive' : 'invalid')" (click)="_ng_flagsToggle($event, EFlag.reg)"></span>
+    <span [attr.class]="'small-icon-button codicon codicon-diff-removed ' + (state.filter.flags.invert ? 'active' : 'inactive')" (click)="_ng_flagsToggle($event, EFlag.invert)"></span>
 </span>

--- a/application/client/src/app/ui/views/sidebar/search/filters/provider.ts
+++ b/application/client/src/app/ui/views/sidebar/search/filters/provider.ts
@@ -280,7 +280,7 @@ export class ProviderFilters extends Provider<FilterRequest> {
                     .filters()
                     .addFromFilter({
                         filter: entity.as().filter(),
-                        flags: { reg: true, word: false, cases: false },
+                        flags: { reg: true, word: false, cases: false, invert: false },
                     })
             ) {
                 this.session.search.store().charts().delete([entity.uuid()]);

--- a/application/client/src/app/ui/views/toolbar/history/preview/filter/template.html
+++ b/application/client/src/app/ui/views/toolbar/history/preview/filter/template.html
@@ -7,4 +7,5 @@
     <span [attr.class]="'small-icon-button codicon codicon-case-sensitive ' + (filter.definition.filter.flags.cases ? 'active' : 'inactive')"></span>
     <span [attr.class]="'small-icon-button codicon codicon-whole-word ' + (filter.definition.filter.flags.word ? 'active' : 'inactive')"></span>
     <span [attr.class]="'small-icon-button codicon codicon-regex ' + (filter.definition.filter.flags.reg ? 'active' : 'inactive')"></span>
+    <span [attr.class]="'small-icon-button codicon codicon-diff-removed ' + (filter.definition.filter.flags.invert ? 'active' : 'inactive')"></span>
 </span>

--- a/application/client/src/app/ui/views/toolbar/search/input/active.ts
+++ b/application/client/src/app/ui/views/toolbar/search/input/active.ts
@@ -26,6 +26,12 @@ export class ActiveSearch {
     }
 
     public isPossibleToSaveAsChart(): boolean {
+        // Inverted filters can't be saved as charts
+        if (this.filter.flags.invert) {
+            return false;
+        }
+
+        // Check if chart already exist
         const request = new ChartRequest({ filter: this.filter.filter });
         return (
             !this.search.store().charts().has(request) &&

--- a/application/client/src/app/ui/views/toolbar/search/input/error.ts
+++ b/application/client/src/app/ui/views/toolbar/search/input/error.ts
@@ -10,6 +10,7 @@ export class ErrorHandler {
             reg: true,
             word: false,
             cases: false,
+            invert: false,
         },
     };
 
@@ -36,6 +37,7 @@ export class ErrorHandler {
         caseSensitive(value: boolean): void;
         wholeWord(value: boolean): void;
         regex(value: boolean): void;
+        invert(value: boolean): void;
     } {
         return {
             value: (value: string) => {
@@ -54,6 +56,10 @@ export class ErrorHandler {
                 this.filter.flags.reg = value;
                 this._checkRegex();
             },
+            invert: (value: boolean) => {
+                this.filter.flags.invert = value;
+                this._checkRegex();
+            },
         };
     }
 
@@ -68,6 +74,7 @@ export class ErrorHandler {
                 cases: this.filter.flags.cases,
                 word: this.filter.flags.word,
                 reg: true,
+                invert: this.filter.flags.invert,
             },
         });
     }

--- a/application/client/src/app/ui/views/toolbar/search/input/input.ts
+++ b/application/client/src/app/ui/views/toolbar/search/input/input.ts
@@ -18,6 +18,7 @@ export class SearchInput {
         word: false,
         cases: false,
         reg: true,
+        invert: false,
     };
     public actions: {
         drop: Subject<void>;
@@ -129,6 +130,7 @@ export class SearchInput {
         caseSensitive(): void;
         wholeWord(): void;
         regex(): void;
+        invert(): void;
     } {
         return {
             value: (value: string | IFilter): void => {
@@ -155,6 +157,10 @@ export class SearchInput {
                 }
                 this.flags.reg = !this.flags.reg;
                 this.error.set().regex(this.flags.reg);
+            },
+            invert: () => {
+                this.flags.invert = !this.flags.invert;
+                this.error.set().invert(this.flags.invert);
             },
         };
     }

--- a/application/client/src/app/ui/views/toolbar/search/input/template.html
+++ b/application/client/src/app/ui/views/toolbar/search/input/template.html
@@ -66,10 +66,15 @@
         (click)="input.set().wholeWord()"
     ></span>
     <span
-        tabindex="13"
         title="Use Regular Expression"
         [attr.class]="'small-icon-button codicon codicon-regex ' + (input.flags.reg ? 'active' : input.error.isValidRegex() ? 'inactive' : 'invalid')"
         (click)="input.set().regex()"
+    ></span>
+    <span
+        tabindex="14"
+        title="Invert Filter"
+        [attr.class]="'small-icon-button codicon codicon-diff-removed ' + (input.flags.invert ? 'active' : 'inactive')"
+        (click)="input.set().invert()"
     ></span>
 </div>
 <div class="summary">
@@ -82,12 +87,12 @@
 </div>
 <div class="extantions">
     <span
-        tabindex="14"
+        tabindex="15"
         (click)="indexed.modes().toggle().breadcrumbs()"
         [attr.class]="'small-icon-button codicon codicon-list-tree ' + (indexed.modes().breadcrumbs() ? 'active' : 'inactive')"
     ></span>
     <span
-        tabindex="15"
+        tabindex="16"
         (click)="ilc().services.ui.layout.toolbar().occupy()"
         [attr.class]="'small-icon-button occupied codicon codicon-fold-' + (occupied ? 'down' : 'up')"
     ></span>

--- a/application/client/src/app/ui/views/toolbar/search/nested/template.html
+++ b/application/client/src/app/ui/views/toolbar/search/nested/template.html
@@ -55,22 +55,28 @@
         [attr.class]="'small-icon-button codicon codicon-regex ' + (input.flags.reg ? 'active' : input.error.isValidRegex() ? 'inactive' : 'invalid')"
         (click)="input.set().regex()"
     ></span>
+    <span
+        tabindex="24"
+        title="Invert Filter"
+        [attr.class]="'small-icon-button codicon codicon-diff-removed ' + (input.flags.invert ? 'active' : 'inactive')"
+        (click)="input.set().invert()"
+    ></span>
 </div>
 <div class="arrows">
     <span
-        tabindex="24"
+        tabindex="25"
         title="Previos"
         class="small-icon-button codicon codicon-arrow-up"
         (click)="prev()"
     ></span>
     <span
-        tabindex="25"
+        tabindex="26"
         title="Next"
         class="small-icon-button codicon codicon-arrow-down"
         (click)="next()"
     ></span>
     <span
-        tabindex="26"
+        tabindex="27"
         title="Close"
         class="small-icon-button codicon codicon-close"
         (click)="close()"

--- a/application/platform/types/filter.ts
+++ b/application/platform/types/filter.ts
@@ -2,6 +2,7 @@ export interface IFilterFlags {
     reg: boolean;
     word: boolean;
     cases: boolean;
+    invert: boolean;
 }
 
 export interface IFilter {
@@ -39,6 +40,7 @@ export enum EFlag {
     cases = 'cases',
     word = 'word',
     reg = 'reg',
+    invert = 'invert',
 }
 
 export type ISearchMap = Array<[number, number][]>;

--- a/application/platform/types/github/filter.ts
+++ b/application/platform/types/github/filter.ts
@@ -14,6 +14,7 @@ const protocols: { [key: string]: (def: FilterDefinition) => FilterDefinition } 
         def.filter.flags.cases = validator.getAsBool(def.filter.flags, 'cases');
         def.filter.flags.word = validator.getAsBool(def.filter.flags, 'word');
         def.filter.flags.reg = validator.getAsBool(def.filter.flags, 'reg');
+        def.filter.flags.invert = validator.getAsBool(def.filter.flags, 'invert');
         def.filter.filter = validator.getAsNotEmptyString(def.filter, 'filter');
         def.active = validator.getAsBool(def, 'active');
         return def;


### PR DESCRIPTION
This PR closes #2375 

* This PR provides a new flag for filter function. The new flag called `invert` and it will negate the filter, providing the logs which don't match the provided search term.
* This will provide a way for the users to filter out entries based on some criteria, then export the clean results into a new tab for further analyzing.
* Invert flag isn't part of charts search for values and searches with invert can't be used as charts.
* Unit tests in rust extended & Unit tests in TypeScript are fixed only.

### Detailed Description
* Filters with `invert` flag are considered as normal filters, making all filter rules apply to them. The only exception that they can't be moved to charts group.
* Since they are normal filters, then combining them with other filters in the same session will bind them with OR clause. For example: Logs that doesn't contains `foo` or contains `baz`. (Third screenshot)
* If users want to have the filter combination with AND clause, then they will need to apply the first filter, export the results to a new session then apply the next filter. Which is the same workflow for other already existing filters.

I think, having the `invert` filter as flag like other filter flags make it easier to the users since they are already familiar with how combining filters in Chipmunk works. 

### Screenshots
<img width="1085" height="853" alt="image" src="https://github.com/user-attachments/assets/1d5d1593-0c67-4ba0-9eb0-b5eae7967313" />
After `Open in a new tap`
<img width="1085" height="853" alt="image" src="https://github.com/user-attachments/assets/fbcc9efe-3e7c-4226-bbac-07a57b1aaaf3" />

Combining filters with OR:
<img width="1085" height="853" alt="image" src="https://github.com/user-attachments/assets/216fcdcc-0845-4654-a135-fa763bcb6308" />
