### PR TITLE
Cleanup unused dependencies

### DIFF
--- a/application/apps/indexer/addons/text_grep/Cargo.toml
+++ b/application/apps/indexer/addons/text_grep/Cargo.toml
@@ -16,8 +16,10 @@ workspace = true
 tokio = { workspace = true, features = ["full"] }
 bufread = { path = "../bufread" }
 tokio-util.workspace = true
-tempfile.workspace = true
 grep-searcher.workspace = true
 grep-regex.workspace = true
 thiserror.workspace = true
 regex.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/application/apps/indexer/plugins_host/Cargo.toml
+++ b/application/apps/indexer/plugins_host/Cargo.toml
@@ -22,7 +22,6 @@ wasmtime = "33.0"
 wasmtime-wasi = "33.0"
 
 parsers = { path = "../parsers" }
-sources = { path = "../sources" }
 stypes = { path = "../stypes" }
 # TODO : Introduce shared crates and move dir_checksum to it.
 dir_checksum = { path = "../../../../cli/development-cli/dir_checksum" }

--- a/application/apps/indexer/session/Cargo.toml
+++ b/application/apps/indexer/session/Cargo.toml
@@ -9,7 +9,6 @@ workspace = true
 
 [dependencies]
 blake3.workspace = true
-crossbeam-channel.workspace = true
 dirs.workspace = true
 dlt-core = { workspace = true, features = ["statistics", "serialization"] }
 file-tools = { path = "../addons/file-tools" }

--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -8,14 +8,11 @@ edition = "2024"
 workspace = true 
 
 [dependencies]
-async-stream = "0.3"
 bufread = { path = "../addons/bufread" }
 bytes = "1.3"
 etherparse = "0.16"
 futures.workspace = true
-indexer_base = { path = "../indexer_base" }
 log.workspace = true
-parsers = { path = "../parsers" }
 pcap-parser = "0.16"
 thiserror.workspace = true
 tokio.workspace = true
@@ -24,11 +21,8 @@ tokio-stream.workspace = true
 tokio-util = { workspace = true , features = ["full"] }
 serde = { workspace = true, features = ["derive"] }
 uuid = { workspace = true , features = ["serde", "v4"] }
-regex.workspace = true
-shellexpand = "3.1"
 stypes = { path = "../stypes", features=["rustcore"] }
 socket2 = "0.5.8"
-shell-tools = { path = "../addons/shell-tools" }
 
 [dev-dependencies]
 env_logger.workspace = true

--- a/application/apps/indexer/stypes/Cargo.toml
+++ b/application/apps/indexer/stypes/Cargo.toml
@@ -12,7 +12,6 @@ test_and_gen = []
 rustcore = [
     "dep:tokio",
     "dep:walkdir",
-    "dep:regex",
     "dlt-core/fibex",
     "dlt-core/statistics",
     "dlt-core/serialization",
@@ -25,7 +24,6 @@ nodejs = [
 [dependencies]
 serde = { workspace = true , features = ["derive"] }
 dlt-core = { workspace = true, features = ["fibex", "serialization"] }
-regex = { workspace = true, optional = true }
 bincode = "1.3"
 extend = { path = "../tools/extend"}
 uuid = { workspace = true, features = ["serde"] }

--- a/application/apps/rustcore/rs-bindings/Cargo.lock
+++ b/application/apps/rustcore/rs-bindings/Cargo.lock
@@ -240,28 +240,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2462,7 +2440,6 @@ dependencies = [
  "rand 0.9.1",
  "serde",
  "serde_json",
- "sources",
  "stypes",
  "thiserror 2.0.12",
  "tokio",
@@ -2984,7 +2961,6 @@ name = "session"
 version = "0.1.0"
 dependencies = [
  "blake3",
- "crossbeam-channel",
  "dirs",
  "dlt-core",
  "file-tools",
@@ -3039,15 +3015,6 @@ dependencies = [
  "log",
  "stypes",
  "which",
-]
-
-[[package]]
-name = "shellexpand"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
-dependencies = [
- "dirs",
 ]
 
 [[package]]
@@ -3135,19 +3102,13 @@ dependencies = [
 name = "sources"
 version = "0.1.0"
 dependencies = [
- "async-stream",
  "bufread",
  "bytes",
  "etherparse",
  "futures",
- "indexer_base",
  "log",
- "parsers",
  "pcap-parser",
- "regex",
  "serde",
- "shell-tools",
- "shellexpand",
  "socket2",
  "stypes",
  "thiserror 2.0.12",
@@ -3191,7 +3152,6 @@ dependencies = [
  "dlt-core",
  "extend",
  "node-bindgen",
- "regex",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -3284,7 +3244,6 @@ dependencies = [
  "grep-regex",
  "grep-searcher",
  "regex",
- "tempfile",
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",

--- a/cli/chipmunk-cli/Cargo.lock
+++ b/cli/chipmunk-cli/Cargo.lock
@@ -104,28 +104,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,27 +389,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "dlt-core"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,22 +432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_home"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
-
-[[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "etherparse"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,12 +448,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fnv"
@@ -607,17 +542,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -780,22 +704,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags 2.9.1",
- "libc",
-]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
-
-[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,12 +845,6 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -1174,7 +1076,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
 ]
 
 [[package]]
@@ -1184,17 +1086,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.1",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1245,19 +1136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
  "nom",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
-dependencies = [
- "bitflags 2.9.1",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1335,24 +1213,6 @@ dependencies = [
  "scopeguard",
  "unescaper",
  "winapi",
-]
-
-[[package]]
-name = "shell-tools"
-version = "0.1.0"
-dependencies = [
- "log",
- "stypes",
- "which",
-]
-
-[[package]]
-name = "shellexpand"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
-dependencies = [
- "dirs",
 ]
 
 [[package]]
@@ -1437,19 +1297,13 @@ dependencies = [
 name = "sources"
 version = "0.1.0"
 dependencies = [
- "async-stream",
  "bufread",
  "bytes",
  "etherparse",
  "futures",
- "indexer_base",
  "log",
- "parsers",
  "pcap-parser",
- "regex",
  "serde",
- "shell-tools",
- "shellexpand",
  "socket2",
  "stypes",
  "thiserror 2.0.12",
@@ -1480,7 +1334,6 @@ dependencies = [
  "bincode",
  "dlt-core",
  "extend",
- "regex",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -1500,19 +1353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
-dependencies = [
- "fastrand",
- "getrandom 0.3.3",
- "once_cell",
- "rustix",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "text_grep"
 version = "0.1.0"
 dependencies = [
@@ -1520,7 +1360,6 @@ dependencies = [
  "grep-regex",
  "grep-searcher",
  "regex",
- "tempfile",
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
@@ -1670,7 +1509,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
  "js-sys",
  "serde",
  "wasm-bindgen",
@@ -1774,17 +1613,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "which"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
-dependencies = [
- "env_home",
- "rustix",
- "winsafe",
 ]
 
 [[package]]
@@ -1958,12 +1786,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"


### PR DESCRIPTION
This PR includes:

* Check is made via [cargo udeps](https://crates.io/crates/cargo-udeps) tool and all tests including generating types and their proptests successfully ran.
* Move tempfile to dev dependencies in grep-regex