### PR TITLE
Change github runner label for MacOS x86_64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       CSC_FOR_PULL_REQUEST: true
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-13, macOS-latest]
+        os: [ubuntu-22.04, windows-latest, macos-15-intel, macOS-latest]
         rust: [stable]
     steps:
       - name: Checkout


### PR DESCRIPTION
Change github runner label for MacOS x86_64