### PR TITLE
Stop File tailing on truncate & Small improvement.

### DIFF
--- a/application/apps/indexer/session/src/operations.rs
+++ b/application/apps/indexer/session/src/operations.rs
@@ -202,8 +202,8 @@ impl OperationAPI {
     }
 
     pub fn emit(&self, event: stypes::CallbackEvent) {
-        let event_log = format!("{event:?}");
         if let Err(err) = self.tx_callback_events.send(event) {
+            let event_log = format!("{:?}", err.0);
             error!("Fail to send event {event_log}; error: {err}")
         }
     }

--- a/application/apps/indexer/session/src/tail/mod.rs
+++ b/application/apps/indexer/session/src/tail/mod.rs
@@ -41,6 +41,11 @@ pub async fn track(
                     .map(|md| md.len())
                     .map_err(|e| Error::Io(e.to_string()))?;
                 if updated != size {
+                    let truncated = size > updated;
+                    if truncated {
+                        log::info!("File has been truncated. Path: {}", path.display());
+                        return Err(Error::Io(String::from("File has been truncated")));
+                    }
                     size = updated;
                     if let Err(err) = tx_update.send(Ok(())).await {
                         return Err(Error::Channel(format!("Fail to send update signal: {err}")));

--- a/application/holder/src/env/fs/index.ts
+++ b/application/holder/src/env/fs/index.ts
@@ -148,4 +148,3 @@ export async function getFileTypeByFilename(filename: string): Promise<FileType>
         return FileType.Text;
     }
 }
-


### PR DESCRIPTION
This PR closes #2394 

It provides the following:
* Stop file tailing if file get truncated returning and IO error because session should be terminated at this point.
* Avoid allocating string for logging channels errors since the channel will return the sent item on errors.