### PR TITLE
Fix Application CLI for Files: Parser argument ignored & Files Concatenating

### DIFF
--- a/application/holder/src/loaders/cli.ts
+++ b/application/holder/src/loaders/cli.ts
@@ -72,7 +72,7 @@ function setup() {
     cli.addOption(
         new Option(
             '-s, --search "<regexp>"',
-            'Collection of filters, which would be applied to each opened session (tab). Ex: cm files -o /path/file_name -s "error" -s "warning"',
+            'Collection of filters, which would be applied to each opened session (tab). Ex: chipmunk files -o /path/file_name -s "error" -s "warning"',
         ).argParser(parser(CLI_HANDLERS['search'], undefined)),
     );
     cli.addOption(new Option(RESTARTING_FLAG, 'Hidden option to manage CLI usage').hideHelp());
@@ -90,7 +90,7 @@ function setup() {
         });
     files.option(
         '-o, --open <filename | glob pattern...>',
-        'Opens file. Ex: cm -o /path/file_name_a. In case of multiple files, concat operation will be done. Ex: cm -o file_a -o file_b; cm -o "**/*.logs"; cm -o "**/*.{logs,txt}"',
+        'Opens file. Ex: chipmunk -o /path/file_name_a. In case of multiple files, concat operation will be done. Ex: chipmunk -o file_a -o file_b; chipmunk -o "**/*.logs"; chipmunk -o "**/*.{logs,txt}"',
         parser(CLI_HANDLERS['open'], undefined),
     );
     const streams = cli
@@ -99,25 +99,25 @@ function setup() {
     streams.addOption(
         new Option(
             '--tcp "<addr:port>"',
-            'Creates TCP connection with given address. Ex: cm --tcp "0.0.0.0:8888"',
+            'Creates TCP connection with given address. Ex: chipmunk --tcp "0.0.0.0:8888"',
         ).argParser(parser(CLI_HANDLERS['stream'], 'tcp')),
     );
     streams.addOption(
         new Option(
             '--udp "<addr:port|multicast,interface;>"',
-            'Creates UDP connection with given address and multicasts. Ex: cm --udp "0.0.0.0:8888|234.2.2.2,0.0.0.0"',
+            'Creates UDP connection with given address and multicasts. Ex: chipmunk --udp "0.0.0.0:8888|234.2.2.2,0.0.0.0"',
         ).argParser(parser(CLI_HANDLERS['stream'], 'udp')),
     );
     streams.addOption(
         new Option(
             '--serial "<path;baud_rate;data_bits;flow_control;parity;stop_bits>"',
-            'Creates serial port connection with given parameters. Ex: cm --serial "/dev/port_a;960000;8;1;0;1"',
+            'Creates serial port connection with given parameters. Ex: chipmunk --serial "/dev/port_a;960000;8;1;0;1"',
         ).argParser(parser(CLI_HANDLERS['stream'], 'serial')),
     );
     streams.addOption(
         new Option(
             '--stdout "<command...>"',
-            'Executes given commands in the scope of one session (tab) and shows mixed output. Ex: cm --stdout "journalctl -r" "adb logcat"',
+            'Executes given commands in the scope of one session (tab) and shows mixed output. Ex: chipmunk --stdout "journalctl -r" "adb logcat"',
         ).argParser(parser(CLI_HANDLERS['stream'], 'stdout')),
     );
     cli.parse();

--- a/application/holder/src/service/cli/open.ts
+++ b/application/holder/src/service/cli/open.ts
@@ -10,8 +10,6 @@ import * as path from 'path';
 import * as Requests from 'platform/ipc/request';
 import * as Factory from 'platform/types/observe/factory';
 import * as Parser from 'platform/types/observe/parser';
-import * as Origin from 'platform/types/observe/origin';
-import { session } from 'electron';
 
 export class Action extends CLIAction {
     protected files: string[] = [];
@@ -64,7 +62,7 @@ export class Action extends CLIAction {
         if (files.length === 0) {
             return;
         }
-        let factory =
+        const factory =
             files.length === 1
                 ? new Factory.File().file(files[0].filename)
                 : new Factory.Concat().files(files.map((f) => f.filename));
@@ -83,7 +81,7 @@ export class Action extends CLIAction {
                 throw new Error("Plugins aren't supperted in CLI yet.");
         }
 
-        let observe = factory.get();
+        const observe = factory.get();
 
         return new Promise((resolve, _reject) => {
             Requests.IpcRequest.send(

--- a/application/holder/src/service/cli/stream.ts
+++ b/application/holder/src/service/cli/stream.ts
@@ -49,14 +49,14 @@ function serial(settings: string): $.Origin.Stream.Stream.Serial.IConfiguration 
                 typeof p === 'boolean'
                     ? p
                     : typeof p === 'string'
-                    ? p === 'true'
-                        ? true
-                        : false
-                    : typeof p === 'number'
-                    ? p === 1
-                        ? true
-                        : false
-                    : true;
+                      ? p === 'true'
+                          ? true
+                          : false
+                      : typeof p === 'number'
+                        ? p === 1
+                            ? true
+                            : false
+                        : true;
         } else {
             const value = parseInt(p, 10);
             if (isNaN(value) || !isFinite(value)) {

--- a/application/platform/types/observe/factory.ts
+++ b/application/platform/types/observe/factory.ts
@@ -196,7 +196,7 @@ export class Concat extends Factory<Concat> {
         if (!(this.observe.origin.instance instanceof $.Origin.Concat.Configuration)) {
             throw new Error(`Given observe object doesn't have Concat origin`);
         }
-        this.observe.origin.instance.set().defaults(type);
+        this.observe.origin.instance.set().type(type);
         this.updated().origin();
         return this;
     }

--- a/application/platform/types/observe/origin/concat.ts
+++ b/application/platform/types/observe/origin/concat.ts
@@ -66,7 +66,7 @@ export class Configuration
 
     public set(): {
         files(files: string[]): Configuration;
-        defaults(type: Types.File.FileType): Configuration;
+        type(type: Types.File.FileType): Configuration;
         push(filename: string, type: Types.File.FileType): Configuration;
         remove(filename: string): Configuration;
         alias(alias?: string): Configuration;
@@ -80,8 +80,11 @@ export class Configuration
                 );
                 return this;
             },
-            defaults: (type: Types.File.FileType): Configuration => {
+            type: (type: Types.File.FileType): Configuration => {
                 this.defaultFileType = type;
+                this.configuration.forEach((conf) => {
+                    conf[1] = type;
+                });
                 return this;
             },
             push: (filename: string, type: Types.File.FileType): Configuration => {


### PR DESCRIPTION
This PR closes #2403

It provides fixes for the main application CLI interface regarding `files` command:
* Use the provided parser type as CLI argument for opening files from the command line. The previous implementation was ignoring the parser argument entirely.
* Fix files concatenating: Apply file types on all configurations in concatenating origin instead of changing the default only.
* Help text: Set correct application name in CLI help texts.