### PR TITLE
CLI: Open multiple files view instead of concatenate

### DIFF
--- a/application/client/src/app/service/cli.ts
+++ b/application/client/src/app/service/cli.ts
@@ -48,6 +48,17 @@ export class Service extends Implementation {
                         return handlers.search(this, request);
                     },
                 ),
+            api
+                .transport()
+                .respondent(
+                    this.getName(),
+                    Requests.Cli.MultiFiles.Request,
+                    (
+                        request: Requests.Cli.MultiFiles.Request,
+                    ): CancelablePromise<Requests.Cli.MultiFiles.Response> => {
+                        return handlers.multiFiles(request);
+                    },
+                ),
         );
         Events.IpcEvent.subscribe(Events.Cli.Done.Event, (_event: Events.Cli.Done.Event) => {
             // TODO: not clear now (after refactoring) - what we should to do now?

--- a/application/client/src/app/service/cli/index.ts
+++ b/application/client/src/app/service/cli/index.ts
@@ -1,2 +1,3 @@
 export { handler as search } from './search';
 export { handler as observe } from './observe';
+export { handler as multiFiles } from './multi_files';

--- a/application/client/src/app/service/cli/multi_files.ts
+++ b/application/client/src/app/service/cli/multi_files.ts
@@ -1,0 +1,20 @@
+import { CancelablePromise } from '@platform/env/promise';
+import * as Requests from '@platform/ipc/request';
+import { Action as FileAnyAction } from '@service/actions/file.any';
+
+export function handler(
+    request: Requests.Cli.MultiFiles.Request,
+): CancelablePromise<Requests.Cli.MultiFiles.Response> {
+    return new CancelablePromise(async (resolve, _reject) => {
+        action(request);
+        resolve(new Requests.Cli.MultiFiles.Response());
+    });
+}
+
+export function action(request: Requests.Cli.MultiFiles.Request): void {
+    if (request.files.length === 0) {
+        return;
+    }
+    const fileAction = new FileAnyAction();
+    fileAction.multiple(request.files);
+}

--- a/application/holder/src/loaders/cli.ts
+++ b/application/holder/src/loaders/cli.ts
@@ -78,7 +78,7 @@ function setup() {
     cli.addOption(new Option(RESTARTING_FLAG, 'Hidden option to manage CLI usage').hideHelp());
     const files = cli
         .command('files [filename...]', { isDefault: true })
-        .description('Opens file(s) or concat files')
+        .description('Opens file(s)')
         .action((args: string[]) => {
             if (args.length === 0) {
                 return;
@@ -90,7 +90,7 @@ function setup() {
         });
     files.option(
         '-o, --open <filename | glob pattern...>',
-        'Opens file. Ex: chipmunk -o /path/file_name_a. In case of multiple files, concat operation will be done. Ex: chipmunk -o file_a -o file_b; chipmunk -o "**/*.logs"; chipmunk -o "**/*.{logs,txt}"',
+        'Opens file. Ex: chipmunk -o /path/file_name_a. In case of multiple files, multiple files view will be opened. Ex: chipmunk -o file_a -o file_b; chipmunk -o "**/*.logs"; chipmunk -o "**/*.{logs,txt}"',
         parser(CLI_HANDLERS['open'], undefined),
     );
     const streams = cli

--- a/application/platform/ipc/request/cli/index.ts
+++ b/application/platform/ipc/request/cli/index.ts
@@ -1,3 +1,4 @@
 export * as Search from './search';
 export * as Observe from './observe';
 export * as GetCommand from './getcommand';
+export * as MultiFiles from './multi_files';

--- a/application/platform/ipc/request/cli/multi_files.ts
+++ b/application/platform/ipc/request/cli/multi_files.ts
@@ -1,0 +1,22 @@
+import { Define, Interface, SignatureRequirement } from '../declarations';
+import { File } from '../../../types/files';
+
+import * as validator from '../../../env/obj';
+
+@Define({ name: 'MultiFilesCLICommandRequest' })
+export class Request extends SignatureRequirement {
+    public files: File[];
+
+    constructor(input: { files: File[] }) {
+        super();
+        validator.isObject(input);
+        this.files = validator.getAsObj(input, 'files');
+    }
+}
+
+export interface Request extends Interface {}
+
+@Define({ name: 'MultiFilesCLICommandResponse' })
+export class Response extends SignatureRequirement {}
+
+export interface Response extends Interface {}


### PR DESCRIPTION
This PR closes #2407 

It provides:
Open multiple files view when CLI arguments are used to provide multiple files instead of concatenate session, providing the users with more control over the files like manual reordering, excluding some files or open each file in a separate session instead of concatenating.