### PR TITLE
Switch to native clipboard API (close #2386)

### DIFF
--- a/application/client/src/app/module/ipc.ts
+++ b/application/client/src/app/module/ipc.ts
@@ -1,25 +1,98 @@
 import { Packed } from '@platform/ipc/transport/index';
 
+/**
+ * Extends the global `window` object with the safe Electron API
+ * exposed from the preload script.
+ *
+ * @remarks
+ * This API provides a limited, secure surface for the renderer process.
+ * It includes IPC communication, selected web utilities, and clipboard access.
+ */
 declare global {
     interface Window {
+        /**
+         * Namespaced Electron API exposed to the renderer.
+         */
         electron: {
             ipc: IPC;
             webUtils: WebUtils;
+            clipboard: Clipboard;
         };
     }
 }
 
+/**
+ * Checks if the `electron` API is available on the current `window` context.
+ *
+ * @returns `true` if the API is defined, otherwise `false`.
+ */
 export function isAvailable(): boolean {
     return window.electron !== undefined && window.electron !== null;
 }
 
+/**
+ * IPC communication interface exposed to the renderer.
+ *
+ * Provides methods for sending messages to the main process and
+ * subscribing or unsubscribing from IPC channels.
+ */
 export interface IPC {
+    /**
+     * Sends a message to the main process over the specified channel.
+     *
+     * @param channel - IPC channel identifier.
+     * @param msg - Serialized message payload.
+     */
     send: (channel: string, msg: Packed) => void;
+
+    /**
+     * Subscribes a callback to events from the specified channel.
+     *
+     * @param channel - IPC channel identifier.
+     * @param callback - Function invoked with event arguments.
+     */
     subscribe: (channel: string, callback: (...args: any[]) => void) => void;
+
+    /**
+     * Removes a previously subscribed callback from the specified channel.
+     *
+     * @param channel - IPC channel identifier.
+     * @param callback - Callback to be removed.
+     */
     unsubscribe: (channel: string, callback: (...args: any[]) => void) => void;
+
+    /**
+     * Removes all listeners from the specified channel.
+     *
+     * @param channel - IPC channel identifier.
+     */
     unsubscribeAll: (channel: string) => void;
 }
 
+/**
+ * Utilities exposed from Electron's `webUtils`.
+ */
 export interface WebUtils {
+    /**
+     * Resolves the absolute filesystem path for a given File object.
+     *
+     * @param file - A File object obtained in the renderer.
+     * @returns The absolute filesystem path.
+     */
     getPathForFile(file: File): string;
+}
+
+/**
+ * Clipboard interface exposed to the renderer.
+ *
+ * Provides write-only access to the system clipboard via IPC.
+ */
+export interface Clipboard {
+    /**
+     * Writes arbitrary data into the system clipboard.
+     *
+     * @param mime - MIME type of the data (e.g. `text/plain`, `image/png`).
+     * @param data - Content as an ArrayBuffer.
+     */
+    write(mime: string, data: ArrayBuffer): void;
 }

--- a/application/client/src/app/module/ipc.ts
+++ b/application/client/src/app/module/ipc.ts
@@ -94,5 +94,5 @@ export interface Clipboard {
      * @param mime - MIME type of the data (e.g. `text/plain`, `image/png`).
      * @param data - Content as an ArrayBuffer.
      */
-    write(mime: string, data: ArrayBuffer): Promise<void>;
+    write(mime: string | undefined, data: ArrayBuffer): Promise<void>;
 }

--- a/application/client/src/app/module/ipc.ts
+++ b/application/client/src/app/module/ipc.ts
@@ -94,5 +94,5 @@ export interface Clipboard {
      * @param mime - MIME type of the data (e.g. `text/plain`, `image/png`).
      * @param data - Content as an ArrayBuffer.
      */
-    write(mime: string, data: ArrayBuffer): void;
+    write(mime: string, data: ArrayBuffer): Promise<void>;
 }

--- a/application/client/src/app/ui/views/sidebar/attachments/preview/image/component.ts
+++ b/application/client/src/app/ui/views/sidebar/attachments/preview/image/component.ts
@@ -211,13 +211,16 @@ export class Preview extends ChangesDetector implements AfterViewInit, AfterCont
                     .then((buffer) => {
                         // We are using native clipboard API, but not browser one (navigator.clipboard)
                         // to avoid possible issues with size of blob.
-                        window.electron.clipboard.write(
-                            response.type || 'application/octet-stream',
-                            buffer,
-                        );
+                        window.electron.clipboard
+                            .write(response.type || 'application/octet-stream', buffer)
+                            .catch((err: Error) => {
+                                this.log().warn(
+                                    `Fail to copy image into clipboard: ${err.message}`,
+                                );
+                            });
                     })
                     .catch((err: Error) => {
-                        this.log().warn(`Fail to copy image into clipboard: ${err.message}`);
+                        this.log().warn(`Fail to load image as bytes: ${err.message}`);
                     });
             })
             .catch((err: Error) => {

--- a/application/client/src/app/ui/views/sidebar/attachments/preview/image/component.ts
+++ b/application/client/src/app/ui/views/sidebar/attachments/preview/image/component.ts
@@ -206,12 +206,16 @@ export class Preview extends ChangesDetector implements AfterViewInit, AfterCont
                     this.log().warn(`Fail to fetch image as Blob`);
                     return;
                 }
-                navigator.clipboard
-                    .write([
-                        new ClipboardItem({
-                            [response.type]: response,
-                        }),
-                    ])
+                response
+                    .arrayBuffer()
+                    .then((buffer) => {
+                        // We are using native clipboard API, but not browser one (navigator.clipboard)
+                        // to avoid possible issues with size of blob.
+                        window.electron.clipboard.write(
+                            response.type || 'application/octet-stream',
+                            buffer,
+                        );
+                    })
                     .catch((err: Error) => {
                         this.log().warn(`Fail to copy image into clipboard: ${err.message}`);
                     });

--- a/application/client/src/app/ui/views/sidebar/attachments/preview/image/component.ts
+++ b/application/client/src/app/ui/views/sidebar/attachments/preview/image/component.ts
@@ -206,13 +206,14 @@ export class Preview extends ChangesDetector implements AfterViewInit, AfterCont
                     this.log().warn(`Fail to fetch image as Blob`);
                     return;
                 }
