### PR TITLE
Add hierarchical AGENTS.md context files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# Chipmunk Project Index
+
+## Overview
+Chipmunk is a high-performance log analysis tool. This file is a repo navigation hub; local `AGENTS.md` files contain module-specific context.
+
+## Start Here (Repo Orientation)
+
+1. `AGENTS.md` (this file)
+2. `cli/development-cli/AGENTS.md` (`cargo chipmunk` task orchestration)
+3. `application/apps/indexer/AGENTS.md` (Rust core)
+4. `application/platform/AGENTS.md` (shared TS contracts)
+5. `application/holder/AGENTS.md` (desktop host flow)
+6. `application/client/AGENTS.md` (desktop application client)
+
+## Architecture & Directory Map
+
+- `application/`: Core application logic.
+  - [`application/apps/indexer/`](./application/apps/indexer/AGENTS.md): Rust backend core (parsing, search, ingestion).
+  - [`application/apps/protocol/`](./application/apps/protocol/AGENTS.md): WASM encoding/decoding for shared types.
+  - `application/apps/rustcore/`: Rust/TypeScript bridge layers.
+    - [`application/apps/rustcore/rs-bindings/`](./application/apps/rustcore/rs-bindings/AGENTS.md): Native Node addon boundary.
+    - [`application/apps/rustcore/ts-bindings/`](./application/apps/rustcore/ts-bindings/AGENTS.md): TS wrapper API over native bindings.
+    - [`application/apps/rustcore/wasm-bindings/`](./application/apps/rustcore/wasm-bindings/AGENTS.md): Frontend-focused WASM utilities.
+  - [`application/client/`](./application/client/AGENTS.md): Angular UI.
+  - [`application/holder/`](./application/holder/AGENTS.md): Electron host process.
+  - [`application/platform/`](./application/platform/AGENTS.md): Shared IPC/types/logging/env.
+- `cli/`: Command-line tools.
+  - [`cli/chipmunk-cli/`](./cli/chipmunk-cli/AGENTS.md): User-facing parser/export CLI.
+  - [`cli/development-cli/`](./cli/development-cli/AGENTS.md): `cargo chipmunk` developer orchestrator.
+- [`plugins/`](./plugins/AGENTS.md): WASM plugin contracts and runtime-facing model.
+- `docs/`: Architecture guides and contributor docs.
+
+## If You Need X, Go to Y
+
+- Build/test/lint any major target: `cli/development-cli` via `cargo chipmunk`.
+- Core parsing/search/ingestion behavior: `application/apps/indexer`.
+- Shared Rust <-> TypeScript message contract: `application/apps/indexer/stypes`.
+- Message encoding/decoding bridge: `application/apps/protocol`.
+- Native FFI boundary to Node/Electron: `application/apps/rustcore/rs-bindings`.
+- Promise-based TS API used by app/client: `application/apps/rustcore/ts-bindings`.
+- Browser-side WASM utilities (fuzzy/ANSI/filter validation): `application/apps/rustcore/wasm-bindings`.
+- Electron lifecycle and IPC forwarding: `application/holder`.
+- Angular views/services: `application/client`.
+- Shared TS IPC/types/env/logging: `application/platform`.
+- Extensible parser/bytesource components: `plugins/`.
+
+## Cross-Module Dependency Map
+
+- Data path: `application/apps/indexer` -> `application/apps/rustcore/rs-bindings` -> `application/apps/rustcore/ts-bindings` -> `application/holder` and `application/client`.
+- Shared type path: `application/apps/indexer/stypes` -> `application/apps/protocol` -> `application/apps/rustcore/ts-bindings` and `application/platform/types`.
+- Plugin path: `plugins/` contracts/components -> `application/apps/indexer/plugins_host` runtime execution.
+- Orchestration path: `cli/development-cli` drives builds/tests/lints across all targets.
+
+## Development Workflow
+
+Primary entry point:
+
+- Build: `cargo chipmunk build [TARGET] -u print`
+- Test: `cargo chipmunk test [TARGET] -u print`
+- Lint: `cargo chipmunk lint [TARGET] -u print`
+
+| Component | Target | Path |
+| :--- | :--- | :--- |
+| Rust Core | `core` | `application/apps/indexer` |
+| Angular UI | `client` | `application/client` |
+| Electron App | `app` | `application/holder` |
+| Shared TS | `shared` | `application/platform` |
+| Rust FFI | `binding` | `application/apps/rustcore/rs-bindings` |
+| TS Bridge | `wrapper` | `application/apps/rustcore/ts-bindings` |
+
+## Landmarks and Hotspots
+
+- `MessageProducer` and search/grabber paths in `application/apps/indexer` are performance-sensitive.
+- `application/apps/indexer/stypes` changes can cascade into protocol, bindings, and platform types.
+- FFI boundary (`application/apps/indexer/session` -> `application/apps/rustcore/rs-bindings` -> `application/apps/rustcore/ts-bindings`) is high-context and regression-prone.
+- Plugin runtime and contracts (`plugins/` + `application/apps/indexer/plugins_host`) need contract/runtime alignment.

