### PR TITLE
TOOL-519: MCP client POC

### DIFF
--- a/application/apps/indexer/mcp/Cargo.toml
+++ b/application/apps/indexer/mcp/Cargo.toml
@@ -7,6 +7,17 @@ edition = "2024"
 workspace = true 
 
 [dependencies]
+axum = { version = "0.7", features = ["macros"] }
+rmcp = { version = "0.11", features = [
+  "server",
+  "transport-io",
+  "schemars",
+  "transport-streamable-http-server-session",
+  "transport-streamable-http-server",
+] }
+schemars = "1.1"
 tokio.workspace = true
 tokio-util.workspace = true
 log.workspace = true
+serde.workspace = true
+anyhow.workspace = true

--- a/application/apps/indexer/mcp/Cargo.toml
+++ b/application/apps/indexer/mcp/Cargo.toml
@@ -4,20 +4,26 @@ version = "0.1.0"
 edition = "2024"
 
 [lints]
-workspace = true 
+workspace = true
 
 [dependencies]
+serde.workspace = true
+anyhow.workspace = true
 axum = { version = "0.7", features = ["macros"] }
 rmcp = { version = "0.11", features = [
+  "client",
+  "macros",
+  "reqwest",
+  "schemars",
   "server",
   "transport-io",
-  "schemars",
-  "transport-streamable-http-server-session",
+  "transport-streamable-http-client-reqwest",
   "transport-streamable-http-server",
+  "transport-streamable-http-server-session",
 ] }
 schemars = "1.1"
 tokio.workspace = true
 tokio-util.workspace = true
 log.workspace = true
-serde.workspace = true
-anyhow.workspace = true
+reqwest = "0.12.25"
+thiserror.workspace = true

--- a/application/apps/indexer/mcp/src/client/conversation.rs
+++ b/application/apps/indexer/mcp/src/client/conversation.rs
@@ -1,0 +1,59 @@
+// Simple model for storing the state of a chat conversation inside the MCP client
+
+use rmcp::{
+    model::Content,
+    serde_json::{Map, Value},
+};
+
+#[derive(Debug)]
+pub enum ChatMessage {
+    ClientToLlm(ClientToLlm),
+    LlmToClient(LlmToClient),
+}
+
+#[derive(Debug)]
+pub enum ClientToLlm {
+    SystemPrompt { content: String },
+    UserPrompt { content: String },
+    ToolResult { content: Vec<Content> },
+}
+
+#[derive(Debug)]
+pub enum LlmToClient {
+    ToolCall {
+        tool_name: String,
+        arguments: Option<Map<String, Value>>,
+    },
+    System {
+        message: String,
+    },
+    FinalResponse {
+        content: String,
+    },
+}
+pub struct Conversation {
+    chat_messages: Vec<ChatMessage>,
+    // TODO:[MCP] keep track of steps?
+    // TODO:[MCP] conversation ID=?
+}
+
+impl Conversation {
+    /// Create a new conversation with an initial system prompt
+    /// # Arguments
+    /// * `system_prompt`: The system prompt to initialize the conversation with
+    pub fn new(system_prompt: String) -> Self {
+        Self {
+            chat_messages: vec![ChatMessage::ClientToLlm(ClientToLlm::SystemPrompt {
+                content: system_prompt,
+            })],
+        }
+    }
+
+    pub fn chat_messages(&self) -> &[ChatMessage] {
+        &self.chat_messages
+    }
+
+    pub fn add_chat_message(&mut self, message: ChatMessage) {
+        self.chat_messages.push(message);
+    }
+}

