### PR TITLE
Gui CLI Glob matching: Sort & Fixes

### DIFF
--- a/application/holder/src/service/cli/open.ts
+++ b/application/holder/src/service/cli/open.ts
@@ -32,7 +32,8 @@ export class Action extends CLIAction {
                 );
                 return '';
             }
-            this.files = files;
+            files.sort();
+            this.files.push(...files);
             return arg;
         } catch (e) {
             this.error.push(new Error(`Fail to parse glob pattern: ${error(e)}`));


### PR DESCRIPTION
This PR closes #2406:

It provides the following changes and fixes regarding using globs in Chipmunk Gui Application CLI:
* Append glob files into files list instead of replacing them to avoid the last glob replacing all other globs matches in case of multiple globs as CLI arguments.
* Sort each glob import alphabetically.