### PR TITLE
Run Searches on separate task

### DIFF
--- a/application/apps/indexer/processor/src/search/searchers/values.rs
+++ b/application/apps/indexer/processor/src/search/searchers/values.rs
@@ -15,6 +15,7 @@ use super::{BaseSearcher, SearchState};
 pub type OperationResults = Result<ValueSearchOutput, SearchError>;
 
 /// Contains the successful output of a value search operation.
+#[derive(Debug)]
 pub struct ValueSearchOutput {
     /// The range of processed lines numbers in which new matches were found.
     pub processed_range: Range<usize>,

--- a/application/apps/indexer/session/src/state/searchers.rs
+++ b/application/apps/indexer/session/src/state/searchers.rs
@@ -1,11 +1,200 @@
 //! Includes Definitions for searchers in sessions with their current state.
+use std::fmt::Debug;
+
+use tokio::sync::mpsc::{self};
+use tokio_util::sync::CancellationToken;
 
 use processor::search::searchers::{
     self, BaseSearcher, SearchState,
-    regular::{self, RegularSearchState},
-    values::{OperationResults, ValueSearchState},
+    regular::{self, RegularSearchHolder, RegularSearchState},
+    values::{OperationResults, ValueSearchHolder, ValueSearchState},
 };
-use tokio_util::sync::CancellationToken;
+
+mod definitions;
+
+pub use definitions::*;
+
+pub fn spawn() -> (mpsc::Sender<SearchRequest>, mpsc::Receiver<SearchResponse>) {
+    let (request_tx, request_rx) = mpsc::channel(32);
+    let (response_tx, response_rx) = mpsc::channel(32);
+
+    tokio::spawn(async move {
+        run(request_rx, response_tx).await;
+    });
+
+    (request_tx, response_rx)
+}
+
+async fn run(
+    mut request_rx: mpsc::Receiver<SearchRequest>,
+    response_tx: mpsc::Sender<SearchResponse>,
+) {
+    fn log_if_err<T, E: Debug>(res: Result<T, E>) {
+        if let Err(err) = res {
+            log::error!("Fail to send search response. Channel is closed, Error: {err:?} ");
+        }
+    }
+
+    let mut searchers = Searchers {
+        regular: SearcherState::NotInited,
+        values: SearcherState::NotInited,
+    };
+    while let Some(request) = request_rx.recv().await {
+        match request {
+            SearchRequest::SearchRegular {
+                rows,
+                bytes,
+                cancel,
+            } => {
+                let Some(res) =
+                    tokio::task::block_in_place(|| searchers.regular.search(rows, bytes, cancel))
+                else {
+                    continue;
+                };
+                let res = response_tx
+                    .send(SearchResponse::SearchRegularResult(res))
+                    .await;
+                log_if_err(res);
+            }
+            SearchRequest::SearchValue {
+                rows,
+                bytes,
+                cancel,
+            } => {
+                let Some(res) =
+                    tokio::task::block_in_place(|| searchers.values.search(rows, bytes, cancel))
+                else {
+                    continue;
+                };
+                let res = response_tx
+                    .send(SearchResponse::SearchValueResult(res))
+                    .await;
+
+                log_if_err(res);
+            }
+            SearchRequest::GetSearchHolder { filename, sender } => {
+                let holder = {
+                    match searchers.regular {
+                        SearcherState::Available(_) => {
+                            use std::mem;
+                            if let SearcherState::Available(holder) =
+                                mem::replace(&mut searchers.regular, SearcherState::InUse)
+                            {
+                                Ok(holder)
+                            } else {
+                                Err(stypes::NativeError {
+                                    severity: stypes::Severity::ERROR,
+                                    kind: stypes::NativeErrorKind::Configuration,
+                                    message: Some(String::from(
+                                        "Could not replace search holder in state",
+                                    )),
+                                })
+                            }
+                        }
+                        SearcherState::InUse => {
+                            Err(stypes::NativeError::channel("Search holder is in use"))
+                        }
+                        SearcherState::NotInited => {
+                            searchers.regular.set_in_use();
+                            Ok(RegularSearchHolder::new(&filename, 0, 0))
+                        }
+                    }
+                };
+                let res = sender.send(holder);
+                log_if_err(res);
+            }
+            SearchRequest::GetSearchValueHolder { filename, sender } => {
+                let holder = {
+                    match searchers.values {
+                        SearcherState::Available(_) => {
+                            use std::mem;
+                            if let SearcherState::Available(holder) =
+                                mem::replace(&mut searchers.values, SearcherState::InUse)
+                            {
+                                Ok(holder)
+                            } else {
+                                Err(stypes::NativeError {
+                                    severity: stypes::Severity::ERROR,
+                                    kind: stypes::NativeErrorKind::Configuration,
+                                    message: Some(String::from(
+                                        "Could not replace search values holder in state",
+                                    )),
+                                })
+                            }
+                        }
+                        SearcherState::InUse => Err(stypes::NativeError::channel(
+                            "Search values holder is in use",
+                        )),
+                        SearcherState::NotInited => {
+                            searchers.values.set_in_use();
+                            Ok(ValueSearchHolder::new(&filename, 0, 0))
+                        }
+                    }
+                };
+                let res = sender.send(holder);
+                log_if_err(res);
+            }
+            SearchRequest::SetSearchHolder {
+                holder,
+                tx_response,
+            } => {
+                let result = if searchers.regular.is_in_use() {
+                    if let Some(holder) = holder {
+                        searchers.regular.set_searcher(holder);
+                    } else {
+                        searchers.regular.set_not_inited();
+                    }
+                    Ok(())
+                } else {
+                    Err(stypes::NativeError::channel(
+                        "Cannot set search holder - it wasn't in use",
+                    ))
+                };
+                let res = tx_response.send(result);
+                log_if_err(res);
+            }
+            SearchRequest::SetValueHolder {
+                holder,
+                tx_response,
+            } => {
+                let result = if searchers.values.is_in_use() {
+                    if let Some(holder) = holder {
+                        searchers.values.set_searcher(holder);
+                    } else {
+                        searchers.values.set_not_inited();
+                    }
+                    Ok(())
+                } else {
+                    Err(stypes::NativeError::channel(
+                        "Cannot set search values holder - it wasn't in use",
+                    ))
+                };
+                let res = tx_response.send(result);
+                log_if_err(res);
+            }
+            SearchRequest::DropSearch { tx_result } => {
+                let result = if searchers.regular.is_in_use() {
+                    false
+                } else {
+                    searchers.regular.set_not_inited();
+                    true
+                };
+                let res = tx_result.send(result);
+                log_if_err(res);
+            }
+            SearchRequest::DropSearchValue { tx_result } => {
+                let result = if searchers.values.is_in_use() {
+                    false
+                } else {
+                    searchers.values.set_not_inited();
+                    true
+                };
+                let res = tx_result.send(result);
+                log_if_err(res);
+            }
+        }
+    }
+}
 
 #[derive(Debug)]
 pub enum SearcherState<State: SearchState> {

--- a/application/apps/indexer/session/src/state/searchers/definitions.rs
+++ b/application/apps/indexer/session/src/state/searchers/definitions.rs
@@ -1,0 +1,51 @@
+use std::path::PathBuf;
+
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use processor::search::searchers::{
+    regular::{self, RegularSearchHolder},
+    values::{OperationResults, ValueSearchHolder},
+};
+
+#[derive(Debug)]
+pub enum SearchRequest {
+    SearchRegular {
+        rows: u64,
+        bytes: u64,
+        cancel: CancellationToken,
+    },
+    SearchValue {
+        rows: u64,
+        bytes: u64,
+        cancel: CancellationToken,
+    },
+    GetSearchHolder {
+        filename: PathBuf,
+        sender: oneshot::Sender<Result<RegularSearchHolder, stypes::NativeError>>,
+    },
+    GetSearchValueHolder {
+        filename: PathBuf,
+        sender: oneshot::Sender<Result<ValueSearchHolder, stypes::NativeError>>,
+    },
+    SetSearchHolder {
+        holder: Option<RegularSearchHolder>,
+        tx_response: oneshot::Sender<Result<(), stypes::NativeError>>,
+    },
+    SetValueHolder {
+        holder: Option<ValueSearchHolder>,
+        tx_response: oneshot::Sender<Result<(), stypes::NativeError>>,
+    },
+    DropSearch {
+        tx_result: oneshot::Sender<bool>,
+    },
+    DropSearchValue {
+        tx_result: oneshot::Sender<bool>,
+    },
+}
+
+#[derive(Debug)]
+pub enum SearchResponse {
+    SearchRegularResult(regular::SearchResults),
+    SearchValueResult(OperationResults),
+}

--- a/application/apps/indexer/session/tests/snapshot_tests/mod.rs
+++ b/application/apps/indexer/session/tests/snapshot_tests/mod.rs
@@ -77,7 +77,9 @@ async fn observe_dlt_with_someip_session() {
     });
 }
 