--- a/application/apps/indexer/mcp/src/client/llm/mock.rs
+++ b/application/apps/indexer/mcp/src/client/llm/mock.rs
@@ -1,0 +1,81 @@
+// A mock LLM client for testing purposes
+// It simulates LLM behavior without making actual API calls / without a HTTP client
+// The logic for processing messages is as follows:
+// - User prompts received from the chipmunk core will cause the mock LLM to emit a ToolCall message:
+//    LlmToClient::ToolCall ("apply_search_filter") with the prompt content as filters
+// - ToolResult messages will be answered with a FinalResponse message containing the tool result
+
+use log::warn;
+use rmcp::serde_json::{self, json};
+use tokio::time::{Duration, sleep};
+
+use crate::client::conversation::LlmToClient;
+use crate::{
+    client::{
+        conversation::{ChatMessage, ClientToLlm, Conversation},
+        llm::LlmClient,
+    },
+    types::{McpError, SearchFilter},
+};
+pub struct MockLlmClient;
+
+// Abstraction of LLM clients using the LlmClient trait
+impl LlmClient for MockLlmClient {
+    /// Process a conversation by taking appropriate action based on the last message and return a LLM response.
+    async fn respond(&self, conversation: &Conversation) -> Result<LlmToClient, McpError> {
+        MockLlmClient::respond(self, conversation).await
+    }
+}
+
+impl MockLlmClient {
+    /// Process a conversation take appropriate action based on the last message in the conversation
+    /// and return a LLM response.
+    /// For the mock client, we have hardcoded logic to simulate LLM behaviour
+    pub async fn respond(&self, conversation: &Conversation) -> Result<LlmToClient, McpError> {
+        warn!(
+            "🟢 Mock LLM client processing message: {:?}",
+            conversation.chat_messages().last()
+        );
+        match conversation.chat_messages().last() {
+            Some(ChatMessage::ClientToLlm(message)) => match message {
+                ClientToLlm::SystemPrompt { .. } => Err(McpError::Generic {
+                    message: "Mock LLM client received a system prompt; nothing to do".into(),
+                }),
+                ClientToLlm::UserPrompt { content } => {
+                    // Simulate LLM reasoning duration
+                    warn!("⏰ Mock LLM client waits 5s ...");
+                    sleep(Duration::from_secs(5)).await;
+
+                    let filters = vec![SearchFilter {
+                        value: content.clone(),
+                        is_regex: false,
+                        ignore_case: true,
+                        is_word: false,
+                    }];
+
+                    let arguments: Option<serde_json::Map<String, serde_json::Value>> =
+                        json!({ "filters": filters }).as_object().cloned();
+
+                    // Return a ToolCall
+                    Ok(LlmToClient::ToolCall {
+                        tool_name: "apply_search_filter".into(),
+                        arguments,
+                    })
+                }
+                ClientToLlm::ToolResult { content } => {
+                    // Simulate LLM reasoning duration
+                    warn!("⏰ Mock LLM client waits 5s ...");
+                    sleep(Duration::from_secs(5)).await;
+
+                    // Return a FinalResponse
+                    Ok(LlmToClient::FinalResponse {
+                        content: format!("Final LLM Response: Tool result {:?}", content),
+                    })
+                }
+            },
+            _ => Err(McpError::Generic {
+                message: "Mock LLM client received unsupported request".into(),
+            }),
+        }
+    }
+}

--- a/application/apps/indexer/mcp/src/client/llm/mod.rs
+++ b/application/apps/indexer/mcp/src/client/llm/mod.rs
@@ -1,0 +1,61 @@
+// LLM client abstraction layer
+use crate::{
+    client::conversation::{Conversation, LlmToClient},
+    types::McpError,
+};
+
+pub mod mock;
+
+/// Configuration used for creation of different LLM client
+#[derive(Debug, Clone)]
+pub enum LlmConfig {
+    Mock,
+    // Other LLM configurations can be added here. They may need other parameters like:
+    // - API keys
+    // - Model names
+    // - temperature settings
+    // - feature flags, ect.
+    // // E.g.:
+    // OpenAi { api_key: String, model: String },
+}
+
+// LLM client trait that LLM clients must implement
+// Note: this causes the following warning:
+//   use of `async fn` in public traits is discouraged as auto trait bounds cannot be specified
+//   note: you can suppress this lint if you plan to use the trait only in your own code, or do not care about auto traits like `Send` on the `Future`
+//   note: `#[warn(async_fn_in_trait)]` on by default
+//   note: `#[warn(async_fn_in_trait)]` on by default
+// We suppress the warning for now as all LLM clients are internal to the MCP client module.
+// Alternatively we would need to use the async-trait crate.
+#[allow(async_fn_in_trait)]
+pub trait LlmClient {
+    /// Process a conversation by taking appropriate action based on the last message and return a LLM response.
+    async fn respond(&self, conversation: &Conversation) -> Result<LlmToClient, McpError>;
+}
+
+// LLM client abstraction wrapper providing a facade for different LLM client implementations
+pub struct Llm<C: LlmClient> {
+    client: C,
+}
+
+// LLM client abstraction wrapper implementation
+impl<C: LlmClient> Llm<C> {
+    pub fn new(client: C) -> Self {
+        Self { client }
+    }
+
+    /// Forward processing of a conversation to the underlying LLM client implementation
+    pub async fn process(&self, conversation: &Conversation) -> Result<LlmToClient, McpError> {
+        self.client.respond(conversation).await
+    }
+}
+
+// Implementation of LLM creation from configuration for the mock client
+// TODO:[MCP] Can this be moved to the client modules? Via trait?
+impl Llm<mock::MockLlmClient> {
+    pub fn from_config(config: LlmConfig) -> Self {
+        match config {
+            LlmConfig::Mock => Llm::new(mock::MockLlmClient),
+        }
+    }
+}