--- a/application/apps/indexer/AGENTS.md
+++ b/application/apps/indexer/AGENTS.md
@@ -1,0 +1,81 @@
+# Indexer (Rust Core) Context
+
+## Overview
+
+Indexer is the Rust backend core for parsing, ingestion, indexing, search, merging, and plugin execution.
+
+## Start Here (First Files to Open)
+
+1. `application/apps/indexer/Cargo.toml`
+2. `application/apps/indexer/processor/src/lib.rs`
+3. `application/apps/indexer/processor/src/producer/`
+4. `application/apps/indexer/processor/src/search/`
+5. `application/apps/indexer/sources/src/`
+6. `application/apps/indexer/parsers/src/`
+7. `application/apps/indexer/session/src/`
+8. `application/apps/indexer/plugins_host/src/`
+9. `application/apps/indexer/stypes/AGENTS.md`
+10. `application/apps/indexer/indexer_base/src/`
+
+## Architecture & Crates (Condensed)
+
+- `processor`: ingestion/search pipeline; `MessageProducer` coordinates `ByteSource` + `Parser`.
+- `sources`: byte ingestion from File/TCP/UDP/Serial/Process/Pcap.
+- `parsers`: DLT/SOME-IP/Text parsing.
+- `indexer_base`: shared chunk/time/progress primitives.
+- `session`: Rust API boundary consumed by Node bindings.
+- `stypes`: Rust/TS shared type source (`ts-rs` generation).
+- `plugins_host`: `wasmtime` runtime for parser/bytesource plugins.
+- `merging`: multi-source chronological merge logic.
+
+## If You Need X, Go to Y
+
+- Add or modify ingestion sources: `application/apps/indexer/sources/src/` + `application/apps/indexer/processor/src/producer/`.
+- Add or modify parser formats: `application/apps/indexer/parsers/src/` + `application/apps/indexer/processor/src/`.
+- Change search/filter behavior: `application/apps/indexer/processor/src/search/`.
+- Adjust random-access/file-windowing: `application/apps/indexer/processor/src/grabber/` + `application/apps/indexer/indexer_base/src/`.
+- Change Node-facing Rust API: `application/apps/indexer/session/src/` then `application/apps/rustcore/rs-bindings`.
+- Change plugin runtime/lifecycle: `application/apps/indexer/plugins_host/src/` + `plugins/`.
+- Add shared Rust/TS type: `application/apps/indexer/stypes` -> `application/apps/protocol` -> `application/apps/rustcore/ts-bindings` -> `application/platform/types`.
+- Investigate pipeline failures: start in `application/apps/indexer/processor/src/producer/`.
+
+## Cross-Module Dependency Map
+
+- Core path: `indexer` -> `application/apps/rustcore/rs-bindings` -> `application/apps/rustcore/ts-bindings` -> `application/holder` / `application/client`.
+- Shared type path: `application/apps/indexer/stypes` -> `application/apps/protocol` -> `application/platform/types`.
+- Plugin path: `plugins/` contracts/artifacts -> `application/apps/indexer/plugins_host`.
+
+## Landmarks and Hotspots
+
+- `MessageProducer` in `processor` (pipeline orchestration).
+- `PluginsManager` and plugin host wrappers in `plugins_host`.
+- `Session` APIs in `session` and FFI alignment with bindings.
+- `spawn_blocking` boundaries in parse/search-heavy paths.
+- `TimedLine` and chunk/progress types in `indexer_base`.
+- High-context boundaries:
+    - `session` -> `rs-bindings` -> `ts-bindings`
+    - `stypes` -> `protocol` -> `platform/types`
+    - `plugins_host` runtime contract alignment with `plugins/`
+
+## Generated Artifacts and Source of Truth
+
+- Shared Rust/TS messages:
+    - Source: `application/apps/indexer/stypes/src/`
+    - Generation: `application/apps/indexer/stypes/generate.sh`
+    - Output: `application/apps/indexer/stypes/bindings/`
+    - Consumer copy target: `application/platform/types/`
+
+## Development & Tech Stack
+
+- Target: `core`
+- Build: `cargo build`
+- Test: `cargo test`
+- Lint: `cargo clippy`
+- Async runtime: `tokio` (`spawn_blocking` for CPU-heavy work)
+- Errors: `anyhow` + `thiserror`
+- Safety: `undocumented_unsafe_blocks` denied
+
+## Testing
+
+- Snapshots: `insta` (set `CI=true` in CI runs)
+- Fuzz/property testing: `proptest`