-#[tokio::test]
+// SomeIP request search in parsing session and searcher use block_in_place
+// on CPU heavy blocks.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn observe_someip_bcapng_session() {
     let input = "../../../developing/resources/someip.pcapng";
     let fibex_file = "../../../developing/resources/someip.xml";
@@ -110,7 +112,9 @@ async fn observe_someip_bcapng_session() {
     });
 }
 
-#[tokio::test]
+// SomeIP request search in parsing session and searcher use block_in_place
+// on CPU heavy blocks.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn observe_someip_legacy_session() {
     let input = "../../../developing/resources/someip.pcap";
     let fibex_file = "../../../developing/resources/someip.xml";


### PR DESCRIPTION
This PR improves the performance and the remove lagging in the UI in cases where search is active alongside with parsing incoming data by moving search processing CPU intensive blocks to another task to avoid blocking session state while these searches are done. Also, it uses `block_in_place()` from tokio to avoid blocking the runtime on such CPU intensive tasks.

These changes improve the performance up to 1.40x on parsing DLT files (500 MB) while a filter is applied:

| Scenario                             | Time (ms) | Improvement vs Master | Speedup vs Master |
| :----------------------------------- | --------: | --------------------: | ----------------: |
| Parsing with no filters              |      4836 |               |          |
| Parsing with filters (This PR)        |      5037 |               +28.31% |             1.40x |
| Parsing with filters (Current Master) |      7026 |                     - |             1.00x |

These changes significantly reduce UI lag when filtering live data streams, such as process output or DLT over TCP/UDP