### PR TITLE
CI: Ensure Clippy is installed on linting jobs

### DIFF
--- a/.github/workflows/lint_master.yml
+++ b/.github/workflows/lint_master.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           toolchain: stable
           override: true
+          components: clippy
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@v1.9.0
       - name: set sccache env var

--- a/.github/workflows/pullrequest_check.yml
+++ b/.github/workflows/pullrequest_check.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           toolchain: stable
           override: true
+          components: clippy
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@v1.9.0
       - name: set sccache env var


### PR DESCRIPTION
GitHub isn't installing clippy by default anymore