--- a/application/apps/indexer/mcp/src/client/messages.rs
+++ b/application/apps/indexer/mcp/src/client/messages.rs
@@ -2,10 +2,13 @@
 #[derive(Debug)]
 pub enum McpClientToChipmunk {
     Response { response: String },
+    // TODO:[MCP] add other message types as needed. E.g.:
 }
 
-/// Messages chipmunk to the MCP client
+/// Messages from chipmunk to the MCP client
 #[derive(Debug, Clone)]
 pub enum McpChipmunkToClient {
-    Prompt { prompt: String },
+    UserPrompt { prompt: String },
+    // TODO:[MCP] add other message types as needed. E.g.:
+    // SystemPrompt { prompt: String },
 }

--- a/application/apps/indexer/mcp/src/client/mod.rs
+++ b/application/apps/indexer/mcp/src/client/mod.rs
@@ -1,19 +1,46 @@
-use tokio::sync::mpsc;
+use log::{error, warn};
 
+use tokio::{select, sync::mpsc};
+
+use rmcp::{
+    RoleClient,
+    model::{CallToolRequestParam, ClientInfo, Implementation, InitializeRequestParam},
+    service::{RunningService, ServiceExt},
+    transport::StreamableHttpClientTransport,
+};
+
+use crate::{
+    client::{
+        conversation::{ChatMessage, ClientToLlm, Conversation, LlmToClient},
+        llm::{Llm, LlmClient, LlmConfig},
+        messages::{McpChipmunkToClient, McpClientToChipmunk},
+    },
+    types::McpError,
+};
+
+pub mod conversation;
+pub mod llm;
 pub mod messages;
 
-use messages::McpChipmunkToClient;
-use messages::McpClientToChipmunk;
+// TODO:[MCP] store this in a single global location
+pub const SERVER_ADDRESS: &str = "http://127.0.0.1:8181/mcp";
 
