### PR TITLE
CI: Run on PR targeting master only.

### DIFF
--- a/.github/workflows/pullrequest_check.yml
+++ b/.github/workflows/pullrequest_check.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   ts_and_rust_lint:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'master'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -64,7 +64,7 @@ jobs:
         run: yarn run check
 
   integration_and_unit_tests:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'master'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
It wouldn't make sense to run the CI checks automatically on PRs targeting development branch since the changes are finalized yet.