### PR TITLE
Fix duplicating filter while applying

### DIFF
--- a/application/client/src/app/ui/views/toolbar/history/component.ts
+++ b/application/client/src/app/ui/views/toolbar/history/component.ts
@@ -105,7 +105,7 @@ export class History extends ChangesDetector implements AfterContentInit {
     }
 
     public use(collection: Collections) {
-        this.state.history.apply(collection.copy());
+        this.state.history.apply(collection);
     }
 
     public onListFilterChange(_event: MatSelectChange) {


### PR DESCRIPTION
When user tries to apply imported filter in the Chipmunk, filters keeps getting duplicated until user changes the tabs. This commit fixes the bug as we do not have to copy the collection while applying the filter