### PR TITLE
Native: Inline highlighting for search matches

### DIFF
--- a/application/apps/indexer/gui/application/Cargo.toml
+++ b/application/apps/indexer/gui/application/Cargo.toml
@@ -40,6 +40,7 @@ dirs.workspace = true
 serialport.workspace = true
 dlt-core.workspace = true
 rustc-hash.workspace = true
+regex.workspace = true
 regex-syntax.workspace = true
 
 #TODO: Replace env logger with log4rs

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_table.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_table.rs
@@ -1,6 +1,6 @@
 use std::{ops::Range, rc::Rc, sync::mpsc::Receiver as StdReceiver};
 
-use egui::{Label, Sense, Ui, Widget};
+use egui::{Sense, Ui};
 use egui_table::{CellInfo, Column, PrefetchInfo, TableDelegate};
 use stypes::{GrabbedElement, NearestPosition};
 use tokio::sync::mpsc::Sender;
@@ -216,7 +216,18 @@ impl<'a> LogsDelegate<'a> {
                 .and_then(|rng| log_item.element.content.get(rng.to_owned()))
                 .unwrap_or_default();
 
-            if Label::new(content).ui(ui).clicked() {
+            let response = match common::logs_tables::highlighted_cell_layout_job(
+                ui,
+                content,
+                log_item.element.pos as u64,
+                self.shared,
+                self.shared.search.compiled_filters(),
+            ) {
+                Some(job) => ui.label(job),
+                None => ui.label(content),
+            };
+
+            if response.clicked() {
                 let is_selected = self.is_row_selected(Some(log_item));
                 self.toggle_row_selected(log_item.element.pos as u64, is_selected);
             }

--- a/application/apps/indexer/gui/application/src/session/ui/common/logs_tables.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/common/logs_tables.rs
@@ -1,8 +1,13 @@
 //! Provides shared helper functions and utilities to be used
 //! with logs tables (both logs and search tables).
 
-use egui::{Align, Color32, CursorIcon, Frame, Layout, Margin, Sense, Shape, Stroke, Ui, vec2};
+use std::ops::{Not, Range};
+
+use egui::{
+    Align, Color32, CursorIcon, Frame, Layout, Margin, Sense, Shape, Stroke, TextStyle, Ui, vec2,
+};
 use egui_table::Column;
+use regex::Regex;
 use uuid::Uuid;
 
 use crate::{
@@ -15,7 +20,10 @@ use crate::{
         error::SessionError,
         ui::{
             definitions::schema::LogSchema,
-            shared::{ObserveState, SessionShared, searching::LogMainIndex},
+            shared::{
+                ObserveState, SessionShared,
+                searching::{FilterIndex, LogMainIndex},
+            },
         },
     },
 };
@@ -31,6 +39,11 @@ pub mod grab_cmd_consts {
 
 pub const ROW_HEADER_SOURCE_COLOR_WIDTH: f32 = 5.0;
 pub const ROW_HEADER_BOOKMARK_WIDTH: f32 = 8.0;
+
+// This overlay is only painted for rows the backend already marked as matched,
+// so it sits on top of the row-level match tint instead of the plain table background.
+// A single translucent white highlight stays visible in both themes on that base.
+const FILTER_MATCH_HIGHLIGHT_BG: Color32 = Color32::from_rgba_unmultiplied_const(255, 255, 255, 60);
 
 /// Creates the columns for logs table based on the provided `schema`,
 /// inserting the row header column into them.
@@ -133,6 +146,123 @@ pub fn get_cell_frame() -> Frame {
     Frame::NONE.inner_margin(Margin::symmetric(4, 0))
 }
 
+/// Returns the backend-reported filter indices for one main-log position, if that row matched.
+fn matched_filter_indices(shared: &SessionShared, main_log_pos: u64) -> Option<&[FilterIndex]> {
+    shared
+        .search
+        .current_matches_map()
+        .and_then(|map| map.get(&LogMainIndex(main_log_pos)))
+        .map(Vec::as_slice)
+}
+
+/// Finds all cell-local matches for the row's matched filters and merges overlap into one pass.
+fn cell_match_spans(
+    content: &str,
+    matched_filters: &[FilterIndex],
+    compiled_filters: &[Regex],
+) -> Vec<Range<usize>> {
+    let spans: Vec<Range<usize>> = matched_filters
+        .iter()
+        .filter_map(|idx| compiled_filters.get(idx.0 as usize))
+        .flat_map(|filter| filter.find_iter(content))
+        .filter_map(|mat| (mat.start() < mat.end()).then_some(mat.range()))
+        .collect();
+
+    merge_match_spans(spans)
+}
+
+/// Resolves the merged highlight spans for one visible cell using the original main-log position.
+fn matched_cell_spans(
+    content: &str,
+    main_log_pos: u64,
+    shared: &SessionShared,
+    compiled_filters: &[Regex],
+) -> Vec<Range<usize>> {
+    matched_filter_indices(shared, main_log_pos)
+        .map(|matched_filters| cell_match_spans(content, matched_filters, compiled_filters))
+        .unwrap_or_default()
+}
+
+/// Coalesces overlapping or adjacent spans so the final paint pass uses minimal segments.
+fn merge_match_spans(mut spans: Vec<Range<usize>>) -> Vec<Range<usize>> {
+    if spans.len() <= 1 {
+        return spans;
+    }
+
+    spans.sort_unstable_by_key(|range| (range.start, range.end));
+
+    let mut merged: Vec<Range<usize>> = Vec::with_capacity(spans.len());
+
+    for span in spans {
+        if let Some(last) = merged.last_mut()
+            && span.start <= last.end
+        {
+            last.end = last.end.max(span.end);
+        } else {
+            merged.push(span);
+        }
+    }
+
+    merged
+}
+
+/// Builds highlighted text only when this cell's main-log position has concrete matches to paint.
+pub fn highlighted_cell_layout_job(
+    ui: &Ui,
+    content: &str,
+    main_log_pos: u64,
+    shared: &SessionShared,
+    compiled_filters: &[Regex],
+) -> Option<egui::text::LayoutJob> {
+    let spans = matched_cell_spans(content, main_log_pos, shared, compiled_filters);
+
+    spans
+        .is_empty()
+        .not()
+        .then(|| build_highlighted_layout_job(ui, content, &spans))
+}
+
+/// Preserves the row-selected text color and adds only background highlight on matched spans.
+fn build_highlighted_layout_job(
+    ui: &Ui,
+    content: &str,
+    spans: &[Range<usize>],
+) -> egui::text::LayoutJob {
+    let mut job = egui::text::LayoutJob::default();
+    let base_format = egui::text::TextFormat {
+        font_id: TextStyle::Body.resolve(ui.style()),
+        color: ui
+            .style()
+            .visuals
+            .override_text_color
+            .unwrap_or_else(|| ui.visuals().text_color()),
+        ..Default::default()
+    };
+    let highlight_format = egui::text::TextFormat {
+        background: FILTER_MATCH_HIGHLIGHT_BG,
+        ..base_format.clone()
+    };
+
+    let mut cursor = 0;
+    for span in spans {
+        if cursor < span.start {
+            job.append(&content[cursor..span.start], 0.0, base_format.clone());
+        }
+        job.append(
+            &content[span.start..span.end],
+            0.0,
+            highlight_format.clone(),
+        );
+        cursor = span.end;
+    }
+
+    if cursor < content.len() {
+        job.append(&content[cursor..], 0.0, base_format);
+    }
+
+    job
+}
+
 /// Apply row background and foreground colors for logs/search tables.
 pub fn apply_log_row_colors(
     ui: &mut Ui,
@@ -187,4 +317,184 @@ pub fn handle_grab_errors(error: SessionError, session_id: Uuid, actions: &mut U
     let notifi = AppNotification::SessionError { session_id, error };
 
     actions.add_notification(notifi);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use processor::search::filter::{self, SearchFilter};
+    use regex::Regex;
+    use stypes::{FileFormat, FilterMatch, ObserveOrigin};
+    use uuid::Uuid;
+
+    use crate::{
+        host::{
+            common::parsers::ParserNames,
+            ui::registry::filters::{FilterDefinition, FilterRegistry},
+        },
+        session::{
+            types::ObserveOperation,
+            ui::shared::{SessionInfo, SessionShared},
+        },
+    };
+
+    use super::{FilterIndex, cell_match_spans, matched_cell_spans, matched_filter_indices};
+
+    fn new_shared() -> SessionShared {
+        let session_id = Uuid::new_v4();
+        let origin = ObserveOrigin::File(
+            "source".to_owned(),
+            FileFormat::Text,
+            PathBuf::from("source.log"),
+        );
+        let observe_op = ObserveOperation::new(Uuid::new_v4(), origin);
+        let session_info = SessionInfo {
+            id: session_id,
+            title: "test".to_owned(),
+            parser: ParserNames::Text,
+        };
+
+        SessionShared::new(session_info, observe_op)
+    }
+
+    fn apply_filter(
+        shared: &mut SessionShared,
+        registry: &mut FilterRegistry,
+        filter: SearchFilter,
+    ) -> Uuid {
+        let filter_def = FilterDefinition::new(filter);
+        let filter_id = filter_def.id;
+        registry.add_filter(filter_def);
+        shared.filters.apply_filter(registry, filter_id);
+        filter_id
+    }
+
+    fn append_row_match(shared: &mut SessionShared, row_nr: u64, filters: Vec<u8>) {
+        shared.search.set_search_operation(Uuid::new_v4());
+        shared.search.append_matches(vec![FilterMatch {
+            index: row_nr,
+            filters,
+        }]);
+    }
+
+    fn compile_regexes(filters: impl IntoIterator<Item = SearchFilter>) -> Vec<Regex> {
+        filters
+            .into_iter()
+            .map(|filter| Regex::new(&filter::as_regex(&filter)).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn plain_text_filter_highlights_literal() {
+        let compiled = compile_regexes([SearchFilter::plain("cpu=(1.0)")]);
+
+        let spans = cell_match_spans("cpu=(1.0) status", &[FilterIndex(0)], &compiled);
+
+        assert_eq!(spans, vec![0..9]);
+    }
+
+    #[test]
+    fn regex_filter_highlights_match() {
+        let compiled = compile_regexes([SearchFilter::plain("cpu=\\d+").regex(true)]);
+
+        let spans = cell_match_spans("cpu=42 status", &[FilterIndex(0)], &compiled);
+
+        assert_eq!(spans, vec![0..6]);
+    }
+
+    #[test]
+    fn ignore_case_matches_mixed_case() {
+        let compiled = compile_regexes([SearchFilter::plain("warning").ignore_case(true)]);
+
+        let spans = cell_match_spans("pre WARNING post", &[FilterIndex(0)], &compiled);
+
+        assert_eq!(spans, vec![4..11]);
+    }
+
+    #[test]
+    fn word_boundary_skips_embedded_text() {
+        let compiled = compile_regexes([SearchFilter::plain("warn").word(true)]);
+
+        let spans = cell_match_spans("prewarn warn warned", &[FilterIndex(0)], &compiled);
+
+        assert_eq!(spans, vec![8..12]);
+    }
+
+    #[test]
+    fn all_matches_in_cell() {
+        let compiled = compile_regexes([SearchFilter::plain("err")]);
+
+        let spans = cell_match_spans("err and err", &[FilterIndex(0)], &compiled);
+
+        assert_eq!(spans, vec![0..3, 8..11]);
+    }
+
+    #[test]
+    fn overlapping_matches_are_merged() {
+        let compiled = compile_regexes([SearchFilter::plain("foo"), SearchFilter::plain("oob")]);
+
+        let spans = cell_match_spans("foobar", &[FilterIndex(0), FilterIndex(1)], &compiled);
+
+        assert_eq!(spans, vec![0..4]);
+    }
+
+    #[test]
+    fn stale_filter_index_is_ignored() {
+        let compiled = compile_regexes([SearchFilter::plain("warn")]);
+
+        let spans = cell_match_spans("warn", &[FilterIndex(1)], &compiled);
+
+        assert!(spans.is_empty());
+    }
+
+    #[test]
+    fn bookmarked_row_has_no_cell_highlight() {
+        let mut shared = new_shared();
+        shared.logs.insert_bookmark(7);
+        let compiled = compile_regexes([SearchFilter::plain("warn")]);
+
+        assert!(matched_filter_indices(&shared, 7).is_none());
+        assert!(matched_cell_spans("warn", 7, &shared, &compiled).is_empty());
+    }
+
+    #[test]
+    fn indexed_row_uses_main_log_pos() {
+        let mut shared = new_shared();
+        let compiled = compile_regexes([SearchFilter::plain("warn")]);
+
+        append_row_match(&mut shared, 42, vec![0]);
+
+        let spans = matched_cell_spans("warn row", 42, &shared, &compiled);
+
+        assert_eq!(spans, vec![0..4]);
+        assert!(matched_cell_spans("warn row", 3, &shared, &compiled).is_empty());
+    }
+
+    #[test]
+    fn active_filters_follow_backend_order() {
+        let mut shared = new_shared();
+        let mut registry = FilterRegistry::default();
+
+        let first_id = apply_filter(&mut shared, &mut registry, SearchFilter::plain("first"));
+        let second_id = apply_filter(&mut shared, &mut registry, SearchFilter::plain("second"));
+        shared
+            .filters
+            .set_temp_search(SearchFilter::plain("temp").ignore_case(true));
+        let filters = shared.search.get_active_filters(&shared.filters, &registry);
+        shared.search.refresh_compiled_filters(&filters);
+
+        append_row_match(&mut shared, 12, vec![0, 2]);
+
+        let spans = matched_cell_spans(
+            "first temp second",
+            12,
+            &shared,
+            shared.search.compiled_filters(),
+        );
+
+        assert_eq!(shared.filters.filter_entries[0].id, first_id);
+        assert_eq!(shared.filters.filter_entries[1].id, second_id);
+        assert_eq!(spans, vec![0..5, 6..10]);
+    }
 }

--- a/application/apps/indexer/gui/application/src/session/ui/logs_table/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/logs_table/mod.rs
@@ -208,7 +208,18 @@ impl<'a> LogsDelegate<'a> {
                 }
             };
 
-            if ui.label(content).clicked() {
+            let response = match common::logs_tables::highlighted_cell_layout_job(
+                ui,
+                content,
+                row_nr,
+                self.shared,
+                self.shared.search.compiled_filters(),
+            ) {
+                Some(job) => ui.label(job),
+                None => ui.label(content),
+            };
+
+            if response.clicked() {
                 let is_selected = self.is_row_selected(row_nr);
                 self.toggle_row_selected(row_nr, is_selected);
             }

--- a/application/apps/indexer/gui/application/src/session/ui/shared/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/shared/mod.rs
@@ -151,6 +151,7 @@ impl SessionShared {
         let filters = self.search.get_active_filters(&self.filters, registry);
         if filters.is_empty() {
             let operation_id = self.search.processing_search_operation();
+            self.search.clear_compiled_filters();
             self.drop_search();
             vec![SessionCommand::DropSearch { operation_id }]
         } else {
@@ -161,6 +162,7 @@ impl SessionShared {
                 });
             }
             self.drop_search();
+            self.search.refresh_compiled_filters(&filters);
             let operation_id = Uuid::new_v4();
             self.search.set_search_operation(operation_id);
             commands.push(SessionCommand::ApplySearchFilter {
@@ -248,6 +250,18 @@ mod tests {
         shared.filters.apply_filter(registry, filter_id);
     }
 
+    fn add_filter_def(
+        shared: &mut SessionShared,
+        registry: &mut FilterRegistry,
+        filter: SearchFilter,
+    ) -> Uuid {
+        let filter_def = FilterDefinition::new(filter);
+        let filter_id = filter_def.id;
+        registry.add_filter(filter_def);
+        shared.filters.apply_filter(registry, filter_id);
+        filter_id
+    }
+
     fn add_value(shared: &mut SessionShared, registry: &mut FilterRegistry, value: &str) {
         let value_def =
             SearchValueDefinition::new(SearchFilter::plain(value).regex(true).ignore_case(true));
@@ -275,7 +289,13 @@ mod tests {
     #[test]
     fn filter_sync_drops_search() {
         let mut shared = new_shared();
-        let registry = FilterRegistry::default();
+        let mut registry = FilterRegistry::default();
+        add_filter(&mut shared, &mut registry, "status=ok");
+        let _ = shared.sync_search_pipelines(&registry, SearchSyncTarget::Filter);
+        assert_eq!(shared.search.compiled_filters().len(), 1);
+        shared.filters.clear_temp_search();
+        let filter_id = shared.filters.filter_entries[0].id;
+        shared.filters.unapply_filter(&mut registry, &filter_id);
         let previous_operation_id = Uuid::new_v4();
         // An empty filter set should only tear down the active search operation.
         shared.search.set_search_operation(previous_operation_id);
@@ -289,6 +309,7 @@ mod tests {
             }
             other => panic!("expected DropSearch command, got {other:?}"),
         }
+        assert!(shared.search.compiled_filters().is_empty());
         assert!(shared.search.processing_search_operation().is_none());
     }
 
@@ -324,6 +345,8 @@ mod tests {
             other => panic!("expected second command ApplySearchFilter, got {other:?}"),
         };
 
+        assert_eq!(shared.search.compiled_filters().len(), 1);
+        assert!(shared.search.compiled_filters()[0].is_match("status=ok"));
         assert_eq!(
             shared.search.processing_search_operation(),
             Some(applied_operation_id)
@@ -348,6 +371,87 @@ mod tests {
             }
             other => panic!("expected ApplySearchFilter, got {other:?}"),
         }
+        assert_eq!(shared.search.compiled_filters().len(), 1);
+        assert!(shared.search.compiled_filters()[0].is_match("TEMP"));
+    }
+
+    #[test]
+    fn filter_sync_cache_matches_apply_payload() {
+        let mut shared = new_shared();
+        let mut registry = FilterRegistry::default();
+        add_filter_def(&mut shared, &mut registry, SearchFilter::plain("status=ok"));
+        add_filter_def(
+            &mut shared,
+            &mut registry,
+            SearchFilter::plain("cpu=\\d+").regex(true).word(true),
+        );
+        add_filter_def(
+            &mut shared,
+            &mut registry,
+            SearchFilter::plain("warning").ignore_case(true),
+        );
+        shared
+            .filters
+            .set_temp_search(SearchFilter::plain("temp").ignore_case(true));
+
+        let commands = shared.sync_search_pipelines(&registry, SearchSyncTarget::Filter);
+
+        let payload_filters = match &commands[0] {
+            SessionCommand::ApplySearchFilter { filters, .. } => filters,
+            other => panic!("expected ApplySearchFilter, got {other:?}"),
+        };
+
+        let compiled = shared.search.compiled_filters();
+        assert_eq!(compiled.len(), payload_filters.len());
+        assert_eq!(payload_filters.len(), 4);
+
+        assert!(compiled[0].is_match("status=ok"));
+        assert!(!compiled[0].is_match("STATUS=OK"));
+
+        assert!(compiled[1].is_match("cpu=42"));
+        assert!(!compiled[1].is_match("cpu=42x"));
+
+        assert!(compiled[2].is_match("WARNING"));
+        assert!(!compiled[2].is_match("WARN"));
+
+        assert!(compiled[3].is_match("TEMP"));
+        assert!(!compiled[3].is_match("TEAM"));
+    }
+
+    #[test]
+    fn filter_sync_cache_updates_after_edit() {
+        let mut shared = new_shared();
+        let mut registry = FilterRegistry::default();
+        let filter_id =
+            add_filter_def(&mut shared, &mut registry, SearchFilter::plain("status=ok"));
+
+        let initial_commands = shared.sync_search_pipelines(&registry, SearchSyncTarget::Filter);
+        assert!(matches!(
+            initial_commands[0],
+            SessionCommand::ApplySearchFilter { .. }
+        ));
+        assert_eq!(shared.search.compiled_filters().len(), 1);
+        assert!(shared.search.compiled_filters()[0].is_match("status=ok"));
+        assert!(!shared.search.compiled_filters()[0].is_match("level=warn"));
+
+        let next_filter = SearchFilter::plain("level=warn");
+        let outcome = registry.edit_filter_for_session(filter_id, shared.get_id(), next_filter);
+        assert!(matches!(
+            outcome,
+            crate::host::ui::registry::filters::RegistryEditOutcome::EditedInPlace
+        ));
+
+        let updated_commands = shared.sync_search_pipelines(&registry, SearchSyncTarget::Filter);
+        let payload_filters = match &updated_commands[1] {
+            SessionCommand::ApplySearchFilter { filters, .. } => filters,
+            other => panic!("expected ApplySearchFilter, got {other:?}"),
+        };
+
+        assert_eq!(payload_filters.len(), 1);
+        assert_eq!(payload_filters[0].value, "level=warn");
+        assert_eq!(shared.search.compiled_filters().len(), 1);
+        assert!(shared.search.compiled_filters()[0].is_match("level=warn"));
+        assert!(!shared.search.compiled_filters()[0].is_match("status=ok"));
     }
 
     #[test]
@@ -412,6 +516,8 @@ mod tests {
         let mut registry = FilterRegistry::default();
         add_filter(&mut shared, &mut registry, "status=ok");
         let filter_id = shared.filters.filter_entries[0].id;
+        let _ = shared.sync_search_pipelines(&registry, SearchSyncTarget::Filter);
+        assert_eq!(shared.search.compiled_filters().len(), 1);
         // Disabled filters stay in session state but should not reach backend sync.
         assert!(shared.filters.set_filter_enabled(&filter_id, false));
 
@@ -419,6 +525,7 @@ mod tests {
 
         assert_eq!(commands.len(), 1);
         assert!(matches!(commands[0], SessionCommand::DropSearch { .. }));
+        assert!(shared.search.compiled_filters().is_empty());
     }
 
     #[test]

--- a/application/apps/indexer/gui/application/src/session/ui/shared/searching/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/shared/searching/mod.rs
@@ -10,5 +10,5 @@ mod search;
 mod search_values;
 
 pub use filters::FiltersState;
-pub use search::{LogMainIndex, SearchState};
+pub use search::{FilterIndex, LogMainIndex, SearchState};
 pub use search_values::SearchValuesState;

--- a/application/apps/indexer/gui/application/src/session/ui/shared/searching/search.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/shared/searching/search.rs
@@ -5,8 +5,9 @@
 //! It is specific to log searching; chart value extraction is tracked separately in
 //! [`SearchValuesState`](super::SearchValuesState).
 
+use processor::search::filter::{self, SearchFilter};
+use regex::Regex;
 use rustc_hash::FxHashMap;
-
 use stypes::FilterMatch;
 use uuid::Uuid;
 
@@ -68,9 +69,18 @@ impl SearchCounts {
 
 #[derive(Debug)]
 pub struct SearchState {
+    /// Active backend operation for the current log search, if one is in flight or retained.
     search_op: Option<SearchOperation>,
+    /// Backend-owned row counts for the active log search projection.
     counts: SearchCounts,
+    /// Row-level backend match metadata keyed by original main-log position.
     matches_map: Option<FxHashMap<LogMainIndex, Vec<FilterIndex>>>,
+    /// Compiled regex matchers for the current effective log-search filters.
+    ///
+    /// # Note:
+    ///
+    /// Must stay in the same backend filter index order as `ApplySearchFilter.filters`.
+    compiled_filters: Vec<Regex>,
 }
 
 impl SearchState {
@@ -79,6 +89,7 @@ impl SearchState {
             search_op: None,
             counts: SearchCounts::default(),
             matches_map: None,
+            compiled_filters: Vec::new(),
         }
     }
 
@@ -91,6 +102,7 @@ impl SearchState {
             search_op,
             counts,
             matches_map,
+            compiled_filters: _,
         } = self;
 
         counts.reset_search_counts();
@@ -102,7 +114,7 @@ impl SearchState {
         &self,
         filters_state: &FiltersState,
         registry: &FilterRegistry,
-    ) -> Vec<processor::search::filter::SearchFilter> {
+    ) -> Vec<SearchFilter> {
         let mut filters: Vec<_> = filters_state
             .enabled_filter_ids()
             .filter_map(|uuid| registry.get_filter(uuid))
@@ -114,6 +126,24 @@ impl SearchState {
         }
 
         filters
+    }
+
+    /// Rebuilds cached regex matchers from the current effective search filters.
+    pub fn refresh_compiled_filters(&mut self, filters: &[SearchFilter]) {
+        self.compiled_filters = filters
+            .iter()
+            .filter_map(|filter| Regex::new(&filter::as_regex(filter)).ok())
+            .collect();
+    }
+
+    /// Clears cached regex matchers when no effective search filters remain.
+    pub fn clear_compiled_filters(&mut self) {
+        self.compiled_filters.clear();
+    }
+
+    /// Returns compiled regex matchers in backend filter index order.
+    pub fn compiled_filters(&self) -> &[Regex] {
+        &self.compiled_filters
     }
 
     /// Returns the current backend search match count.
@@ -205,6 +235,7 @@ impl SearchState {
             search_op: _,
             counts,
             matches_map,
+            compiled_filters: _,
         } = self;
 
         counts.reset_search_counts();
@@ -219,6 +250,7 @@ impl SearchState {
 
 #[cfg(test)]
 mod tests {
+    use processor::search::filter::SearchFilter;
     use uuid::Uuid;
 
     use crate::session::{types::OperationPhase, ui::definitions::UpdateOperationOutcome};
@@ -230,6 +262,13 @@ mod tests {
             index: 42,
             filters: vec![1, 3],
         }
+    }
+
+    fn sample_filters() -> Vec<SearchFilter> {
+        vec![
+            SearchFilter::plain("status=ok"),
+            SearchFilter::plain("warning").ignore_case(true),
+        ]
     }
 
     #[test]
@@ -320,5 +359,28 @@ mod tests {
             state.search_operation_phase(),
             Some(OperationPhase::Initializing)
         );
+    }
+
+    #[test]
+    fn refresh_compiled_filters_follows_order() {
+        let mut state = SearchState::new(Uuid::new_v4());
+
+        state.refresh_compiled_filters(&sample_filters());
+
+        let compiled = state.compiled_filters();
+        assert_eq!(compiled.len(), 2);
+        assert!(compiled[0].is_match("status=ok"));
+        assert!(!compiled[0].is_match("STATUS=OK"));
+        assert!(compiled[1].is_match("WARNING"));
+    }
+
+    #[test]
+    fn clear_compiled_filters_empties_cache() {
+        let mut state = SearchState::new(Uuid::new_v4());
+        state.refresh_compiled_filters(&sample_filters());
+
+        state.clear_compiled_filters();
+
+        assert!(state.compiled_filters().is_empty());
     }
 }


### PR DESCRIPTION
This PR adds inline highlighting for matches inside logs in both tables porting the same feature from the electron to the native UI 