### PR TITLE
Session Setup for UDP & Improve space allocation

### DIFF
--- a/application/apps/indexer/gui/application/src/host/common/sources.rs
+++ b/application/apps/indexer/gui/application/src/host/common/sources.rs
@@ -52,7 +52,7 @@ impl From<&StreamConfig> for StreamNames {
         match value {
             StreamConfig::Process(..) => Self::Process,
             StreamConfig::Tcp(..) => Self::Tcp,
-            StreamConfig::Udp => Self::Udp,
+            StreamConfig::Udp(..) => Self::Udp,
             StreamConfig::Serial => Self::Serial,
         }
     }

--- a/application/apps/indexer/gui/application/src/host/service/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/service/mod.rs
@@ -18,7 +18,9 @@ use crate::{
         ui::session_setup::state::{
             SessionSetupState,
             parsers::{DltParserConfig, ParserConfig, someip::SomeIpParserConfig},
-            sources::{ByteSourceConfig, ProcessConfig, SourceFileInfo, StreamConfig, TcpConfig},
+            sources::{
+                ByteSourceConfig, ProcessConfig, SourceFileInfo, StreamConfig, TcpConfig, UdpConfig,
+            },
         },
     },
     session::{InitSessionError, init_session},
@@ -182,7 +184,7 @@ impl HostService {
                 ByteSourceConfig::Stream(StreamConfig::Process(ProcessConfig::new()))
             }
             StreamNames::Tcp => ByteSourceConfig::Stream(StreamConfig::Tcp(TcpConfig::new())),
-            StreamNames::Udp => ByteSourceConfig::Stream(StreamConfig::Udp),
+            StreamNames::Udp => ByteSourceConfig::Stream(StreamConfig::Udp(UdpConfig::new())),
             StreamNames::Serial => ByteSourceConfig::Stream(StreamConfig::Serial),
         };
 