--- a/application/apps/indexer/stypes/AGENTS.md
+++ b/application/apps/indexer/stypes/AGENTS.md
@@ -1,0 +1,49 @@
+# Shared Types (stypes) Context
+
+## Overview
+
+`stypes` is the source of truth for data structures shared between Rust core and TypeScript surfaces.
+
+## Start Here (First Files to Open)
+
+1. `application/apps/indexer/stypes/Cargo.toml`
+2. `application/apps/indexer/stypes/src/`
+3. `application/apps/indexer/stypes/generate.sh`
+4. `application/apps/indexer/stypes/bindings/`
+5. `application/apps/protocol/src/lib.rs`
+6. `application/apps/rustcore/ts-bindings/spec/session.protocol.spec.ts`
+7. `application/platform/types/`
+
+## If You Need X, Go to Y
+
+- Add or modify a shared type: `application/apps/indexer/stypes/src/`.
+- Control TS export shape: Rust derives/attributes (`TS`, `#[ts(export)]`) in `application/apps/indexer/stypes/src/`.
+- Regenerate TS bindings: `./generate.sh` in `stypes`.
+- Validate encode/decode compatibility: `application/apps/protocol` and `application/apps/rustcore/ts-bindings` protocol specs.
+- Update consumed TS contracts: `application/platform/types/`.
+
+## Cross-Module Dependency Map
+
+- Source of truth: `application/apps/indexer/stypes/src/`.
+- Consumed directly by Rust indexer crates.
+- Exported to TS via generated bindings and via `application/apps/protocol`.
+- Downstream consumers include `application/apps/rustcore/ts-bindings`, `application/holder`, `application/client`, and shared `application/platform/types`.
+
+## Landmarks and Hotspots
+
+- `TS` derivations and serde traits on core structs/enums.
+- `proptest` coverage for new types and serialization edges.
+- Type changes with optional/enum evolution are high-context because they affect protocol and frontend contracts.
+
+## Generated Artifacts and Source of Truth
+
+- Source: `application/apps/indexer/stypes/src/`
+- Generation: `application/apps/indexer/stypes/generate.sh`
+- Generated output: `application/apps/indexer/stypes/bindings/`
+- Consumer copy target: `application/platform/types/`
+
+## Tech Stack
+
+- `ts-rs` for TypeScript derivation.
+- `proptest` for property-based robustness.
+- `serde` for JSON/Bincode serialization.

