### PR TITLE
Fix missing dependency on Windows.

### DIFF
--- a/application/apps/indexer/sources/Cargo.toml
+++ b/application/apps/indexer/sources/Cargo.toml
@@ -24,5 +24,8 @@ uuid = { workspace = true , features = ["serde", "v4"] }
 stypes = { path = "../stypes", features=["rustcore"] }
 socket2 = "0.5.8"
 
+[target.'cfg(windows)'.dependencies]
+shell-tools = { path = "../addons/shell-tools" }
+
 [dev-dependencies]
 env_logger.workspace = true


### PR DESCRIPTION
This PR adds the missing dependency `shell-tools` on Windows only.