### PR TITLE
Native UI: Timeout for logs Receivers + Retry for Senders

### DIFF
--- a/application/apps/indexer/gui/application/src/session/command.rs
+++ b/application/apps/indexer/gui/application/src/session/command.rs
@@ -1,6 +1,6 @@
 use std::ops::RangeInclusive;
 
-use tokio::sync::oneshot::Sender;
+use std::sync::mpsc::Sender;
 
 use processor::{grabber::LineRange, search::filter::SearchFilter};
 use stypes::GrabbedElement;

--- a/application/apps/indexer/gui/application/src/session/service/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/service/mod.rs
@@ -119,14 +119,7 @@ impl SessionService {
                     .map_err(SessionError::from);
 
                 if sender.send(elements).is_err() {
-                    log::error!("Communication error while sending grabbed lines");
-
-                    let notifi = AppNotification::SessionError {
-                        session_id: self.session.get_uuid(),
-                        error: ComputationError::Communication("Sending log lines failed".into())
-                            .into(),
-                    };
-                    self.senders.send_notification(notifi).await;
+                    log::debug!("Grabbed lines receiver dropped before receiving the results.");
                 }
             }
             SessionCommand::GrabIndexedLinesBlocking { range, sender } => {
@@ -138,14 +131,9 @@ impl SessionService {
                     .map_err(SessionError::from);
 
                 if sender.send(elements).is_err() {
-                    log::error!("Communication error while sending grabbed indexed lines");
-
-                    let notifi = AppNotification::SessionError {
-                        session_id: self.session.get_uuid(),
-                        error: ComputationError::Communication("Sending log lines failed".into())
-                            .into(),
-                    };
-                    self.senders.send_notification(notifi).await;
+                    log::debug!(
+                        "Grabbed indexed lines receiver dropped before receiving the results."
+                    );
                 }
             }
             SessionCommand::ApplySearchFilter(search_filters) => {


### PR DESCRIPTION
* Add timeout for logs blocking receivers to avoid freezing the UI.
* Add Send with retry command for blocking command senders to avoid freezing the UI, and apply it to log tables + Charts.
* Avoid request grabbed logs when we still don't have any logs yet.
* Reset logs requests if logs data are missing to request them on next frame.