--- a/application/apps/protocol/AGENTS.md
+++ b/application/apps/protocol/AGENTS.md
@@ -1,0 +1,44 @@
+# Protocol WASM Context
+
+## Overview
+
+`protocol` is the WASM encode/decode bridge around shared `stypes`, used by Node/Electron/TypeScript layers.
+
+## Start Here (First Files to Open)
+
+1. `application/apps/protocol/Cargo.toml`
+2. `application/apps/protocol/src/lib.rs`
+3. `application/apps/protocol/src/generate.rs`
+4. `application/apps/protocol/src/err.rs`
+5. `application/apps/protocol/test.sh`
+6. `application/apps/indexer/stypes/AGENTS.md`
+7. `application/apps/rustcore/ts-bindings/spec/session.protocol.spec.ts`
+
+## If You Need X, Go to Y
+
+- Expose a new shared message type: `application/apps/protocol/src/lib.rs` macro invocations.
+- Change encode/decode wrapper generation: `application/apps/protocol/src/generate.rs` (`gen_encode_decode_fns!`).
+- Investigate WASM boundary errors: `application/apps/protocol/src/err.rs` and caller expectations in `application/apps/rustcore/ts-bindings`.
+- Validate protocol compatibility: run `cargo chipmunk test protocol -u print` and inspect TS protocol specs.
+
+## Cross-Module Dependency Map
+
+- Upstream schema source: `application/apps/indexer/stypes`.
+- Protocol output consumed by `application/apps/rustcore/ts-bindings`.
+- Indirectly feeds `application/holder` and `application/client` through TS bindings.
+
+## Landmarks and Hotspots
+
+- `gen_encode_decode_fns!` macro wiring in `application/apps/protocol/src/lib.rs`.
+- `serde-wasm-bindgen` conversion boundaries.
+- Type additions are high-context because they require synchronized updates across `stypes`, protocol, and TS tests.
+
+## Quick Commands
+
+- Build: `cargo chipmunk build protocol -u print`
+- Test: `cargo chipmunk test protocol -u print`
+- Lint: `cargo chipmunk lint protocol -u print`
+
+## Additional Notes (Not Default Workflow)
+
+- `application/apps/protocol/test.sh` can run property-test-heavy paths and may take significantly longer than typical target tests.

--- a/application/apps/rustcore/rs-bindings/AGENTS.md
+++ b/application/apps/rustcore/rs-bindings/AGENTS.md
@@ -1,0 +1,41 @@
+# Rust Bindings (FFI) Context
+
+## Overview
+
+`rs-bindings` is the native Node addon boundary between Rust core (`application/apps/indexer/session`) and Node/Electron.
+
+## Start Here (First Files to Open)
+
+1. `application/apps/rustcore/rs-bindings/Cargo.toml`
+2. `application/apps/rustcore/rs-bindings/src/lib.rs`
+3. `application/apps/rustcore/rs-bindings/src/js/session/`
+4. `application/apps/rustcore/rs-bindings/src/js/jobs/`
+5. `application/apps/rustcore/rs-bindings/src/js/converting/`
+6. `application/apps/indexer/session/src/`
+7. `application/apps/rustcore/ts-bindings/src/`
+
+## If You Need X, Go to Y
+
+- Add or modify session-facing operation: `application/apps/rustcore/rs-bindings/src/js/session/` plus matching `application/apps/indexer/session` API.
+- Add static job without active session: `application/apps/rustcore/rs-bindings/src/js/jobs/` (`UnboundJobs` path).
+- Debug Node-side lifecycle or callback bridging: `RustSession` flow in `application/apps/rustcore/rs-bindings/src/js/session/`.
+- Investigate Rust type translation to JS payloads: conversion paths in `application/apps/rustcore/rs-bindings/src/js/converting/`.
+
+## Cross-Module Dependency Map
+
+- Upstream Rust API comes from `application/apps/indexer/session`.
+- Exposes native addon consumed by `application/apps/rustcore/ts-bindings`.
+- Downstream UI surfaces are `application/holder` and `application/client` through TS wrappers.
+
+## Landmarks and Hotspots
+
+- `RustSession` lifecycle methods.
+- `UnboundJobs` APIs.
+- Runtime/thread boundaries (Tokio runtime interaction with Node threads).
+- Memory allocator configuration (`tikv-jemallocator`/`mimalloc`) is high-context and global-impact.
+
+## Development
+
+- Target: `binding`
+- Build: `cargo chipmunk build binding -u print`
+- Lint: `cargo clippy`