+                const contentType = response.type.trim();
                 response
                     .arrayBuffer()
                     .then((buffer) => {
                         // We are using native clipboard API, but not browser one (navigator.clipboard)
                         // to avoid possible issues with size of blob.
                         window.electron.clipboard
-                            .write(response.type || 'application/octet-stream', buffer)
+                            .write(contentType.length > 0 ? contentType : undefined, buffer)
                             .catch((err: Error) => {
                                 this.log().warn(
                                     `Fail to copy image into clipboard: ${err.message}`,

--- a/application/holder/package.json
+++ b/application/holder/package.json
@@ -28,6 +28,7 @@
     "glob": "^11.0.1",
     "http-proxy-agent": "^7.0.2",
     "https-proxy-agent": "^7.0.6",
+    "mime-types": "^3.0.1",
     "module-alias": "^2.2.3",
     "moment-timezone": "^0.5.46",
     "platform": "link:../platform",
@@ -38,6 +39,7 @@
     "uuid": "^11.0.5"
   },
   "devDependencies": {
+    "@types/mime-types": "^3.0.1",
     "@types/module-alias": "^2.0.2",
     "@types/node": "^22.10.10",
     "@types/request": "^2.48.8",

--- a/application/holder/src/preload/preload.ts
+++ b/application/holder/src/preload/preload.ts
@@ -1,15 +1,57 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
 
+/**
+ * Exposes a safe API into the renderer process under `window.electron`.
+ *
+ * @remarks
+ * This API is defined in the preload script and isolated via
+ * `contextBridge.exposeInMainWorld`, so the renderer does not have
+ * direct access to Node.js or Electron internals.
+ *
+ * Namespaces:
+ * - `ipc` — wrapper around `ipcRenderer` for sending and receiving messages.
+ * - `webUtils` — exposes selected Electron utilities (e.g. file path resolution).
+ * - `clipboard` — provides clipboard operations via IPC handled in the main process.
+ */
 contextBridge.exposeInMainWorld('electron', {
     ipc: {
+        /**
+         * Sends a message to the main process on the specified channel.
+         */
         send: (channel: string, msg: unknown) => ipcRenderer.send(channel, msg),
+
+        /**
+         * Subscribes to messages on the specified channel.
+         */
         subscribe: (channel: string, callback: (...args: unknown[]) => void) =>
             ipcRenderer.on(channel, callback),
+
+        /**
+         * Removes a specific listener from the specified channel.
+         */
         unsubscribe: (channel: string, callback: (...args: unknown[]) => void) =>
             ipcRenderer.removeListener(channel, callback),
+
+        /**
+         * Removes all listeners from the specified channel.
+         */
         unsubscribeAll: (channel: string) => ipcRenderer.removeAllListeners(channel),
     },
     webUtils: {
+        /**
+         * Returns the absolute filesystem path for a given File object.
+         */
         getPathForFile: (file: File) => webUtils.getPathForFile(file),
+    },
+    clipboard: {
+        /**
+         * Writes data into the system clipboard via the main process.
+         *
+         * @param mime - MIME type of the data (for example `text/plain` or `image/png`).
+         * @param data - Raw content as an ArrayBuffer.
+         * @returns A promise that resolves when the data is written.
+         */
+        write: (mime: string, data: ArrayBuffer) =>
+            ipcRenderer.invoke('clipboard:write', { mime, data }),
     },
 });

--- a/application/holder/src/service/electron.ts
+++ b/application/holder/src/service/electron.ts
@@ -14,6 +14,8 @@ import { Transport } from 'platform/ipc/transport';
 import { Subjects, Subject } from 'platform/env/subscription';
 import { Protocol } from './electron/protocol';
 
+import * as handles from './electron/handles';
+
 @DependOn(paths)
 @SetupService(services['electron'])
 export class Service extends Implementation {
@@ -42,9 +44,12 @@ export class Service extends Implementation {
     }
 
     public override async ready(): Promise<void> {
+        // Wait for ready
         await app.whenReady();
-        // Register protocol
+        // Register protocols
         this._protocol.register();
+        // Register custom handles
+        handles.register();
         // Setup minimal security requirements for angular app
         session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
             callback({

--- a/application/holder/src/service/electron/handles/clipboard.ts
+++ b/application/holder/src/service/electron/handles/clipboard.ts
@@ -1,0 +1,26 @@
+import { nativeImage, clipboard, ipcMain } from 'electron';
+
+/**
+ * Registers an IPC handler for writing data into the system clipboard.
+ *
+ * @remarks
+ * This method is intended to be called in the **main process**.
+ * It exposes the `clipboard:write` channel, which can then be invoked
+ * from a renderer process via `ipcRenderer.invoke`.
+ */
+export function register() {
+    ipcMain.handle('clipboard:write', (_e, { mime, data }) => {
+        const buf = Buffer.from(data);
+        if (mime.startsWith('image/')) {
+            const img = nativeImage.createFromBuffer(buf);
+            clipboard.writeImage(img);
+            return;
+        }
+        if (mime.startsWith('text/')) {
+            clipboard.writeText(buf.toString('utf8'));
+            return;
+        }
+        clipboard.writeBuffer(mime || 'application/octet-stream', buf);
+        return;
+    });
+}

--- a/application/holder/src/service/electron/handles/index.ts
+++ b/application/holder/src/service/electron/handles/index.ts
@@ -1,0 +1,18 @@
+import * as clipboard from './clipboard';
+
+/**
+ * Registers all available IPC APIs that must be exposed
+ * to the renderer process.
+ *
+ * @remarks
+ * Call this function once in the **main process** during
+ * application startup (e.g. after `app.whenReady()`).
+ *
+ * This function delegates to the individual API modules
+ * (such as `clipboard.register()`), ensuring their IPC
+ * channels are set up and ready for renderer use via
+ * `ipcRenderer.invoke` / `contextBridge`.
+ */
+export function register() {
+    clipboard.register();
+}

--- a/application/holder/src/service/electron/protocol.ts
+++ b/application/holder/src/service/electron/protocol.ts
@@ -4,6 +4,7 @@ import * as url from 'url';
 import * as fs from 'fs';
 import * as mime from 'mime-types';
 import * as path from 'path';
+import * as net from 'platform/types/net';
 
 const PROTOCOL: string = 'attachment';
 
@@ -82,15 +83,15 @@ export class Protocol {
 
             const stream = fs.createReadStream(filePath);
             const contentType =
-                mime.contentType(path.basename(filePath)) || 'application/octet-stream';
+                mime.contentType(path.basename(filePath)) || net.CONTENT_TYPE_OCTET_STREAM;
 
             return new Response(stream, {
                 headers: {
                     'Content-Type': contentType,
                     'Content-Length': String(stat.size),
                     'Content-Disposition': `attachment; filename="${path.basename(filePath)}"`,
-                    'Accept-Ranges': 'bytes',
-                    'Cache-Control': 'no-store',
+                    'Accept-Ranges': net.ACCEPT_RANGES_BYTES,
+                    'Cache-Control': net.CACHE_CONTROL_NO_STORE,
                 },
             });
         } catch {

--- a/application/holder/yarn.lock
+++ b/application/holder/yarn.lock
@@ -418,6 +418,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/mime-types@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@types/mime-types@npm:3.0.1"
+  checksum: 10c0/61c2056529dc5bc73c25b2a053e21f063fd547c21e12a2be94ca78b89b0f83c9a75afed9a8bda3c78592ee880acc82778302651527f7882cf5ba8e58ab320e29
+  languageName: node
+  linkType: hard
+
 "@types/module-alias@npm:^2.0.2":
   version: 2.0.4
   resolution: "@types/module-alias@npm:2.0.4"
@@ -1148,6 +1155,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "chipmunk@workspace:."
   dependencies:
+    "@types/mime-types": "npm:^3.0.1"
     "@types/module-alias": "npm:^2.0.2"
     "@types/node": "npm:^22.10.10"
     "@types/request": "npm:^2.48.8"
@@ -1167,6 +1175,7 @@ __metadata:
     glob: "npm:^11.0.1"
     http-proxy-agent: "npm:^7.0.2"
     https-proxy-agent: "npm:^7.0.6"
+    mime-types: "npm:^3.0.1"
     module-alias: "npm:^2.2.3"
     moment-timezone: "npm:^0.5.46"
     platform: "link:../platform"
@@ -3221,12 +3230,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:^1.54.0":
+  version: 1.54.0
+  resolution: "mime-db@npm:1.54.0"
+  checksum: 10c0/8d907917bc2a90fa2df842cdf5dfeaf509adc15fe0531e07bb2f6ab15992416479015828d6a74200041c492e42cce3ebf78e5ce714388a0a538ea9c53eece284
+  languageName: node
+  linkType: hard
+
 "mime-types@npm:^2.1.12":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
     mime-db: "npm:1.52.0"
   checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "mime-types@npm:3.0.1"
+  dependencies:
+    mime-db: "npm:^1.54.0"
+  checksum: 10c0/bd8c20d3694548089cf229016124f8f40e6a60bbb600161ae13e45f793a2d5bb40f96bbc61f275836696179c77c1d6bf4967b2a75e0a8ad40fe31f4ed5be4da5
   languageName: node
   linkType: hard
 

--- a/application/platform/package.json
+++ b/application/platform/package.json
@@ -143,6 +143,7 @@
     "./types/github/filemetadata": "./dist/types/github/filemetadata.js",
     "./types/github/filter": "./dist/types/github/filter.js",
     "./types/bindings": "./dist/types/bindings/index.js",
+    "./types/net": "./dist/types/net.js",
     "./package.json": "./package.json"
   },
   "packageManager": "yarn@4.6.0"

--- a/application/platform/types/index.ts
+++ b/application/platform/types/index.ts
@@ -10,3 +10,4 @@ export * as comment from './comment';
 export * as bookmark from './bookmark';
 export * as sde from './sde';
 export * as bindings from './bindings';
+export * as net from './net';

--- a/application/platform/types/net.ts
+++ b/application/platform/types/net.ts
@@ -1,0 +1,3 @@
+export const CONTENT_TYPE_OCTET_STREAM = 'application/octet-stream';
+export const CACHE_CONTROL_NO_STORE = 'no-store';
+export const ACCEPT_RANGES_BYTES = 'bytes';


### PR DESCRIPTION
## Changes
- Extend exposed API with clipboard API
- Switch from browser's clipboard API to native one (in context of images)
- Switch loading of attachment to stream-based