### PR TITLE
Export filters as JSON

### DIFF
--- a/application/client/src/app/service/bridge.ts
+++ b/application/client/src/app/service/bridge.ts
@@ -700,7 +700,7 @@ export class Service extends Implementation {
                     new Requests.Storage.EntriesSet.Request({
                         key: dest.key,
                         file: dest.file,
-                        entries: JSON.stringify(entries),
+                        entries: entries,
                         mode,
                     }),
                 )

--- a/application/holder/src/service/storage.ts
+++ b/application/holder/src/service/storage.ts
@@ -157,7 +157,7 @@ export class Service extends Implementation {
                         return new CancelablePromise((resolve, reject) => {
                             const entries: Entry[] | Error = (() => {
                                 try {
-                                    const entries: Entry[] = JSON.parse(request.entries);
+                                    const entries: Entry[] = request.entries;
                                     if (!(entries instanceof Array)) {
                                         throw new Error(`Expecting entries will be {Entry[]}`);
                                     }

--- a/application/platform/ipc/request/storage/entries.set.ts
+++ b/application/platform/ipc/request/storage/entries.set.ts
@@ -1,6 +1,7 @@
 import { Define, Interface, SignatureRequirement } from '../declarations';
 
 import * as validator from '../../../env/obj';
+import { Entry } from '../../../types/storage/entry';
 
 export type Mode = 'overwrite' | 'update' | 'append';
 
@@ -8,15 +9,15 @@ export type Mode = 'overwrite' | 'update' | 'append';
 export class Request extends SignatureRequirement {
     public key?: string;
     public file?: string;
-    public entries: string;
+    public entries: Entry[];
     public mode: Mode;
-    constructor(input: { key?: string; file?: string; entries: string; mode: Mode }) {
+    constructor(input: { key?: string; file?: string; entries: Entry[]; mode: Mode }) {
         super();
         validator.isObject(input);
         this.key = validator.getAsNotEmptyStringOrAsUndefined(input, 'key');
         this.file = validator.getAsNotEmptyStringOrAsUndefined(input, 'file');
         this.mode = validator.getAsNotEmptyString(input, 'mode') as Mode;
-        this.entries = validator.getAsNotEmptyString(input, 'entries');
+        this.entries = validator.getAsArray(input, 'entries');
         if (this.key === undefined && this.file === undefined) {
             throw new Error(`For EntriesSetRequest should be defined "file" or "key"`);
         }


### PR DESCRIPTION
Filters are exported as a String which add too many escape characters. This commit changes the exported filter to JSON.
The Content field from the exported json is still string and still includes the escape characters. Exporting JSON needs lot of changes and can be tackled in separate PR.

Fixes: #2475