--- a/application/apps/rustcore/ts-bindings/AGENTS.md
+++ b/application/apps/rustcore/ts-bindings/AGENTS.md
@@ -1,0 +1,45 @@
+# TypeScript Bindings Context
+
+## Overview
+
+`ts-bindings` is the high-level TypeScript API over the native Rust addon, used by Electron holder and Angular client.
+
+## Start Here (First Files to Open)
+
+1. `application/apps/rustcore/ts-bindings/src/api/`
+2. `application/apps/rustcore/ts-bindings/src/api/executors/`
+3. `application/apps/rustcore/ts-bindings/src/native/`
+4. `application/apps/rustcore/ts-bindings/src/services/`
+5. `application/apps/rustcore/ts-bindings/spec/`
+6. `application/apps/rustcore/rs-bindings/AGENTS.md`
+7. `application/apps/protocol/AGENTS.md`
+
+## If You Need X, Go to Y
+
+- Change session flow (`grab`, `search`, filters): `application/apps/rustcore/ts-bindings/src/api/` and related executors.
+- Add or modify static utility jobs: `application/apps/rustcore/ts-bindings/src/services/` and provider/native wrappers.
+- Adjust progress reporting behavior: `application/apps/rustcore/ts-bindings/src/api/` and `application/apps/rustcore/ts-bindings/src/services/` tracker-related flow.
+- Debug binary protocol translation issues: `application/apps/rustcore/ts-bindings/src/native/` and `application/apps/rustcore/ts-bindings/spec/session.protocol.spec.ts`.
+- Validate end-to-end behavior with native addon: `application/apps/rustcore/ts-bindings/spec/` tests using Electron runtime.
+
+## Cross-Module Dependency Map
+
+- Consumes native APIs from `rs-bindings`.
+- Consumes protocol encoders/decoders from `application/apps/protocol`.
+- Provides API used by `application/holder` and `application/client`.
+
+## Landmarks and Hotspots
+
+- `Session`, `SessionStream`, `SessionSearch` classes.
+- `CancelablePromise` usage in long-running operations.
+- Executor classes for operation-specific orchestration.
+- Protocol and addon version drift is a high-context boundary.
+
+## Development & Testing
+
+- Target: `wrapper`
+- Build: `cargo chipmunk build wrapper -u print`
+- Test: `cargo chipmunk test wrapper -u print`
+- Lint: `cargo chipmunk lint wrapper -u print`
+- Benchmarks: `application/apps/rustcore/ts-bindings/spec/_session.benchmark.spec.ts`
+- Test defaults: `application/apps/rustcore/ts-bindings/spec/defaults.json`

--- a/application/apps/rustcore/wasm-bindings/AGENTS.md
+++ b/application/apps/rustcore/wasm-bindings/AGENTS.md
@@ -1,0 +1,40 @@
+# WASM Bindings Context
+
+## Overview
+
+`wasm-bindings` provides browser-facing Rust WASM utilities for fuzzy matching, ANSI rendering, and filter validation.
+
+## Start Here (First Files to Open)
+
+1. `application/apps/rustcore/wasm-bindings/Cargo.toml`
+2. `application/apps/rustcore/wasm-bindings/src/lib.rs`
+3. `application/apps/rustcore/wasm-bindings/src/`
+4. `application/apps/rustcore/wasm-bindings/spec/`
+5. `application/apps/rustcore/wasm-bindings/pkg/`
+6. `application/apps/rustcore/wasm-bindings/package.json`
+7. `application/client/AGENTS.md`
+
+## If You Need X, Go to Y
+
+- Tune fuzzy matching output/scoring: matcher code in `application/apps/rustcore/wasm-bindings/src/`.
+- Change ANSI conversion or stripping behavior: ANSI conversion code in `application/apps/rustcore/wasm-bindings/src/`.
+- Update regex/filter validation messages: filter validation code in `application/apps/rustcore/wasm-bindings/src/`.
+- Validate browser compatibility regressions: WASM-facing specs in `application/apps/rustcore/wasm-bindings/spec/`.
+
+## Cross-Module Dependency Map
+
+- Built as a WASM package consumed by `application/client`.
+- Interacts with frontend behavior, not the Node native addon path.
+
+## Landmarks and Hotspots
+
+- `matcher` integration with `skim` scoring.
+- `ansi` HTML conversion rules and escaping.
+- `filter` regex validation and error messaging.
+- Browser runtime compatibility (Karma/ChromeHeadless) is the critical hotspot.
+
+## Quick Commands
+
+- Build: `cargo chipmunk build wasm -u print`
+- Test: `cargo chipmunk test wasm -u print`
+- Lint: `cargo chipmunk lint wasm -u print`