@@ -218,7 +220,9 @@ impl HostService {
             ByteSourceConfig::Stream(StreamConfig::Tcp(config)) => {
                 ObserveOrigin::Stream(source_id, Transport::TCP(config.into()))
             }
-            ByteSourceConfig::Stream(StreamConfig::Udp) => todo!("UDP not supported yet"),
+            ByteSourceConfig::Stream(StreamConfig::Udp(config)) => {
+                ObserveOrigin::Stream(source_id, Transport::UDP(config.into()))
+            }
             ByteSourceConfig::Stream(StreamConfig::Serial) => {
                 todo!("Serial Port not supported yet")
             }

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/mod.rs
@@ -1,4 +1,4 @@
-use egui::{Frame, Margin, Ui};
+use egui::{Align, Frame, Key, Label, Layout, Margin, RichText, TextEdit, Ui, Widget as _};
 
 use crate::host::ui::{
     UiActions,
@@ -50,25 +50,74 @@ fn render_stream(stream: &mut StreamConfig, actions: &mut UiActions, ui: &mut Ui
             .outer_margin(Margin::symmetric(10, 4))
     };
     let mut output = RenderOutcome::None;
-    ui.vertical(|ui| {
+    ui.with_layout(Layout::top_down_justified(Align::Min), |ui| {
         get_frame(ui).show(ui, |ui| {
-            ui.set_min_width(ui.available_width());
             ui.heading("Connection");
             ui.add_space(10.);
             output = match stream {
                 StreamConfig::Process(config) => process::render_connection(config, actions, ui),
                 StreamConfig::Tcp(config) => tcp::render_connection(config, ui),
-                StreamConfig::Udp => udp::render_connection(ui),
+                StreamConfig::Udp(config) => udp::render_connection(config, ui),
                 StreamConfig::Serial => serial::render_connection(ui),
             };
         });
 
         get_frame(ui).show(ui, |ui| {
-            ui.set_min_width(ui.available_width());
             ui.heading("Recent");
             ui.add_space(10.);
         });
     });
 
     output
+}
+
+/// Specifies the needed functionality to be used with the function [`render_socket_address`].
+trait ConfigBindAddress {
+    fn bind_addr(&mut self) -> &mut String;
+    fn validate(&mut self);
+    fn is_valid(&self) -> bool;
+    fn bind_err_msg(&self) -> Option<&str>;
+}
+
+/// General function to render the binding address for TCP & UDP.
+fn render_socket_address<C: ConfigBindAddress>(config: &mut C, ui: &mut Ui) -> RenderOutcome {
+    let mut outcome = RenderOutcome::None;
+
+    ui.vertical(|ui| {
+        Label::new("Socket Address:").selectable(false).ui(ui);
+
+        let ip_txt_res = TextEdit::singleline(config.bind_addr())
+            .vertical_align(Align::Center)
+            .desired_width(200.)
+            .hint_text("127.0.0.1:8080")
+            .show(ui)
+            .response;
+
+        if ip_txt_res.changed() {
+            config.validate();
+        }
+
+        if ip_txt_res.lost_focus() && ip_txt_res.ctx.input(|ui| ui.key_pressed(Key::Enter)) {
+            if config.is_valid() {
+                outcome = RenderOutcome::StartSession;
+            } else {
+                // Single line moves focus on enter. This is a quick fix
+                // in case command isn't valid.
+                ip_txt_res.request_focus();
+            }
+        }
+
+        ui.vertical(|ui| {
+            ui.set_height(20.);
+            if let Some(err_msg) = config.bind_err_msg() {
+                let err_txt = RichText::new(err_msg)
+                    .size(10.5)
+                    .small()
+                    .color(ui.style().visuals.warn_fg_color);
+                Label::new(err_txt).selectable(false).ui(ui);
+            }
+        });
+    });
+
+    outcome
 }

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/tcp.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/tcp.rs
@@ -1,46 +1,27 @@
-use egui::{Align, Color32, Key, Label, RichText, TextEdit, Ui, Widget};
+use egui::Ui;
 
-use crate::host::ui::session_setup::state::sources::TcpConfig;
+use crate::host::ui::session_setup::{ state::sources::TcpConfig};
 
-use super::RenderOutcome;
+use super::{ConfigBindAddress, RenderOutcome, render_socket_address};
+
+impl ConfigBindAddress for TcpConfig {
+    fn bind_addr(&mut self) -> &mut String {
+        &mut self.bind_addr
+    }
+
+    fn validate(&mut self) {
+        self.validate();
+    }
+
+    fn is_valid(&self) -> bool {
+        self.is_valid()
+    }
+
+    fn bind_err_msg(&self) -> Option<&str> {
+        self.get_err_msg()
+    }
+}
 
 pub fn render_connection(config: &mut TcpConfig, ui: &mut Ui) -> RenderOutcome {
-    let mut outcome = RenderOutcome::None;
-    ui.vertical(|ui| {
-        Label::new("Socket Address:").selectable(false).ui(ui);
-
-        let ip_txt_res = TextEdit::singleline(&mut config.bind_addr)
-            .vertical_align(Align::Center)
-            .desired_width(200.)
-            .hint_text("127.0.0.1:8080")
-            .show(ui)
-            .response;
-
-        if ip_txt_res.changed() {
-            config.validate();
-        }
-
-        if ip_txt_res.lost_focus() && ip_txt_res.ctx.input(|ui| ui.key_pressed(Key::Enter)) {
-            if config.is_valid() {
-                outcome = RenderOutcome::StartSession;
-            } else {
-                // Single line moves focus on enter. This is a quick fix
-                // in case command isn't valid.
-                ip_txt_res.request_focus();
-            }
-        }
-
-        ui.vertical(|ui| {
-            ui.set_height(20.);
-            if let Some(err_msg) = config.get_err_msg() {
-                let err_txt = RichText::new(err_msg)
-                    .size(10.5)
-                    .small()
-                    .color(Color32::YELLOW);
-                Label::new(err_txt).selectable(false).ui(ui);
-            }
-        });
-    });
-
-    outcome
+    render_socket_address(config, ui)
 }

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/udp.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/udp.rs
@@ -1,8 +1,134 @@
-use egui::Ui;
+use egui::{Align, Button, Label, Layout, Response, RichText, Sides, TextEdit, Ui, Widget, vec2};
 
-use super::RenderOutcome;
+use crate::{
+    common::phosphor::icons,
+    host::ui::session_setup::state::sources::{MulticastItem, UdpConfig},
+};
 
-pub fn render_connection(ui: &mut Ui) -> RenderOutcome {
-    ui.heading("UDP Connectoin Config Comming Soon");
-    RenderOutcome::None
+use super::{ConfigBindAddress, RenderOutcome, render_socket_address};
+
+impl ConfigBindAddress for UdpConfig {
+    fn bind_addr(&mut self) -> &mut String {
+        &mut self.bind_addr
+    }
+
+    fn validate(&mut self) {
+        self.validate();
+    }
+
+    fn is_valid(&self) -> bool {
+        self.is_valid()
+    }
+
+    fn bind_err_msg(&self) -> Option<&str> {
+        self.get_bind_err()
+    }
+}
+
+pub fn render_connection(config: &mut UdpConfig, ui: &mut Ui) -> RenderOutcome {
+    let outcome = render_socket_address(config, ui);
+
+    if !config.multicasts.is_empty() {
+        render_multicasts(config, ui);
+    }
+
+    ui.allocate_ui_with_layout(
+        vec2(ui.available_width(), 30.),
+        Layout::right_to_left(Align::Center),
+        |ui| {
+            let multi_res = Button::new("Add Multicast")
+                .min_size(vec2(100., 20.))
+                .ui(ui);
+
+            if multi_res.clicked() {
+                config.multicasts.push(MulticastItem::new());
+            }
+        },
+    );
+
+    outcome
+}
+
+fn render_multicasts(config: &mut UdpConfig, ui: &mut Ui) {
+    ui.separator();
+    ui.heading("Multicasts");
+
+    let mut to_delete = None;
+    for (idx, item) in config.multicasts.iter_mut().enumerate() {
+        Sides::new().show(
+            ui,
+            |ui| {
+                let multi_res = label_input_field(
+                    "Address",
+                    &mut item.multi_address,
+                    "255.255.255.255",
+                    item.multi_address_err,
+                    ui,
+                );
+
+                let inter_res = label_input_field(
+                    "Interface Address",
+                    &mut item.interface_addr,
+                    "0.0.0.0",
+                    item.interface_addr_err,
+                    ui,
+                );
+
+                if multi_res.changed() || inter_res.changed() {
+                    item.validate();
+                }
+            },
+            |ui| {
+                ui.allocate_ui_with_layout(
+                    vec2(0., 50.),
+                    Layout::right_to_left(Align::Center),
+                    |ui| {
+                        ui.add_space(10.);
+                        let button_res = Button::new(icons::regular::X)
+                            .frame(false)
+                            .ui(ui)
+                            .on_hover_text("Remove");
+
+                        if button_res.clicked() {
+                            to_delete = Some(idx);
+                        }
+                    },
+                );
+            },
+        );
+    }
+
+    if let Some(to_del) = to_delete {
+        config.multicasts.remove(to_del);
+    }
+}
+
+fn label_input_field(
+    label: &str,
+    value: &mut String,
+    hint_text: &str,
+    error_msg: Option<&str>,
+    ui: &mut Ui,
+) -> Response {
+    ui.allocate_ui_with_layout(vec2(200., 70.), Layout::top_down(Align::LEFT), |ui| {
+        ui.style_mut().spacing.item_spacing.y += 2.;
+
+        Label::new(label).selectable(false).ui(ui);
+
+        let input_res = TextEdit::singleline(value).hint_text(hint_text).ui(ui);
+
+        if let Some(msg) = error_msg {
+            let txt = RichText::new(msg)
+                .small()
+                .size(11.)
+                .color(ui.visuals().warn_fg_color);
+
+            ui.label(txt);
+        }
+
+        ui.allocate_space(ui.available_size());
+
+        input_res
+    })
+    .inner
 }

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/side_config/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/side_config/mod.rs
@@ -19,7 +19,6 @@ pub fn render_content(state: &mut SessionSetupState, actions: &mut UiActions, ui
     }
 
     group_frame(ui).show(ui, |ui| {
-        ui.set_min_width(ui.available_width());
         let title = format!("{} Parser", ParserNames::from(&state.parser));
         ui.heading(title);
         ui.add_space(6.);
@@ -42,8 +41,6 @@ fn validation_errors(state: &SessionSetupState, ui: &mut Ui) {
     }
 
     group_frame(ui).show(ui, |ui| {
-        ui.set_min_width(ui.available_width());
-
         ui.heading("Error(s)");
 
         for err in errors {

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/state/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/state/mod.rs
@@ -8,7 +8,7 @@ use crate::host::{
         UiActions,
         session_setup::state::{
             parsers::someip::SomeIpParserConfig,
-            sources::{ProcessConfig, StreamConfig},
+            sources::{ProcessConfig, StreamConfig, TcpConfig, UdpConfig},
         },
     },
 };
@@ -50,8 +50,8 @@ impl SessionSetupState {
             StreamNames::Process => {
                 ByteSourceConfig::Stream(StreamConfig::Process(ProcessConfig::new()))
             }
-            StreamNames::Tcp => todo!(),
-            StreamNames::Udp => todo!(),
+            StreamNames::Tcp => ByteSourceConfig::Stream(StreamConfig::Tcp(TcpConfig::new())),
+            StreamNames::Udp => ByteSourceConfig::Stream(StreamConfig::Udp(UdpConfig::new())),
             StreamNames::Serial => todo!(),
         };
 

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/state/sources/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/state/sources/mod.rs
@@ -1,10 +1,12 @@
 pub mod file;
 pub mod process;
 pub mod tcp;
+mod udp;
 
 pub use file::SourceFileInfo;
 pub use process::ProcessConfig;
 pub use tcp::TcpConfig;
+pub use udp::{MulticastItem, UdpConfig};
 
 #[derive(Debug, Clone)]
 pub enum ByteSourceConfig {
@@ -37,7 +39,7 @@ impl ByteSourceConfig {
 pub enum StreamConfig {
     Process(ProcessConfig),
     Tcp(TcpConfig),
-    Udp,
+    Udp(UdpConfig),
     Serial,
 }
 
@@ -46,7 +48,7 @@ impl StreamConfig {
         match self {
             StreamConfig::Process(config) => config.is_valid(),
             StreamConfig::Tcp(config) => config.is_valid(),
-            StreamConfig::Udp => todo!(),
+            StreamConfig::Udp(config) => config.is_valid(),
             StreamConfig::Serial => todo!(),
         }
     }
@@ -55,7 +57,7 @@ impl StreamConfig {
         match self {
             StreamConfig::Process(config) => config.validation_errors(),
             StreamConfig::Tcp(config) => config.validation_errors(),
-            StreamConfig::Udp => todo!(),
+            StreamConfig::Udp(config) => config.validation_errors(),
             StreamConfig::Serial => todo!(),
         }
     }

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/state/sources/tcp.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/state/sources/tcp.rs
@@ -34,12 +34,12 @@ impl TcpConfig {
     }
 
     pub fn validate(&mut self) {
-        if self.bind_addr.is_empty() {
-            self.err_msg = Some("Socket Address is required");
+        self.err_msg = if self.bind_addr.is_empty() {
+            Some("Socket Address is required")
         } else if self.bind_addr.parse::<SocketAddr>().is_err() {
-            self.err_msg = Some("Socket Address is invalid");
+            Some("Socket Address is invalid")
         } else {
-            self.err_msg = None;
+            None
         }
     }
 }

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/state/sources/udp.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/state/sources/udp.rs
@@ -1,0 +1,132 @@
+use std::net::{IpAddr, SocketAddr};
+
+#[derive(Debug, Clone)]
+pub struct UdpConfig {
+    pub bind_addr: String,
+    bind_err_msg: Option<&'static str>,
+    pub multicasts: Vec<MulticastItem>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MulticastItem {
+    pub multi_address: String,
+    pub interface_addr: String,
+    pub multi_address_err: Option<&'static str>,
+    pub interface_addr_err: Option<&'static str>,
+}
+
+impl MulticastItem {
+    pub fn new() -> Self {
+        let mut item = Self {
+            multi_address: String::from("255.255.255.255"),
+            interface_addr: String::from("0.0.0.0"),
+            multi_address_err: None,
+            interface_addr_err: None,
+        };
+
+        item.validate();
+
+        item
+    }
+
+    pub fn validate(&mut self) {
+        self.multi_address_err = if self.multi_address.is_empty() {
+            Some("Address is required")
+        } else if self.multi_address.parse::<IpAddr>().is_err() {
+            Some("Address is invalid")
+        } else {
+            None
+        };
+
+        self.interface_addr_err = if self.interface_addr.is_empty() {
+            Some("Interface address is required")
+        } else if self.interface_addr.parse::<IpAddr>().is_err() {
+            Some("Interface Address is invalid")
+        } else {
+            None
+        }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.multi_address_err.is_none() && self.interface_addr_err.is_none()
+    }
+
+    pub fn validation_errors(&self) -> Vec<&str> {
+        [self.multi_address_err, self.interface_addr_err]
+            .iter()
+            .filter_map(|err| *err)
+            .collect()
+    }
+}
+
+impl UdpConfig {
+    pub fn new() -> Self {
+        let mut config = Self {
+            bind_addr: String::new(),
+            bind_err_msg: None,
+            multicasts: Vec::new(),
+        };
+
+        config.validate();
+
+        config
+    }
+
+    pub fn validate(&mut self) {
+        self.bind_err_msg = if self.bind_addr.is_empty() {
+            Some("Socket Address is required")
+        } else if self.bind_addr.parse::<SocketAddr>().is_err() {
+            Some("Socket Address is invalid")
+        } else {
+            None
+        };
+
+        self.multicasts.iter_mut().for_each(|item| item.validate());
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.bind_err_msg.is_none() && self.multicasts.iter().all(|item| item.is_valid())
+    }
+
+    pub fn validation_errors(&self) -> Vec<&str> {
+        let mut errors = Vec::new();
+
+        if let Some(err_msg) = self.bind_err_msg {
+            errors.push(err_msg);
+        }
+
+        errors.extend(
+            self.multicasts
+                .iter()
+                .flat_map(|item| item.validation_errors()),
+        );
+
+        errors
+    }
+
+    pub fn get_bind_err(&self) -> Option<&str> {
+        self.bind_err_msg
+    }
+}
+
+impl From<MulticastItem> for stypes::MulticastInfo {
+    fn from(item: MulticastItem) -> Self {
+        Self {
+            multiaddr: item.multi_address,
+            interface: Some(item.interface_addr),
+        }
+    }
+}
+
+impl From<UdpConfig> for stypes::UDPTransportConfig {
+    fn from(config: UdpConfig) -> Self {
+        Self {
+            bind_addr: config.bind_addr,
+            multicast: config
+                .multicasts
+                .into_iter()
+                .map(stypes::MulticastInfo::from)
+                .collect(),
+        }
+    }
+}

--- a/application/apps/indexer/gui/application/src/session/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/mod.rs
@@ -97,7 +97,7 @@ impl Session {
             .default_height(200.)
             .resizable(true)
             .show_inside(ui, |ui| {
-                ui.set_min_size(ui.available_size());
+                ui.take_available_height();
                 bottom_panel.render_content(shared, actions, ui);
             });
 

--- a/application/apps/indexer/gui/application/src/session/ui/shared/info.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/shared/info.rs
@@ -23,7 +23,7 @@ impl SessionInfo {
             ObserveOrigin::Stream(_id, transport) => match transport {
                 Transport::Process(config) => config.command.to_owned(),
                 Transport::TCP(config) => config.bind_addr.to_owned(),
-                Transport::UDP(_config) => todo!(),
+                Transport::UDP(config) => config.bind_addr.to_owned(),
                 Transport::Serial(_config) => todo!(),
             },
         };


### PR DESCRIPTION
* Implement session setup for UDP.
* Use generic function to render binding address for both TCP and UDP.
* Avoid using set_min function and replace some of them with take_available functions