-#[derive(Debug)]
-
-pub struct McpClient {
-    client_to_chipmunk_tx: mpsc::Sender<McpClientToChipmunk>,
-    chipmunk_to_client_rx: mpsc::Receiver<McpChipmunkToClient>,
+pub struct McpConfig {
+    pub url: String,
 }
 
-impl McpClient {
-    pub fn new() -> (
+pub struct MCPClient {
+    chipmunk_to_client_rx: mpsc::Receiver<McpChipmunkToClient>,
+    client_to_chipmunk_tx: mpsc::Sender<McpClientToChipmunk>,
+    llm_config: LlmConfig,
+    mcp_config: McpConfig,
+}
+
+impl MCPClient {
+    pub fn new(
+        mcp_config: McpConfig,
+        llm_config: LlmConfig,
+    ) -> (
         Self,
         mpsc::Sender<McpChipmunkToClient>,
         mpsc::Receiver<McpClientToChipmunk>,
@@ -23,27 +50,146 @@ impl McpClient {
 
         (
             Self {
-                client_to_chipmunk_tx,
                 chipmunk_to_client_rx,
+                client_to_chipmunk_tx,
+                mcp_config,
+                llm_config,
             },
             chipmunk_to_client_tx,
             client_to_chipmunk_rx,
         )
     }
 
-    pub fn start(self) {
-        // Start listening for messages
-        tokio::spawn(self.run());
+    pub async fn start(self) -> Result<(), McpError> {
+        // Setup MCP connection
+        let transport = StreamableHttpClientTransport::from_uri(SERVER_ADDRESS);
 
-        // TODO: Start client, ...
+        // TODO:[MCP] match with MCP server definition
+        let client_info = ClientInfo {
+            protocol_version: Default::default(),
+            capabilities: Default::default(),
+            client_info: Implementation {
+                name: String::from("mcp-client"),
+                title: None,
+                version: String::from(env!("CARGO_PKG_VERSION")),
+                website_url: None,
+                icons: None,
+            },
+        };
+
+        let mcp_service = client_info
+            .serve(transport)
+            .await
+            .map_err(|e| McpError::Generic {
+                message: e.to_string(),
+            })?;
+
+        warn!(
+            "🟢 MCP client connected to MCP server: {:?}",
+            mcp_service.peer_info()
+        );
+
+        let tools = mcp_service.list_tools(Default::default()).await?;
+        warn!(
+            "🟢 Client received available tools from MCP server: {:?}",
+            tools
+                .tools
+                .iter()
+                .map(|tool| tool.name.to_string().clone())
+                .collect::<Vec<String>>()
+        );
+
+        let chipmunk_to_client_rx = self.chipmunk_to_client_rx;
+        let chipmunk_response_tx = self.client_to_chipmunk_tx.clone();
+
+        let llm = Llm::from_config(self.llm_config);
+
+        tokio::spawn(async move {
+            if let Err(e) = MCPClient::run(
+                chipmunk_to_client_rx,
+                chipmunk_response_tx,
+                mcp_service,
+                llm,
+            )
+            .await
+            {
+                error!("MCP client event loop ended: {:?}", e);
+            }
+        });
+        warn!("🟢 MCP client started");
+
+        Ok(())
     }
 
-    // TODO: handle incoming messages
-    async fn run(mut self) {
-        while let Some(message) = self.chipmunk_to_client_rx.recv().await {
-            match message {
-                McpChipmunkToClient::Prompt { .. } => {}
+    pub async fn run(
+        mut chipmunk_request_rx: mpsc::Receiver<McpChipmunkToClient>,
+        chipmunk_response_tx: mpsc::Sender<McpClientToChipmunk>,
+        mut mcp_service: RunningService<RoleClient, InitializeRequestParam>,
+        llm: Llm<impl LlmClient>,
+    ) -> Result<(), McpError> {
+        // TODO:[MCP] System prompt probably needs to be tailored to our use case
+        // Also this would need to be moved to the below loop, into the initial llm request / system prompt
+        let mut conversation = Conversation::new("You are a helpful assistant.".into());
+        loop {
+            select! {
+                Some(chipmunk_request) = chipmunk_request_rx.recv() => {
+                    match chipmunk_request {
+                        McpChipmunkToClient::UserPrompt { prompt } => {
+                            warn!("🟢 MCP Client received mock prompt: {}", prompt);
+                            conversation.add_chat_message(ChatMessage::ClientToLlm(ClientToLlm::UserPrompt { content: prompt.clone() }));
+
+                            // Interatively let the LLM client process conversation / last message
+                            //  until we get a final response - which would be sent back to chipmunk.
+                            loop {
+                                match llm.process(&conversation).await? {
+                                    LlmToClient::ToolCall { tool_name, arguments } => {
+
+                                        // TODO:[MCP] It seems a bit weird to add the message here.
+                                        // Maybe this should be done in the LLM client instead.
+                                        // I believe it is important that the message is added,
+                                        // since it needs to be part of the converation history, so
+                                        // it is visible for the LLM in future prompts/steps.
+                                        conversation.add_chat_message(ChatMessage::LlmToClient(LlmToClient::ToolCall {
+                                            tool_name: tool_name.clone(),
+                                            arguments: arguments.clone(),
+                                        }));
+
+                                        let tool_call_param = CallToolRequestParam {
+                                            name: tool_name.into(),
+                                            arguments,
+                                        };
+
+                                        let tool_result = mcp_service
+                                            .call_tool(tool_call_param)
+                                            .await
+                                            .map_err(|e| McpError::Generic {
+                                                message: e.to_string(),
+                                            })?;
+
+                                        // Same as above, the tool result needs to be part of the
+                                        // chat history, so that it is visible for the LLM in future
+                                        // prompts/steps.
+                                        conversation.add_chat_message(ChatMessage::ClientToLlm(ClientToLlm::ToolResult {
+                                            content: tool_result.content,
+                                        }));
+                                    }
+                                    LlmToClient::FinalResponse { content } => {
+                                        warn!(" ✅ MCP client received final LLM response: {:?}", content);
+                                        // TODO:[MCP] Send final response back to Chipmunk
+                                        break;
+                                    }
+                                    LlmToClient::System { .. } => {
+                                        // TODO:[MCP] Do nothing for now
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                else => {}
             }
         }
+
+        Ok(())
     }
 }

--- a/application/apps/indexer/mcp/src/lib.rs
+++ b/application/apps/indexer/mcp/src/lib.rs
@@ -2,7 +2,10 @@
 
 use tokio::sync::mpsc;
 
-use crate::{client::McpClient, server::McpServer};
+use crate::{
+    client::{MCPClient, McpConfig, llm::LlmConfig},
+    server::McpServer,
+};
 use client::messages::{McpChipmunkToClient, McpClientToChipmunk};
 use server::messages::McpServerToChipmunk;
 
@@ -16,8 +19,13 @@ pub struct McpChannelEndpoints {
     pub server_to_chipmunk_rx: mpsc::Receiver<McpServerToChipmunk>,
 }
 
-pub fn new() -> (McpServer, McpClient, McpChannelEndpoints) {
-    let (mcp_client, chipmunk_to_client_tx, client_to_chipmunk_rx) = McpClient::new();
+pub fn new() -> (McpServer, MCPClient, McpChannelEndpoints) {
+    let llm_config = LlmConfig::Mock;
+    let mcp_config = McpConfig {
+        url: String::from("http//:localhost:8181"),
+    };
+    let (mcp_client, chipmunk_to_client_tx, client_to_chipmunk_rx) =
+        MCPClient::new(mcp_config, llm_config);
     let (mcp_server, server_to_chipmunk_rx) = McpServer::new();
 
     let mcp_channel_endpoints = McpChannelEndpoints {

--- a/application/apps/indexer/mcp/src/server/messages.rs
+++ b/application/apps/indexer/mcp/src/server/messages.rs
@@ -1,3 +1,5 @@
+use rmcp::schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 
 use crate::types::McpError;
@@ -12,7 +14,7 @@ pub enum McpServerToChipmunk {
 }
 
 // TODO: MOCK
-#[derive(Debug)]
+#[derive(Clone, Debug, JsonSchema, Serialize, Deserialize)]
 pub struct SearchFilter {
     pub value: String,
     pub is_regex: bool,

--- a/application/apps/indexer/mcp/src/server/messages.rs
+++ b/application/apps/indexer/mcp/src/server/messages.rs
@@ -1,23 +1,14 @@
-use rmcp::schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 
 use crate::types::McpError;
 
+use crate::types::SearchFilter;
+
 /// Messages from the MCP server to chipmunk
 #[derive(Debug)]
 pub enum McpServerToChipmunk {
-    ApplyFilter {
+    ApplySearchFilter {
         filters: Vec<SearchFilter>,
         response_tx: oneshot::Sender<Result<(), McpError>>,
     },
-}
-
-// TODO: MOCK
-#[derive(Clone, Debug, JsonSchema, Serialize, Deserialize)]
-pub struct SearchFilter {
-    pub value: String,
-    pub is_regex: bool,
-    pub ignore_case: bool,
-    pub is_word: bool,
 }

--- a/application/apps/indexer/mcp/src/server/mod.rs
+++ b/application/apps/indexer/mcp/src/server/mod.rs
@@ -1,4 +1,17 @@
+use anyhow::Result;
 use log::{error, warn};
+use rmcp::{
+    ErrorData as RmcpError,
+    handler::server::wrapper::Parameters,
+    handler::server::{ServerHandler, tool::ToolRouter},
+    model::{CallToolResult, Content, ErrorCode},
+    model::{ServerCapabilities, ServerInfo},
+    tool, tool_handler, tool_router,
+    transport::streamable_http_server::{
+        session::local::LocalSessionManager,
+        tower::{StreamableHttpServerConfig, StreamableHttpService},
+    },
+};
 use tokio::{
     sync::{mpsc, oneshot},
     time::{self, sleep},
@@ -6,15 +19,34 @@ use tokio::{
 
 pub mod messages;
 
+pub const BIND_ADDRESS: &str = "127.0.0.1:8181";
+
 use messages::McpServerToChipmunk;
 
 use crate::server::messages::SearchFilter;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct McpServer {
     server_to_chipmunk_tx: mpsc::Sender<McpServerToChipmunk>,
+    pub tool_router: ToolRouter<Self>,
 }
 
+#[tool_handler]
+impl ServerHandler for McpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            instructions: Some("Chipmunk MCP Server".to_string()),
+            capabilities: ServerCapabilities::builder()
+                .enable_tools()
+                .enable_resources()
+                .enable_prompts()
+                .build(),
+            ..Default::default()
+        }
+    }
+}
+
+#[tool_router]
 impl McpServer {
     pub fn new() -> (Self, mpsc::Receiver<McpServerToChipmunk>) {
         let (server_to_chipmunk_tx, server_to_chipmunk_rx) = mpsc::channel(32);
@@ -22,15 +54,37 @@ impl McpServer {
         (
             Self {
                 server_to_chipmunk_tx,
+                tool_router: Self::tool_router(),
             },
             server_to_chipmunk_rx,
         )
     }
 
-    pub fn start(self) {
-        tokio::spawn(self.run());
+    pub async fn start(self) -> Result<()> {
+        let ct = tokio_util::sync::CancellationToken::new();
+        let (mcp_server, _task_rx_inner) = McpServer::new();
+
+        let service = StreamableHttpService::new(
+            move || Ok(mcp_server.clone()),
+            LocalSessionManager::default().into(),
+            StreamableHttpServerConfig {
+                cancellation_token: ct.child_token(),
+                ..Default::default()
+            },
+        );
+        let router = axum::Router::new().nest_service("/mcp", service);
+        let tcp_listener = tokio::net::TcpListener::bind(BIND_ADDRESS).await?;
+
+        tokio::spawn(async move {
+            if let Err(server_err) = axum::serve(tcp_listener, router).await {
+                eprintln!("MCP Server error: {:?}", server_err);
+            }
+        });
+
+        Ok(())
     }
 
+    #[allow(dead_code)]
     async fn run(self) {
         // TODO: Send a mock message after 1 seconds
         warn!("🔅 MCP: sleep timer started");
@@ -72,5 +126,90 @@ impl McpServer {
                 )
             }
         }
+    }
+
+    #[tool(description = r#"Generate SearchFilter objects for filtering logs.
+
+This tool accepts one or more filter specifications and returns a list of SearchFilter objects.
+Each filter can be customized with flags for regex matching, case sensitivity, and word boundaries.
+
+**Input Parameters:**
+- `filters`: An array of filter objects, where each object contains:
+  - `filter` (string): The text or pattern to search for
+  - `is_regex` (boolean): true if the filter is a regular expression pattern
+  - `ignore_case` (boolean): true for case-insensitive matching
+  - `is_word` (boolean): true to match whole words only (word boundary matching)
+
+**Usage Examples:**
+
+Single filter:
+- Input: [{"filter": "error", "is_regex": false, "ignore_case": false, "is_word": false}]
+- Use case: Find exact matches of "error"
+
+Multiple filters:
+- Input: [
+    {"filter": "ERROR", "is_regex": false, "ignore_case": true, "is_word": false},
+    {"filter": "\\d{4}-\\d{2}-\\d{2}", "is_regex": true, "ignore_case": false, "is_word": false}
+  ]
+- Use case: Find "ERROR" (any case) OR date patterns
+
+Common patterns:
+- Case-insensitive word: {"filter": "warning", "is_regex": false, "ignore_case": true, "is_word": true}
+- Regex pattern: {"filter": "\\b(error|fail|exception)\\b", "is_regex": true, "ignore_case": false, "is_word": false}
+- Exact match: {"filter": "timeout", "is_regex": false, "ignore_case": false, "is_word": false}
+
+**Natural Language Interpretation:**
+When the user provides natural language instructions, interpret them as follows:
+- "error" → single filter for "error"
+- "error or warning" → two filters, one for "error" and one for "warning"
+- "case-insensitive ERROR" → set ignore_case: true
+- "match the word 'timeout'" → set is_word: true
+- "regex pattern \\d+" → set is_regex: true
+- "find ERROR, WARNING, and CRITICAL" → three separate filters
+"#)]
+    async fn apply_search_filter(
+        &self,
+        Parameters(params): Parameters<Vec<SearchFilter>>,
+    ) -> Result<CallToolResult, RmcpError> {
+        log::info!(
+            "Received apply_search_filter tool call with params: {:?}",
+            params
+        );
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+        let task = McpServerToChipmunk::ApplyFilter {
+            filters: vec![],
+            response_tx,
+        };
+        let task_tx_clone = self.server_to_chipmunk_tx.clone();
+        // Send task over communication channel in a separate thread,
+        // in future, we can skip match over task spawn
+        match tokio::spawn(async move { task_tx_clone.send(task).await }).await {
+            Ok(_) => log::info!("Sent Search task to MCP server"),
+            Err(err) => log::error!(
+                "Failed to send Search task to MCP server: ApplyFilter: {}",
+                err
+            ),
+        };
+
+        // Wait for the response from task over communication channel
+        // based on the response send back the JSON response to client
+        response_rx
+            .await
+            .map(|task_response| match task_response {
+                Ok(()) => Ok(CallToolResult::success(vec![Content::json(
+                    "Server task finished successfully",
+                )?])),
+                Err(err) => {
+                    let err_msg = format!("Error while applying the task: {err}");
+                    Ok(CallToolResult::error(vec![Content::json(err_msg)?]))
+                }
+            })
+            .map_err(|err| {
+                RmcpError::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Did not receive the response from search filter task {err:?}"),
+                    None,
+                )
+            })?
     }
 }

--- a/application/apps/indexer/mcp/src/types.rs
+++ b/application/apps/indexer/mcp/src/types.rs
@@ -1,18 +1,61 @@
-use std::fmt;
+use std::{ffi::os_str::Display, fmt};
 
-#[derive(Debug)]
+use rmcp::ServiceError;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
 pub enum McpError {
+    // Client errors
+    #[error("MCP service error: {0}")]
+    Service(#[from] ServiceError),
+
+    #[error("Connection failed: {message}")]
+    Connection { message: String },
+
+    #[error("Request timeout: {message}")]
+    Timeout { message: String },
+
+    // Server errors
+    #[error("Tool execution failed: {message}")]
+    ToolExecution { message: String },
+
+    #[error("Setup failed: {message}")]
+    Setup { message: String },
+
+    // Generic
+    #[error("{message}")]
     Generic { message: String },
-    ApplyFilter { message: String },
 }
 
-impl fmt::Display for McpError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            McpError::Generic { message } => write!(f, "{}", message),
-            McpError::ApplyFilter { message } => write!(f, "{}", message),
-        }
+// TODO:[MCP] Probably makes sense to move to tools.rs if we will, have that (in the server?)
+#[derive(Clone, Debug, JsonSchema, Serialize, Deserialize)]
+pub struct SearchFilter {
+    pub value: String,
+    pub is_regex: bool,
+    pub ignore_case: bool,
+    pub is_word: bool,
+}
+
+// TODO:[MCP] Probably makes sense to move to tools.rs if we will, have that (in the server?)
+#[derive(Clone, Debug, JsonSchema, Serialize, Deserialize)]
+pub struct SearchFilters {
+    pub filters: Vec<SearchFilter>,
+}
+
+impl fmt::Display for SearchFilters {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let filters: Vec<String> = self
+            .filters
+            .iter()
+            .map(|filter| {
+                format!(
+                    "{{ value: {}, is_regex: {}, ignore_case: {}, is_word: {} }}",
+                    filter.value, filter.is_regex, filter.ignore_case, filter.is_word
+                )
+            })
+            .collect();
+        write!(f, "[{}]", filters.join(", "))
     }
 }
-
-impl std::error::Error for McpError {}

--- a/application/apps/indexer/session/src/state/api.rs
+++ b/application/apps/indexer/session/src/state/api.rs
@@ -29,7 +29,7 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 pub enum Api {
-    // TODO: Can this be removed? Do we need to keep track of context. E.g. store a promptID?
+    // TODO:[MCP] This is the API structure for handling receiving a prompt from UI once the UI is implemented
     SendChatPrompt(String),
     SetSessionFile(
         (

--- a/application/apps/indexer/session/src/state/mod.rs
+++ b/application/apps/indexer/session/src/state/mod.rs
@@ -539,10 +539,10 @@ pub async fn run(
                     stypes::NativeError::channel("Failed to response to Api::SetSessionFile")
                 })?;
             }
-            // TODO:
+            // TODO:[MCP] This will be used to handle prompts from the chat UI once it is implemented
             Api::SendChatPrompt(prompt) => {
                 if let Some(mcp_api) = &mcp_api {
-                    mcp_api.handle_send_prompt(prompt).await?;
+                    mcp_api.send_prompt(prompt).await?;
                 } else {
                     return Err(stypes::NativeError::channel("TODO"));
                 }


### PR DESCRIPTION
This PR includes the following:
- Implement needed changes on the chipmunk core: [TOOL-516](https://esrlabs.atlassian.net/browse/TOOL-516)
  - Chipmunk internal MCP API]: Thin MCP API that bundles creation and interaction with the MCP client and server:
    - create and manage MCP API instances
    - run the MCP event loop to process incoming messages
    - methods to send messages to the MCP client and server
    - => application/apps/indexer/session/src/mcp_api/mod.rs
  - Chipmunk session changes:
    - Instantiate and start MCP server and client.
    - Send a mock test prompt
    - => application/apps/indexer/session/src/session.rs
  - Chipmunk state API: Example changes showcasing where UI triggers would be connected to the MCP API => application/apps/indexer/session/src/state/mod.rs
- Implement a basic MCP client POC: [TOOL-519](https://esrlabs.atlassian.net/browse/TOOL-519)
  - application/apps/indexer/session/src/state/mod.rs
  - new and start functions to create and spin up the MCP client (connecting to the MCP server)
  - run function that initializes conversation state and handles incoming messages (e.g. prompts form chipmunk) and processing of chat messages using the llm client
  - Abstraction layer for LLM clients => application/apps/indexer/mcp/src/client/llm/mod.rs
  - A mock LLM client that simulates LLM behavior without making actual API calls / without a HTTP client =>application/apps/indexer/mcp/src/client/llm/mock.rs
  
**Note:** Open topics or Notes are marked with // TODO:[MCP]
**Note:** contains `log::warn!()` statements for debug purposes. They will need to be removed / replaced by sensible debug statements.

Logical flow explained:
- Chipmunk is started. In session.new()
- The MCP server and client are instantiated
- The MCP server is started
- The MCP client is started
- A mock prompt message is sent from chipmunk core via MCP api mpsc channel to the MCP client
- The MCP client uses a mock LLM client to handle the prompt, which wants to make MCP tool call
- The MCP client sends a tool invocation to the MCP server
- The MCP server sends a tool / task request to the chipmunk core via mpsc channel
- Chipmunk handles the request by sending a Search request via operations API
- Result is returned to MCP server -> MCP client -> LLM client
- LLM client sends a Final response