--- a/application/client/AGENTS.md
+++ b/application/client/AGENTS.md
@@ -1,0 +1,44 @@
+# Angular Client Context
+
+## Overview
+
+The Angular client is the primary UI for viewing logs, managing filters, and visualizing data.
+
+## Start Here (First Files to Open)
+
+1. `application/client/angular.json`
+2. `application/client/src/app/`
+3. `application/client/src/app/service/`
+4. `application/client/src/app/ui/`
+5. `application/client/src/app/ui/styles/`
+6. `application/platform/AGENTS.md`
+7. `application/apps/rustcore/ts-bindings/AGENTS.md`
+
+## If You Need X, Go to Y
+
+- Change screen-level behavior: UI features in `application/client/src/app/ui/`.
+- Change shared UI state or backend calls: `application/client/src/app/service/`.
+- Update app-wide styling rules: `application/client/src/app/ui/styles/` and component styles.
+- Trace backend data into UI: follow `ts-bindings` calls through services and component subscriptions.
+
+## Cross-Module Dependency Map
+
+- Consumes APIs through `application/apps/rustcore/ts-bindings`.
+- Exchanges contracts with Electron via `application/platform/ipc/` and shared `application/platform/types/`.
+- Runs inside Electron holder in desktop distribution.
+
+## Landmarks and Hotspots
+
+- Observable-based service/component interactions.
+- Filter/search and chart rendering flows are high-context UI surfaces.
+- IPC contract drift with `platform` or `holder` is a common integration hotspot.
+
+## Tech Stack & Conventions
+
+- Target: `client`
+- Build: `cargo chipmunk build client -u print`
+- Test: `cargo chipmunk test client -u print`
+- Lint: `cargo chipmunk lint client -u print`
+- Framework: Angular 19
+- Styling: Vanilla CSS (preferred)
+- Naming: `camelCase` for vars/functions, `PascalCase` for classes/interfaces

--- a/application/holder/AGENTS.md
+++ b/application/holder/AGENTS.md
@@ -1,0 +1,40 @@
+# Electron Holder Context
+
+## Overview
+
+`holder` is the Electron desktop host process. It owns lifecycle, windowing, and IPC bridging between UI and Rust-backed services.
+
+## Start Here (First Files to Open)
+
+1. `application/holder/package.json`
+2. `application/holder/src/controller/`
+3. `application/holder/src/service/bridge/`
+4. `application/holder/src/service/electron/`
+5. `application/platform/AGENTS.md`
+6. `application/apps/rustcore/ts-bindings/AGENTS.md`
+
+## If You Need X, Go to Y
+
+- Change startup/shutdown/update behavior: lifecycle/controller flow in `application/holder/src/controller/` and `application/holder/src/register/`.
+- Change IPC forwarding between client and backend: bridge/service flow in `application/holder/src/service/bridge/` plus `application/platform/ipc/` contracts.
+- Change native menus/dialog/window behavior: Electron integration code in `application/holder/src/service/electron/`.
+- Trace backend call flow: holder IPC handlers -> `application/apps/rustcore/ts-bindings` APIs -> Rust boundary.
+
+## Cross-Module Dependency Map
+
+- Consumes `application/apps/rustcore/ts-bindings` for Rust-backed operations.
+- Shares IPC contract/types with `application/platform`.
+- Hosts and serves Angular client runtime.
+
+## Landmarks and Hotspots
+
+- Electron lifecycle hooks.
+- IPC channel registration/forwarding.
+- Window state/menu/dialog integration.
+- IPC contract drift between holder/client/platform is the main hotspot.
+
+## Development
+
+- Target: `app`
+- Build: `cargo chipmunk build app -u print`
+- Lint: `cargo chipmunk lint app -u print`

