### PR TITLE
Fix clippy warning + LSP false positive errors

### DIFF
--- a/application/apps/indexer/parsers/src/dlt/attachment.rs
+++ b/application/apps/indexer/parsers/src/dlt/attachment.rs
@@ -404,7 +404,7 @@ pub mod tests {
     fn ft_file(id: u32, ecu: &str, name: &str, payload: &[u8]) -> Vec<Message> {
         let size: usize = payload.len();
         let mut packets: usize = size / DLT_FT_CHUNK_SIZE;
-        if size % DLT_FT_CHUNK_SIZE != 0 {
+        if !size.is_multiple_of(DLT_FT_CHUNK_SIZE) {
             packets += 1;
         }
 

--- a/application/apps/indexer/plugins_host/benches/plugin_utls.rs
+++ b/application/apps/indexer/plugins_host/benches/plugin_utls.rs
@@ -5,12 +5,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use stypes::{PluginConfigItem, PluginConfigValue};
 
-// Note:
-// Rust LSP may mark this as an error, but this is an issue with the LSP itself.
-// The code will compile without problems.
-
-#[path = "./../../processor/benches/bench_utls.rs"]
-mod bench_utls;
+const CONFIG_ENV_VAR: &str = "CHIPMUNK_BENCH_CONFIG";
 
 /// Represents the needed configuration to run benchmarks on a plugin.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -28,7 +23,8 @@ pub struct PluginBenchConfig {
 /// This function expects to get the path for the plugin configurations `toml` file
 /// via bench configuration environment variable.
 pub fn get_plugin_config() -> PluginBenchConfig {
-    let config_path = bench_utls::get_config()
+    let config_path = std::env::var(CONFIG_ENV_VAR)
+        .ok()
         .map(PathBuf::from)
         .expect("Path to plugin config must be provided as additional config");
     assert!(config_path.exists(), "Config files doesn't exist");

--- a/application/apps/indexer/processor/src/producer/tests/mock_parser.rs
+++ b/application/apps/indexer/processor/src/producer/tests/mock_parser.rs
@@ -100,7 +100,7 @@ fn test_mock_parser() {
 
     let parse_result_ok_none = parser.parse(b"ab", None).unwrap().next().unwrap();
     assert_eq!(parse_result_ok_none.consumed, 1);
-    assert!(matches!(parse_result_ok_none.message, None));
+    assert!(parse_result_ok_none.message.is_none());
 
     let parse_result_ok_val = parser.parse(b"ab", None).unwrap().next().unwrap();
     assert_eq!(parse_result_ok_val.consumed, 2);

--- a/application/apps/indexer/session/src/handlers/search.rs
+++ b/application/apps/indexer/session/src/handlers/search.rs
@@ -27,6 +27,9 @@ type SearchResultChannel = (
     Receiver<(RegularSearchHolder, searchers::regular::SearchResults)>,
 );
 
+type SearchOutputResult =
+    Result<SearchOutput, (Option<Box<RegularSearchHolder>>, stypes::NativeError)>;
+
 #[derive(Debug)]
 struct SearchOutput {
     matches: Vec<stypes::FilterMatch>,
@@ -74,9 +77,7 @@ pub async fn execute_search(
                 && tx_result.send((holder, search_results)).await.is_ok()
             {}
         });
-        let search_results: Option<
-            Result<SearchOutput, (Option<RegularSearchHolder>, stypes::NativeError)>,
-        > = select! {
+        let search_results: Option<SearchOutputResult> = select! {
             res = async {
                 loop {
                     match timeout(
@@ -95,7 +96,7 @@ pub async fn execute_search(
                                 |(holder, search_results)| {
                                     match search_results {
                                         Ok((_processed, matches, stats)) => Ok(SearchOutput {matches, stats, holder}),
-                                        Err(err) => Err((Some(holder), stypes::NativeError {
+                                        Err(err) => Err((Some(Box::new(holder)), stypes::NativeError {
                                             severity: stypes::Severity::ERROR,
                                             kind: stypes::NativeErrorKind::OperationSearch,
                                             message: Some(format!(
@@ -139,7 +140,7 @@ pub async fn execute_search(
                 Err((holder, err)) => {
                     if let Some(holder) = holder {
                         state
-                            .set_search_holder(Some(holder), operation_api.id())
+                            .set_search_holder(Some(*holder), operation_api.id())
                             .await?;
                     } else {
                         state.set_search_holder(None, operation_api.id()).await?;

--- a/application/apps/indexer/session/src/handlers/search_values.rs
+++ b/application/apps/indexer/session/src/handlers/search_values.rs
@@ -26,7 +26,7 @@ type SearchResultChannel = (
 );
 
 type ValueSearchResult =
-    Result<ValueSearchResults, (Option<ValueSearchHolder>, stypes::NativeError)>;
+    Result<ValueSearchResults, (Option<Box<ValueSearchHolder>>, stypes::NativeError)>;
 
 struct ValueSearchResults {
     values: HashMap<u8, Vec<ValueSearchMatch>>,
@@ -91,7 +91,7 @@ pub async fn execute_value_search(
                                 |(holder, search_results)| {
                                     match search_results {
                                         Ok(ValueSearchOutput{values, ..}) => Ok(ValueSearchResults {values, holder}),
-                                        Err(err) => Err((Some(holder), stypes::NativeError {
+                                        Err(err) => Err((Some(Box::new(holder)), stypes::NativeError {
                                             severity: stypes::Severity::ERROR,
                                             kind: stypes::NativeErrorKind::OperationSearch,
                                             message: Some(format!(
@@ -127,7 +127,7 @@ pub async fn execute_value_search(
                 Err((holder, err)) => {
                     if let Some(holder) = holder {
                         state
-                            .set_search_values_holder(Some(holder), operation_api.id())
+                            .set_search_values_holder(Some(*holder), operation_api.id())
                             .await?;
                     } else {
                         state


### PR DESCRIPTION
* Fix clippy warning with the new rust version.
* Avoid LSP false positives errors in plugins benchmark utls by duplicating small amount of code.