--- a/application/platform/AGENTS.md
+++ b/application/platform/AGENTS.md
@@ -1,0 +1,41 @@
+# Shared Platform Context
+
+## Overview
+
+`platform` contains shared TypeScript contracts and utilities used by holder/client and bridge layers.
+
+## Start Here (First Files to Open)
+
+1. `application/platform/ipc/`
+2. `application/platform/types/`
+3. `application/platform/env/`
+4. `application/platform/log/`
+5. `application/client/AGENTS.md`
+6. `application/holder/AGENTS.md`
+
+## If You Need X, Go to Y
+
+- Change IPC message contracts: `application/platform/ipc/`.
+- Change shared domain interfaces/enums: `application/platform/types/`.
+- Change runtime environment detection/config: `application/platform/env/`.
+- Change shared frontend logging utilities: `application/platform/log/`.
+- Trace cross-app type issues: start in `application/platform/types/`, then check `application/apps/indexer/stypes` and protocol/bindings if data originates in Rust.
+
+## Cross-Module Dependency Map
+
+- Consumed by both `application/client` and `application/holder`.
+- Some `application/platform/types/` entries are generated downstream from `application/apps/indexer/stypes`.
+- IPC contracts here define holder <-> client communication boundaries.
+
+## Landmarks and Hotspots
+
+- IPC contract definitions and channel naming.
+- Shared type evolution affecting multiple targets.
+- Generated-vs-manual type changes in `application/platform/types/` are a high-context hotspot.
+
+## Development
+
+- Target: `shared`
+- Build: `cargo chipmunk build shared -u print`
+- Lint: `cargo chipmunk lint shared -u print`
+- Note: platform changes can affect multiple targets.

--- a/cli/chipmunk-cli/AGENTS.md
+++ b/cli/chipmunk-cli/AGENTS.md
@@ -1,0 +1,45 @@
+# Chipmunk CLI Context
+
+## Overview
+`chipmunk-cli` is the user-facing CLI for connecting sources, parsing logs, and exporting output.
+
+## Start Here (First Files to Open)
+
+1. `cli/chipmunk-cli/Cargo.toml`
+2. `cli/chipmunk-cli/src/main.rs`
+3. `cli/chipmunk-cli/src/cli_args/`
+4. `cli/chipmunk-cli/src/session/`
+5. `cli/chipmunk-cli/src/session/format/`
+6. `application/apps/indexer/AGENTS.md`
+
+## If You Need X, Go to Y
+
+- Change command syntax/options: `cli/chipmunk-cli/src/cli_args/`.
+- Change ingestion/parsing runtime behavior: `cli/chipmunk-cli/src/session/` and underlying indexer interactions.
+- Change output formatting: `cli/chipmunk-cli/src/session/format/`.
+- Debug parser/source compatibility from CLI path: trace CLI args -> session wiring -> indexer source/parser.
+
+## Cross-Module Dependency Map
+
+- CLI orchestrates indexer capabilities for terminal use.
+- Output format logic is local, while parsing/ingestion logic is rooted in core indexer crates.
+
+## Landmarks and Hotspots
+
+- Hierarchical `clap` command structure in `cli/chipmunk-cli/src/cli_args/`.
+- Session flow that wires parser/source/output.
+- Connection resilience behavior (reconnect/keepalive) in source-related paths.
+
+## Development
+
+- Target: `cli-chipmunk`
+- Build: `cargo build`
+- Test: `cargo test`
+- Lint: `cargo clippy`
+- Install: `cargo install --path cli/chipmunk-cli`
+
+## Usage Example
+
+```bash
+chipmunk-cli -o logs.dlt -f binary dlt -f file1.xml tcp 127.0.0.1:7777 -m 1000
+```

--- a/cli/development-cli/AGENTS.md
+++ b/cli/development-cli/AGENTS.md
@@ -1,0 +1,43 @@
+# Development CLI (`cargo chipmunk`) Context
+
+## Overview
+`development-cli` is the developer task orchestrator for build/test/lint/release workflows across this repo.
+
+## Start Here (First Files to Open)
+
+1. `cli/development-cli/Cargo.toml`
+2. `cli/development-cli/src/main.rs`
+3. `cli/development-cli/src/jobs_runner/`
+4. `cli/development-cli/src/target/`
+5. `cli/development-cli/src/dev_environment/`
+6. `cli/development-cli/src/release/`
+7. `cli/development-cli/src/benchmark/`
+
+## If You Need X, Go to Y
+
+- Change dependency resolution or job scheduling: `cli/development-cli/src/jobs_runner/`.
+- Change target definitions (build/test/lint commands): `cli/development-cli/src/target/`.
+- Change smart rebuild/cache behavior: checksum and job-state logic in `cli/development-cli/src/build_state_records.rs`, `cli/development-cli/src/jobs_runner/`, and `cli/development-cli/dir_checksum/`.
+- Change output modes/progress UI/logging behavior: output handling in `cli/development-cli/src/tracker.rs`, `cli/development-cli/src/jobs_runner/`, and target execution flow.
+- Change tool/version validation: `cli/development-cli/src/dev_environment/`.
+- Investigate command orchestration regressions: trace `cli/development-cli/src/main.rs` -> target resolution -> jobs runner -> command output.
+
+## Cross-Module Dependency Map
+
+- Drives tasks for all major targets (`core`, `client`, `app`, `shared`, `binding`, `wrapper`, CLI targets).
+- Encodes project-wide target dependency graph and execution policy.
+
+## Landmarks and Hotspots
+
+- Target graph and concurrency logic in `cli/development-cli/src/jobs_runner/`.
+- Incremental rebuild state handling (`.build_last_state`) in `cli/development-cli/src/build_state_records.rs`.
+- Output mode behavior (`bars`, `report`, `print`, `immediate`) in `cli/development-cli/src/tracker.rs`.
+
+## Development
+
+- Target: `cli-dev`
+- Build: `cargo build`
+- Test: `cargo test`
+- Lint: `cargo clippy`
+- Install: `cargo install --path cli/development-cli`
+- Integration tests: `python cli/development-cli/integration_tests/run_all.py`

--- a/plugins/AGENTS.md
+++ b/plugins/AGENTS.md
@@ -1,0 +1,47 @@
+# Plugins System Context
+
+## Overview
+The plugin system extends Chipmunk with sandboxed WASM parser and bytesource components.
+
+## Start Here (First Files to Open)
+
+1. `plugins/plugins_api/Cargo.toml` (core plugin API crate)
+2. `plugins/plugins_api/src/` (parser/bytesource traits, export macros, shared helpers)
+3. `plugins/plugins_api/wit/v0.1.0/` (WIT contracts and worlds)
+4. `plugins/examples/rust/` and `plugins/templates/rust/parser/` (reference and starter implementations)
+4. `application/apps/indexer/plugins_host/src/`
+5. `application/apps/indexer/AGENTS.md`
+
+## If You Need X, Go to Y
+
+- Implement a Rust parser plugin: crate based on `plugins/templates/rust/parser/` or `plugins/examples/rust/` using `plugins_api` + `parser_export!`.
+- Implement a Rust bytesource plugin: follow `plugins/examples/rust/file_source/` using `plugins_api` + `bytesource_export!`.
+- Implement C/C++ plugin bindings: generate headers from `plugins/plugins_api/wit/v0.1.0/` via `wit-bindgen`.
+- Debug load/runtime issues: plugin component artifacts plus host-side logic in `application/apps/indexer/plugins_host/`.
+- Verify install/discovery behavior: plugin output layout under `~/.chipmunk/plugins/...`.
+
+## Cross-Module Dependency Map
+
+- Contracts/components are authored in `plugins`.
+- Runtime loading/execution is handled by `application/apps/indexer/plugins_host` via `wasmtime`.
+- Plugin outputs feed indexer ingestion/parsing pipelines.
+
+## Landmarks and Hotspots
+
+- WIT interface definitions under `plugins/plugins_api/wit/v0.1.0/` and generated bindings.
+- Export macros: `parser_export!`, `bytesource_export!`.
+- WASM component model and WASI boundaries.
+- Memory ownership rules (incoming/outgoing buffers) are critical hotspots.
+
+## Technology Stack
+
+- Runtime: `wasmtime`
+- Interface: WIT
+- Model: WASM Component Model
+- Resource access: WASI
+
+## Build and Installation
+
+- Build (Rust component): `cargo component build -r`
+- Install parser plugin: `~/.chipmunk/plugins/parsers/<plugin_name>/`
+- Install bytesource plugin: `~/.chipmunk/plugins/bytesources/<plugin_name>/`


### PR DESCRIPTION
Add main context file in repo root mapping multiple localized context files across the repo components providing technical guidance for AI agents and developers.

I've chosen the generic `AGENTS.md` name to ensure it will work with most of coding agent tools and provides