### PR TITLE
Native: Add Filter Library & Presets

### DIFF
--- a/application/apps/indexer/gui/application/src/host/ui/registry/filters.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/registry/filters.rs
@@ -1,8 +1,27 @@
-use crate::common::validation::ValidationEligibility;
-use crate::common::validation::{validate_filter_regex_enable, validate_search_value_filter};
-use processor::search::filter::SearchFilter;
 use rustc_hash::{FxHashMap, FxHashSet};
 use uuid::Uuid;
+
+use processor::search::filter::SearchFilter;
+
+use crate::common::validation::{
+    ValidationEligibility, validate_filter_regex_enable, validate_search_value_filter,
+};
+
+/// Global registry of filters and search values shared across all sessions.
+/// It tracks which filters are assigned to which sessions.
+#[derive(Debug, Default, Clone)]
+pub struct FilterRegistry {
+    filters: FxHashMap<Uuid, FilterDefinition>,
+    search_values: FxHashMap<Uuid, SearchValueDefinition>,
+    /// Monotonic change counter for filter definition catalog mutations.
+    filter_definitions_revision: u64,
+    /// Monotonic change counter for search-value definition catalog mutations.
+    search_value_definitions_revision: u64,
+    /// Mapping: FilterId -> Set of SessionIds
+    filter_usage: FxHashMap<Uuid, FxHashSet<Uuid>>,
+    /// Mapping: SearchValueId -> Set of SessionIds
+    value_usage: FxHashMap<Uuid, FxHashSet<Uuid>>,
+}
 
 /// Represents a filter definition in the global registry.
 #[derive(Debug, Clone)]
@@ -15,48 +34,11 @@ pub struct FilterDefinition {
     pub regex_enable_eligibility: ValidationEligibility,
 }
 
-impl FilterDefinition {
-    /// Creates a registry-owned filter definition and caches whether it can
-    /// later be converted into a search value.
-    pub fn new(filter: SearchFilter) -> Self {
-        let search_value_eligibility = validate_search_value_filter(&filter);
-        let regex_enable_eligibility = validate_filter_regex_enable(&filter);
-        Self {
-            id: Uuid::new_v4(),
-            filter,
-            search_value_eligibility,
-            regex_enable_eligibility,
-        }
-    }
-}
-
 /// Represents a search value definition in the global registry.
 #[derive(Debug, Clone)]
 pub struct SearchValueDefinition {
     pub id: Uuid,
     pub filter: SearchFilter,
-}
-
-impl SearchValueDefinition {
-    /// Creates a registry-owned search value definition.
-    pub fn new(filter: SearchFilter) -> Self {
-        Self {
-            id: Uuid::new_v4(),
-            filter,
-        }
-    }
-}
-
-/// Global registry of filters and search values shared across all sessions.
-/// It tracks which filters are assigned to which sessions.
-#[derive(Debug, Default, Clone)]
-pub struct FilterRegistry {
-    filters: FxHashMap<Uuid, FilterDefinition>,
-    search_values: FxHashMap<Uuid, SearchValueDefinition>,
-    // Mapping: FilterId -> Set of SessionIds
-    filter_usage: FxHashMap<Uuid, FxHashSet<Uuid>>,
-    // Mapping: SearchValueId -> Set of SessionIds
-    value_usage: FxHashMap<Uuid, FxHashSet<Uuid>>,
 }
 
 /// Outcome of editing one session's view of a registry definition.
@@ -85,6 +67,11 @@ impl FilterRegistry {
         &self.filters
     }
 
+    /// Monotonic change counter for filter definition catalog mutations.
+    pub fn filter_definitions_revision(&self) -> u64 {
+        self.filter_definitions_revision
+    }
+
     /// Returns the immutable search value definition used by UI rendering and sync.
     pub fn get_search_value(&self, id: &Uuid) -> Option<&SearchValueDefinition> {
         self.search_values.get(id)
@@ -93,6 +80,11 @@ impl FilterRegistry {
     /// Exposes the full search-value registry for read-only library views.
     pub fn search_value_map(&self) -> &FxHashMap<Uuid, SearchValueDefinition> {
         &self.search_values
+    }
+
+    /// Monotonic change counter for search-value definition catalog mutations.
+    pub fn search_value_definitions_revision(&self) -> u64 {
+        self.search_value_definitions_revision
     }
 
     /// Inserts a new global filter definition without attaching it to a session.
@@ -110,6 +102,7 @@ impl FilterRegistry {
 
         let id = filter.id;
         self.filters.insert(id, filter);
+        self.filter_definitions_revision += 1;
         id
     }
 
@@ -128,6 +121,7 @@ impl FilterRegistry {
 
         let id = search_value.id;
         self.search_values.insert(id, search_value);
+        self.search_value_definitions_revision += 1;
         id
     }
 
@@ -198,13 +192,17 @@ impl FilterRegistry {
 
     /// Removes the filter definition and all of its session usage tracking.
     pub fn remove_filter(&mut self, id: &Uuid) {
-        self.filters.remove(id);
+        if self.filters.remove(id).is_some() {
+            self.filter_definitions_revision += 1;
+        }
         self.filter_usage.remove(id);
     }
 
     /// Removes the search-value definition and all of its session usage tracking.
     pub fn remove_search_value(&mut self, id: &Uuid) {
-        self.search_values.remove(id);
+        if self.search_values.remove(id).is_some() {
+            self.search_value_definitions_revision += 1;
+        }
         self.value_usage.remove(id);
     }
 
@@ -252,9 +250,13 @@ impl FilterRegistry {
             let Some(filter_def) = self.filters.get_mut(&filter_id) else {
                 return RegistryEditOutcome::NotFound;
             };
+            if filter_def.filter == next_filter {
+                return RegistryEditOutcome::EditedInPlace;
+            }
             filter_def.filter = next_filter;
             filter_def.search_value_eligibility = validate_search_value_filter(&filter_def.filter);
             filter_def.regex_enable_eligibility = validate_filter_regex_enable(&filter_def.filter);
+            self.filter_definitions_revision += 1;
             return RegistryEditOutcome::EditedInPlace;
         }
 
@@ -292,7 +294,11 @@ impl FilterRegistry {
             let Some(value_def) = self.search_values.get_mut(&value_id) else {
                 return RegistryEditOutcome::NotFound;
             };
+            if value_def.filter == next_filter {
+                return RegistryEditOutcome::EditedInPlace;
+            }
             value_def.filter = next_filter;
+            self.search_value_definitions_revision += 1;
             return RegistryEditOutcome::EditedInPlace;
         }
 
@@ -323,12 +329,37 @@ impl FilterRegistry {
 
     /// Removes a closing session from usage tracking without deleting any global
     /// filter or search-value definitions.
-    pub(super) fn cleanup_session(&mut self, session_id: &Uuid) {
+    pub fn cleanup_session(&mut self, session_id: &Uuid) {
         for sessions in self.filter_usage.values_mut() {
             sessions.remove(session_id);
         }
         for sessions in self.value_usage.values_mut() {
             sessions.remove(session_id);
+        }
+    }
+}
+
+impl FilterDefinition {
+    /// Creates a registry-owned filter definition and caches whether it can
+    /// later be converted into a search value.
+    pub fn new(filter: SearchFilter) -> Self {
+        let search_value_eligibility = validate_search_value_filter(&filter);
+        let regex_enable_eligibility = validate_filter_regex_enable(&filter);
+        Self {
+            id: Uuid::new_v4(),
+            filter,
+            search_value_eligibility,
+            regex_enable_eligibility,
+        }
+    }
+}
+
+impl SearchValueDefinition {
+    /// Creates a registry-owned search value definition.
+    pub fn new(filter: SearchFilter) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            filter,
         }
     }
 }
@@ -397,6 +428,24 @@ mod tests {
     }
 
     #[test]
+    fn filter_revision_tracks_definition_changes() {
+        let mut registry = FilterRegistry::default();
+        let first_id = registry.add_filter(FilterDefinition::new(
+            SearchFilter::plain("status=ok").ignore_case(true),
+        ));
+
+        assert_eq!(registry.filter_definitions_revision(), 1);
+
+        registry.add_filter(FilterDefinition::new(
+            SearchFilter::plain("status=ok").ignore_case(true),
+        ));
+        assert_eq!(registry.filter_definitions_revision(), 1);
+
+        registry.remove_filter(&first_id);
+        assert_eq!(registry.filter_definitions_revision(), 2);
+    }
+
+    #[test]
     fn add_value_reuses_existing() {
         let mut registry = FilterRegistry::default();
         let first_id = registry.add_search_value(SearchValueDefinition::new(
@@ -413,6 +462,28 @@ mod tests {
 
         assert_eq!(reused_id, first_id);
         assert_eq!(registry.search_value_map().len(), 1);
+    }
+
+    #[test]
+    fn search_value_revision_tracks_definition_changes() {
+        let mut registry = FilterRegistry::default();
+        let first_id = registry.add_search_value(SearchValueDefinition::new(
+            SearchFilter::plain("cpu=(\\d+)")
+                .regex(true)
+                .ignore_case(true),
+        ));
+
+        assert_eq!(registry.search_value_definitions_revision(), 1);
+
+        registry.add_search_value(SearchValueDefinition::new(
+            SearchFilter::plain("cpu=(\\d+)")
+                .regex(true)
+                .ignore_case(true),
+        ));
+        assert_eq!(registry.search_value_definitions_revision(), 1);
+
+        registry.remove_search_value(&first_id);
+        assert_eq!(registry.search_value_definitions_revision(), 2);
     }
 
     #[test]
@@ -479,6 +550,36 @@ mod tests {
         assert!(edited.filter.is_ignore_case());
         assert!(edited.search_value_eligibility.is_eligible());
         assert!(edited.regex_enable_eligibility.is_eligible());
+    }
+
+    #[test]
+    fn in_place_filter_edit_updates_revision_only_on_change() {
+        let mut registry = FilterRegistry::default();
+        let session_id = Uuid::new_v4();
+        let filter_id = registry.add_filter(FilterDefinition::new(
+            SearchFilter::plain("status=ok").ignore_case(true),
+        ));
+        registry.apply_filter_to_session(filter_id, session_id);
+
+        let baseline_revision = registry.filter_definitions_revision();
+        let unchanged = registry.edit_filter_for_session(
+            filter_id,
+            session_id,
+            SearchFilter::plain("status=ok").ignore_case(true),
+        );
+        assert_eq!(unchanged, RegistryEditOutcome::EditedInPlace);
+        assert_eq!(registry.filter_definitions_revision(), baseline_revision);
+
+        let changed = registry.edit_filter_for_session(
+            filter_id,
+            session_id,
+            SearchFilter::plain("status=warn").ignore_case(true),
+        );
+        assert_eq!(changed, RegistryEditOutcome::EditedInPlace);
+        assert_eq!(
+            registry.filter_definitions_revision(),
+            baseline_revision + 1
+        );
     }
 
     #[test]
@@ -686,6 +787,45 @@ mod tests {
         assert_eq!(edited.filter.value, "mem=(\\d+)");
         assert!(edited.filter.is_regex());
         assert!(edited.filter.is_ignore_case());
+    }
+
+    #[test]
+    fn in_place_search_value_edit_updates_revision_only_on_change() {
+        let mut registry = FilterRegistry::default();
+        let session_id = Uuid::new_v4();
+        let value_id = registry.add_search_value(SearchValueDefinition::new(
+            SearchFilter::plain("duration=(\\d+)")
+                .regex(true)
+                .ignore_case(true),
+        ));
+        registry.apply_search_value_to_session(value_id, session_id);
+
+        let baseline_revision = registry.search_value_definitions_revision();
+        let unchanged = registry.edit_search_value_for_session(
+            value_id,
+            session_id,
+            SearchFilter::plain("duration=(\\d+)")
+                .regex(true)
+                .ignore_case(true),
+        );
+        assert_eq!(unchanged, RegistryEditOutcome::EditedInPlace);
+        assert_eq!(
+            registry.search_value_definitions_revision(),
+            baseline_revision
+        );
+
+        let changed = registry.edit_search_value_for_session(
+            value_id,
+            session_id,
+            SearchFilter::plain("latency=(\\d+)")
+                .regex(true)
+                .ignore_case(true),
+        );
+        assert_eq!(changed, RegistryEditOutcome::EditedInPlace);
+        assert_eq!(
+            registry.search_value_definitions_revision(),
+            baseline_revision + 1
+        );
     }
 
     #[test]

--- a/application/apps/indexer/gui/application/src/host/ui/registry/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/registry/mod.rs
@@ -1,17 +1,48 @@
 pub mod filters;
+pub mod presets;
 
 use filters::FilterRegistry;
+use presets::PresetRegistry;
 use uuid::Uuid;
 
 /// Global registry for all shared state across sessions.
 #[derive(Debug, Default)]
 pub struct HostRegistry {
     pub filters: FilterRegistry,
+    pub presets: PresetRegistry,
 }
 
 impl HostRegistry {
     /// Cleanup all usage records for a closing session.
     pub fn cleanup_session(&mut self, session_id: &Uuid) {
         self.filters.cleanup_session(session_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use processor::search::filter::SearchFilter;
+
+    use super::*;
+
+    #[test]
+    fn defaults_empty_presets() {
+        let registry = HostRegistry::default();
+
+        assert!(registry.presets.presets().is_empty());
+    }
+
+    #[test]
+    fn cleanup_keeps_presets() {
+        let mut registry = HostRegistry::default();
+        let preset_id =
+            registry
+                .presets
+                .add_preset("Errors", vec![SearchFilter::plain("error")], vec![]);
+
+        registry.cleanup_session(&Uuid::new_v4());
+
+        assert_eq!(registry.presets.presets().len(), 1);
+        assert_eq!(registry.presets.get(&preset_id).unwrap().name, "Errors");
     }
 }

--- a/application/apps/indexer/gui/application/src/host/ui/registry/presets.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/registry/presets.rs
@@ -1,0 +1,581 @@
+use crate::{host::ui::registry::filters::FilterRegistry, session::ui::SessionShared};
+use processor::search::filter::SearchFilter;
+use uuid::Uuid;
+
+/// Host-level registry for named preset snapshots captured from session filters and charts.
+#[derive(Debug, Default, Clone)]
+pub struct PresetRegistry {
+    presets: Vec<Preset>,
+    /// Monotonic catalog revision used by UI caches keyed on preset structure.
+    definitions_revision: u64,
+}
+
+/// Preset definition with copied semantic content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Preset {
+    pub id: Uuid,
+    pub name: String,
+    pub filters: Vec<SearchFilter>,
+    pub search_values: Vec<SearchFilter>,
+}
+
+/// Result of applying a preset edit request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PresetUpdateOutcome {
+    NotFound,
+    Unchanged,
+    Updated {
+        /// Final stored name after uniqueness normalization.
+        name: String,
+    },
+}
+
+impl PresetRegistry {
+    pub fn presets(&self) -> &[Preset] {
+        &self.presets
+    }
+
+    /// Monotonic catalog revision used by UI caches keyed on preset structure.
+    pub fn definitions_revision(&self) -> u64 {
+        self.definitions_revision
+    }
+
+    fn unique_preset_name(&self, base_name: &str, skip_id: Option<Uuid>) -> String {
+        if !self
+            .presets
+            .iter()
+            .any(|preset| Some(preset.id) != skip_id && preset.name == base_name)
+        {
+            return base_name.to_owned();
+        }
+
+        let mut suffix = 2;
+        loop {
+            let candidate = format!("{base_name}_{suffix}");
+            if !self
+                .presets
+                .iter()
+                .any(|preset| Some(preset.id) != skip_id && preset.name == candidate)
+            {
+                return candidate;
+            }
+            suffix += 1;
+        }
+    }
+
+    pub fn get(&self, id: &Uuid) -> Option<&Preset> {
+        self.presets.iter().find(|preset| preset.id == *id)
+    }
+
+    pub fn add_preset(
+        &mut self,
+        name: impl Into<String>,
+        filters: Vec<SearchFilter>,
+        search_values: Vec<SearchFilter>,
+    ) -> Uuid {
+        let name = self.unique_preset_name(&name.into(), None);
+        let preset = Preset {
+            id: Uuid::new_v4(),
+            name,
+            filters,
+            search_values,
+        };
+        let id = preset.id;
+        self.presets.push(preset);
+        self.definitions_revision += 1;
+        id
+    }
+
+    pub fn add_preset_from_session(
+        &mut self,
+        shared: &SessionShared,
+        registry: &FilterRegistry,
+    ) -> Uuid {
+        let filters = shared
+            .filters
+            .filter_entries
+            .iter()
+            .filter_map(|item| registry.get_filter(&item.id))
+            .map(|def| def.filter.clone())
+            .collect();
+        let search_values = shared
+            .filters
+            .search_value_entries
+            .iter()
+            .filter_map(|item| registry.get_search_value(&item.id))
+            .map(|def| def.filter.clone())
+            .collect();
+
+        self.add_preset(shared.get_info().title.clone(), filters, search_values)
+    }
+
+    pub fn update_preset(
+        &mut self,
+        id: Uuid,
+        requested_name: impl Into<String>,
+        filters: Vec<SearchFilter>,
+        search_values: Vec<SearchFilter>,
+    ) -> PresetUpdateOutcome {
+        let requested_name = requested_name.into();
+        let Some(index) = self.presets.iter().position(|preset| preset.id == id) else {
+            return PresetUpdateOutcome::NotFound;
+        };
+
+        let next_name = self.unique_preset_name(&requested_name, Some(id));
+        let preset = &mut self.presets[index];
+        if preset.name == next_name
+            && preset.filters == filters
+            && preset.search_values == search_values
+        {
+            return PresetUpdateOutcome::Unchanged;
+        }
+
+        preset.name = next_name.clone();
+        preset.filters = filters;
+        preset.search_values = search_values;
+        self.definitions_revision += 1;
+
+        PresetUpdateOutcome::Updated { name: next_name }
+    }
+
+    pub fn remove_preset(&mut self, id: Uuid) -> bool {
+        let Some(index) = self.presets.iter().position(|preset| preset.id == id) else {
+            return false;
+        };
+
+        self.presets.remove(index);
+        self.definitions_revision += 1;
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use stypes::{FileFormat, ObserveOrigin};
+
+    use crate::{
+        host::{
+            common::parsers::ParserNames,
+            ui::registry::filters::{FilterDefinition, RegistryEditOutcome, SearchValueDefinition},
+        },
+        session::{types::ObserveOperation, ui::SessionInfo},
+    };
+
+    use super::*;
+
+    fn plain(value: &str) -> SearchFilter {
+        SearchFilter::plain(value).ignore_case(true)
+    }
+
+    fn regex(value: &str) -> SearchFilter {
+        SearchFilter::plain(value).regex(true).ignore_case(true)
+    }
+
+    fn new_shared() -> SessionShared {
+        let session_id = Uuid::new_v4();
+        let origin = ObserveOrigin::File(
+            "source".to_owned(),
+            FileFormat::Text,
+            PathBuf::from("source.log"),
+        );
+        let observe_op = ObserveOperation::new(Uuid::new_v4(), origin);
+        let session_info = SessionInfo {
+            id: session_id,
+            title: "test".to_owned(),
+            parser: ParserNames::Text,
+        };
+
+        SessionShared::new(session_info, observe_op)
+    }
+
+    fn add_filter_definition(registry: &mut FilterRegistry, value: &str) -> Uuid {
+        let definition = FilterDefinition::new(SearchFilter::plain(value).ignore_case(true));
+        let id = definition.id;
+        registry.add_filter(definition);
+        id
+    }
+
+    fn add_search_value_definition(registry: &mut FilterRegistry, value: &str) -> Uuid {
+        let definition =
+            SearchValueDefinition::new(SearchFilter::plain(value).regex(true).ignore_case(true));
+        let id = definition.id;
+        registry.add_search_value(definition);
+        id
+    }
+
+    #[test]
+    fn defaults_empty() {
+        let registry = PresetRegistry::default();
+
+        assert!(registry.presets().is_empty());
+        assert_eq!(registry.definitions_revision(), 0);
+    }
+
+    #[test]
+    fn add_keeps_order() {
+        let mut registry = PresetRegistry::default();
+        let first_id = registry.add_preset("First", vec![plain("one")], vec![]);
+        let second_id = registry.add_preset("Second", vec![plain("two")], vec![]);
+
+        assert_eq!(registry.presets()[0].id, first_id);
+        assert_eq!(registry.presets()[1].id, second_id);
+        assert_eq!(registry.definitions_revision(), 2);
+    }
+
+    #[test]
+    fn keeps_filter_duplicates() {
+        let mut registry = PresetRegistry::default();
+        let preset_id = registry.add_preset(
+            "Errors",
+            vec![plain("error"), plain("warn"), plain("error"), plain("warn")],
+            vec![],
+        );
+
+        assert_eq!(
+            registry.get(&preset_id).unwrap().filters,
+            vec![plain("error"), plain("warn"), plain("error"), plain("warn")]
+        );
+    }
+
+    #[test]
+    fn keeps_search_value_duplicates() {
+        let mut registry = PresetRegistry::default();
+        let preset_id = registry.add_preset(
+            "Durations",
+            vec![],
+            vec![
+                regex("duration=(\\d+)"),
+                regex("latency=(\\d+)"),
+                regex("duration=(\\d+)"),
+            ],
+        );
+
+        assert_eq!(
+            registry.get(&preset_id).unwrap().search_values,
+            vec![
+                regex("duration=(\\d+)"),
+                regex("latency=(\\d+)"),
+                regex("duration=(\\d+)")
+            ]
+        );
+    }
+
+    #[test]
+    fn duplicates_stay_per_list() {
+        let mut registry = PresetRegistry::default();
+        let preset_id = registry.add_preset(
+            "Shared Value",
+            vec![plain("error"), plain("error")],
+            vec![plain("error"), plain("error")],
+        );
+        let preset = registry.get(&preset_id).unwrap();
+
+        assert_eq!(preset.filters, vec![plain("error"), plain("error")]);
+        assert_eq!(preset.search_values, vec![plain("error"), plain("error")]);
+    }
+
+    #[test]
+    fn identical_presets_both_store() {
+        let mut registry = PresetRegistry::default();
+        let first_id = registry.add_preset(
+            "Errors",
+            vec![plain("error")],
+            vec![regex("duration=(\\d+)")],
+        );
+        let second_id = registry.add_preset(
+            "Errors",
+            vec![plain("error")],
+            vec![regex("duration=(\\d+)")],
+        );
+
+        assert_ne!(first_id, second_id);
+        assert_eq!(registry.presets().len(), 2);
+    }
+
+    #[test]
+    fn keeps_base_name_free() {
+        let mut registry = PresetRegistry::default();
+        registry.add_preset("Errors_2", vec![plain("error")], vec![]);
+
+        let preset_id = registry.add_preset("Errors", vec![plain("warn")], vec![]);
+
+        assert_eq!(registry.get(&preset_id).unwrap().name, "Errors");
+    }
+
+    #[test]
+    fn appends_second_suffix() {
+        let mut registry = PresetRegistry::default();
+        registry.add_preset("Errors", vec![plain("error")], vec![]);
+
+        let preset_id = registry.add_preset("Errors", vec![plain("warn")], vec![]);
+
+        assert_eq!(registry.get(&preset_id).unwrap().name, "Errors_2");
+    }
+
+    #[test]
+    fn skips_taken_suffixes() {
+        let mut registry = PresetRegistry::default();
+        registry.add_preset("Errors", vec![plain("error")], vec![]);
+        registry.add_preset("Errors_2", vec![plain("warn")], vec![]);
+
+        let preset_id = registry.add_preset("Errors", vec![plain("info")], vec![]);
+
+        assert_eq!(registry.get(&preset_id).unwrap().name, "Errors_3");
+    }
+
+    #[test]
+    fn remove_preset_keeps_other_order() {
+        let mut registry = PresetRegistry::default();
+        let first_id = registry.add_preset("First", vec![plain("one")], vec![]);
+        let second_id = registry.add_preset("Second", vec![plain("two")], vec![]);
+        let third_id = registry.add_preset("Third", vec![plain("three")], vec![]);
+
+        assert!(registry.remove_preset(second_id));
+
+        assert_eq!(
+            registry
+                .presets()
+                .iter()
+                .map(|preset| preset.id)
+                .collect::<Vec<_>>(),
+            vec![first_id, third_id]
+        );
+    }
+
+    #[test]
+    fn filter_snapshot_is_not_link() {
+        let shared = new_shared();
+        let session_id = shared.get_id();
+        let mut filters_registry = FilterRegistry::default();
+        let mut preset_registry = PresetRegistry::default();
+        let filter_id = add_filter_definition(&mut filters_registry, "error");
+
+        filters_registry.apply_filter_to_session(filter_id, session_id);
+        let preset_id = preset_registry.add_preset(
+            "Errors",
+            vec![
+                filters_registry
+                    .get_filter(&filter_id)
+                    .unwrap()
+                    .filter
+                    .clone(),
+            ],
+            vec![],
+        );
+
+        let outcome = filters_registry.edit_filter_for_session(
+            filter_id,
+            session_id,
+            SearchFilter::plain("warn").ignore_case(true),
+        );
+
+        assert_eq!(outcome, RegistryEditOutcome::EditedInPlace);
+        assert_eq!(
+            filters_registry.get_filter(&filter_id).unwrap().filter,
+            plain("warn")
+        );
+        assert_eq!(
+            preset_registry.get(&preset_id).unwrap().filters,
+            vec![plain("error")]
+        );
+    }
+
+    #[test]
+    fn search_value_snapshot_is_not_link() {
+        let shared = new_shared();
+        let session_id = shared.get_id();
+        let mut filters_registry = FilterRegistry::default();
+        let mut preset_registry = PresetRegistry::default();
+        let value_id = add_search_value_definition(&mut filters_registry, "duration=(\\d+)");
+
+        filters_registry.apply_search_value_to_session(value_id, session_id);
+        let preset_id = preset_registry.add_preset(
+            "Durations",
+            vec![],
+            vec![
+                filters_registry
+                    .get_search_value(&value_id)
+                    .unwrap()
+                    .filter
+                    .clone(),
+            ],
+        );
+
+        let outcome = filters_registry.edit_search_value_for_session(
+            value_id,
+            session_id,
+            SearchFilter::plain("latency=(\\d+)")
+                .regex(true)
+                .ignore_case(true),
+        );
+
+        assert_eq!(outcome, RegistryEditOutcome::EditedInPlace);
+        assert_eq!(
+            filters_registry.get_search_value(&value_id).unwrap().filter,
+            regex("latency=(\\d+)")
+        );
+        assert_eq!(
+            preset_registry.get(&preset_id).unwrap().search_values,
+            vec![regex("duration=(\\d+)")]
+        );
+    }
+
+    #[test]
+    fn update_preset_replaces_all_fields() {
+        let mut registry = PresetRegistry::default();
+        let preset_id = registry.add_preset(
+            "Errors",
+            vec![plain("error")],
+            vec![regex("duration=(\\d+)")],
+        );
+
+        let outcome = registry.update_preset(
+            preset_id,
+            "Warnings",
+            vec![plain("warn"), plain("info")],
+            vec![regex("latency=(\\d+)")],
+        );
+
+        assert_eq!(
+            outcome,
+            PresetUpdateOutcome::Updated {
+                name: "Warnings".to_owned(),
+            }
+        );
+        assert_eq!(
+            registry.get(&preset_id).unwrap(),
+            &Preset {
+                id: preset_id,
+                name: "Warnings".to_owned(),
+                filters: vec![plain("warn"), plain("info")],
+                search_values: vec![regex("latency=(\\d+)")],
+            }
+        );
+        assert_eq!(registry.definitions_revision(), 2);
+    }
+
+    #[test]
+    fn update_preset_keeps_same_data() {
+        let mut registry = PresetRegistry::default();
+        let preset_id = registry.add_preset(
+            "Errors",
+            vec![plain("error")],
+            vec![regex("duration=(\\d+)")],
+        );
+
+        let outcome = registry.update_preset(
+            preset_id,
+            "Errors",
+            vec![plain("error")],
+            vec![regex("duration=(\\d+)")],
+        );
+
+        assert_eq!(outcome, PresetUpdateOutcome::Unchanged);
+        assert_eq!(registry.get(&preset_id).unwrap().name, "Errors");
+        assert_eq!(registry.definitions_revision(), 1);
+    }
+
+    #[test]
+    fn update_preset_uses_unique_name() {
+        let mut registry = PresetRegistry::default();
+        let first_id = registry.add_preset("First", vec![plain("one")], vec![]);
+        registry.add_preset("Taken", vec![plain("two")], vec![]);
+        registry.add_preset("Taken_2", vec![plain("three")], vec![]);
+
+        let outcome = registry.update_preset(first_id, "Taken", vec![plain("one")], vec![]);
+
+        assert_eq!(
+            outcome,
+            PresetUpdateOutcome::Updated {
+                name: "Taken_3".to_owned(),
+            }
+        );
+        assert_eq!(registry.get(&first_id).unwrap().name, "Taken_3");
+        assert_eq!(registry.definitions_revision(), 4);
+    }
+
+    #[test]
+    fn update_preset_handles_missing_id() {
+        let mut registry = PresetRegistry::default();
+
+        let outcome = registry.update_preset(
+            Uuid::new_v4(),
+            "Missing",
+            vec![plain("one")],
+            vec![regex("duration=(\\d+)")],
+        );
+
+        assert_eq!(outcome, PresetUpdateOutcome::NotFound);
+        assert_eq!(registry.definitions_revision(), 0);
+    }
+
+    #[test]
+    fn remove_preset_advances_revision() {
+        let mut registry = PresetRegistry::default();
+        let preset_id = registry.add_preset("Errors", vec![plain("one")], vec![]);
+
+        assert!(registry.remove_preset(preset_id));
+        assert_eq!(registry.definitions_revision(), 2);
+    }
+
+    #[test]
+    fn captures_applied_session_state() {
+        let mut shared = new_shared();
+        let mut filters_registry = FilterRegistry::default();
+        let mut preset_registry = PresetRegistry::default();
+        let first_filter_id = add_filter_definition(&mut filters_registry, "error");
+        let second_filter_id = add_filter_definition(&mut filters_registry, "warn");
+        let first_value_id = add_search_value_definition(&mut filters_registry, "duration=(\\d+)");
+        let second_value_id = add_search_value_definition(&mut filters_registry, "latency=(\\d+)");
+
+        shared
+            .filters
+            .apply_filter(&mut filters_registry, first_filter_id);
+        shared
+            .filters
+            .apply_filter_with_state(&mut filters_registry, second_filter_id, false);
+        shared
+            .filters
+            .apply_search_value(&mut filters_registry, first_value_id);
+        shared
+            .filters
+            .apply_search_value_with_state(&mut filters_registry, second_value_id, false);
+
+        let preset_id = preset_registry.add_preset_from_session(&shared, &filters_registry);
+        let preset = preset_registry.get(&preset_id).unwrap();
+
+        assert_eq!(preset.name, "test");
+        assert_eq!(
+            preset.filters,
+            vec![
+                filters_registry
+                    .get_filter(&first_filter_id)
+                    .unwrap()
+                    .filter
+                    .clone(),
+                filters_registry
+                    .get_filter(&second_filter_id)
+                    .unwrap()
+                    .filter
+                    .clone(),
+            ]
+        );
+        assert_eq!(
+            preset.search_values,
+            vec![
+                filters_registry
+                    .get_search_value(&first_value_id)
+                    .unwrap()
+                    .filter
+                    .clone(),
+                filters_registry
+                    .get_search_value(&second_value_id)
+                    .unwrap()
+                    .filter
+                    .clone(),
+            ]
+        );
+    }
+}

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/library/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/library/mod.rs
@@ -1,0 +1,959 @@
+use egui::{
+    Align, Button, Frame, Layout, Margin, Response, RichText, ScrollArea, Sense, Sides, TextEdit,
+    Ui, UiBuilder, vec2,
+};
+use rustc_hash::FxHashSet;
+use tokio::sync::mpsc::Sender;
+use uuid::Uuid;
+
+use crate::{
+    common::{phosphor::icons, validation::ValidationEligibility},
+    host::ui::{UiActions, registry::filters::FilterRegistry},
+    session::{
+        command::SessionCommand,
+        ui::shared::{SearchSyncTarget, SessionShared},
+    },
+};
+
+const HEADING_FONT_SIZE: f32 = 16.0;
+
+/// Bottom-panel library surface with local navigation state.
+///
+/// Definition actions still go through normal session command dispatch so the
+/// existing apply/delete and explicit sync paths remain unchanged.
+#[derive(Debug)]
+pub struct LibraryUI {
+    cmd_tx: Sender<SessionCommand>,
+    filter_state: DefinitionQueryState,
+    chart_state: DefinitionQueryState,
+}
+
+/// Local query state and cached matches for one library definition column.
+#[derive(Debug, Default)]
+struct DefinitionQueryState {
+    query: String,
+    matching_ids: Option<FxHashSet<Uuid>>,
+    cached_revision: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FilterFlags {
+    regex: bool,
+    ignore_case: bool,
+    word: bool,
+}
+
+#[derive(Debug, Clone)]
+struct FilterRowView<'a> {
+    id: Uuid,
+    applied: bool,
+    text: &'a str,
+    flags: FilterFlags,
+    regex_enable_eligibility: &'a ValidationEligibility,
+}
+
+#[derive(Debug, Clone)]
+struct SearchValueRowView<'a> {
+    id: Uuid,
+    applied: bool,
+    text: &'a str,
+}
+
+/// Deferred row mutation applied after rendering finishes for the current list.
+///
+/// The registry maps stay borrowed while rows are rendered, so we queue only
+/// the chosen action and execute it once iteration is complete.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingDefinitionAction {
+    Toggle(Uuid),
+    Delete(Uuid),
+}
+
+impl LibraryUI {
+    pub fn new(cmd_tx: Sender<SessionCommand>) -> Self {
+        Self {
+            cmd_tx,
+            filter_state: DefinitionQueryState::default(),
+            chart_state: DefinitionQueryState::default(),
+        }
+    }
+
+    pub fn render_content(
+        &mut self,
+        shared: &mut SessionShared,
+        actions: &mut UiActions,
+        registry: &mut FilterRegistry,
+        ui: &mut Ui,
+    ) {
+        ui.columns_const(|[filter_col, search_values_col]| {
+            Self::render_section_group(filter_col, |ui| {
+                self.render_filter_definitions(shared, actions, registry, ui);
+            });
+            Self::render_section_group(search_values_col, |ui| {
+                self.render_search_value_definitions(shared, actions, registry, ui);
+            });
+        });
+    }
+
+    fn render_filter_definitions(
+        &mut self,
+        shared: &mut SessionShared,
+        actions: &mut UiActions,
+        registry: &mut FilterRegistry,
+        ui: &mut Ui,
+    ) {
+        ui.vertical(|ui| {
+            ui.label(RichText::new("Filters").heading().size(HEADING_FONT_SIZE));
+            ui.add_space(8.0);
+
+            if registry.filters_map().is_empty() {
+                ui.label(RichText::new("No filter definitions in library").weak());
+                return;
+            }
+
+            let query_changed =
+                Self::render_name_filter_input(ui, "Filter by name", &mut self.filter_state.query)
+                    .changed();
+            self.filter_state.update_with_revision(
+                registry.filter_definitions_revision(),
+                query_changed,
+                |query| collect_matching_filter_ids(query, registry),
+            );
+
+            ScrollArea::vertical()
+                .id_salt("library_filters")
+                .auto_shrink(false)
+                .show(ui, |ui| {
+                    // Defer mutations until after the loop so we do not mutate
+                    // session/registry state while iterating the borrowed map.
+                    let mut pending_action = None;
+                    let mut any_visible = false;
+                    let session_id = shared.get_id();
+                    for (id, def) in registry.filters_map() {
+                        if !self.filter_state.matches(id) {
+                            continue;
+                        }
+
+                        any_visible = true;
+                        let row = FilterRowView {
+                            id: *id,
+                            applied: shared.filters.is_filter_applied(id),
+                            text: def.filter.value.as_str(),
+                            flags: FilterFlags {
+                                regex: def.filter.is_regex(),
+                                ignore_case: def.filter.is_ignore_case(),
+                                word: def.filter.is_word(),
+                            },
+                            regex_enable_eligibility: &def.regex_enable_eligibility,
+                        };
+                        let delete_enabled = registry.can_remove_filter(&row.id, &session_id);
+
+                        if let Some(action) = self.render_library_row(
+                            ui,
+                            row.applied,
+                            PendingDefinitionAction::Toggle(row.id),
+                            |ui, _action| {
+                                Self::render_filter_display_row(ui, &row);
+                            },
+                            |ui, action| {
+                                let mut delete_btn = ui
+                                    .add_enabled(delete_enabled, Button::new("Delete definition"));
+                                delete_btn = delete_btn.on_disabled_hover_ui(|ui| {
+                                    ui.set_max_width(ui.spacing().tooltip_width);
+                                    ui.label(format!(
+                                        "Cannot delete: currently used in {} other session(s).",
+                                        registry.filter_usage_count(&row.id)
+                                            - usize::from(
+                                                registry.is_filter_applied(&row.id, &session_id,),
+                                            )
+                                    ));
+                                });
+                                if delete_btn.clicked() {
+                                    *action = Some(PendingDefinitionAction::Delete(row.id));
+                                }
+                            },
+                        ) {
+                            pending_action = Some(action);
+                        }
+                    }
+
+                    if !any_visible {
+                        ui.label(
+                            RichText::new("No filter definitions match the current filter.").weak(),
+                        );
+                    }
+
+                    match pending_action {
+                        Some(PendingDefinitionAction::Toggle(id)) => {
+                            self.toggle_filter_definition(shared, actions, registry, id);
+                        }
+                        Some(PendingDefinitionAction::Delete(id)) => {
+                            self.delete_filter_definition(shared, actions, registry, id);
+                        }
+                        None => {}
+                    }
+                });
+        });
+    }
+
+    fn render_search_value_definitions(
+        &mut self,
+        shared: &mut SessionShared,
+        actions: &mut UiActions,
+        registry: &mut FilterRegistry,
+        ui: &mut Ui,
+    ) {
+        ui.vertical(|ui| {
+            ui.label(RichText::new("Charts").heading().size(HEADING_FONT_SIZE));
+            ui.add_space(8.0);
+
+            if registry.search_value_map().is_empty() {
+                ui.label(RichText::new("No chart definitions in library").weak());
+                return;
+            }
+
+            let query_changed =
+                Self::render_name_filter_input(ui, "Filter by name", &mut self.chart_state.query)
+                    .changed();
+            self.chart_state.update_with_revision(
+                registry.search_value_definitions_revision(),
+                query_changed,
+                |query| collect_matching_search_value_ids(query, registry),
+            );
+
+            ScrollArea::vertical()
+                .id_salt("library_charts")
+                .auto_shrink(false)
+                .show(ui, |ui| {
+                    // Charts use the same deferred-mutation pattern as filters
+                    // because search-value rows are rendered from a borrowed map.
+                    let mut pending_action = None;
+                    let mut any_visible = false;
+                    let session_id = shared.get_id();
+                    for (id, def) in registry.search_value_map() {
+                        if !self.chart_state.matches(id) {
+                            continue;
+                        }
+
+                        any_visible = true;
+                        let row = SearchValueRowView {
+                            id: *id,
+                            applied: shared.filters.is_search_value_applied(id),
+                            text: def.filter.value.as_str(),
+                        };
+                        let delete_enabled = registry.can_remove_search_value(&row.id, &session_id);
+
+                        if let Some(action) = self.render_library_row(
+                            ui,
+                            row.applied,
+                            PendingDefinitionAction::Toggle(row.id),
+                            |ui, _action| {
+                                Self::render_search_value_display_row(ui, &row);
+                            },
+                            |ui, action| {
+                                let mut delete_btn = ui
+                                    .add_enabled(delete_enabled, Button::new("Delete definition"));
+                                delete_btn = delete_btn.on_disabled_hover_ui(|ui| {
+                                    ui.set_max_width(ui.spacing().tooltip_width);
+                                    ui.label(format!(
+                                        "Cannot delete: currently used in {} other session(s).",
+                                        registry.search_value_usage_count(&row.id)
+                                            - usize::from(
+                                                registry
+                                                    .is_search_value_applied(&row.id, &session_id,),
+                                            )
+                                    ));
+                                });
+                                if delete_btn.clicked() {
+                                    *action = Some(PendingDefinitionAction::Delete(row.id));
+                                }
+                            },
+                        ) {
+                            pending_action = Some(action);
+                        }
+                    }
+
+                    if !any_visible {
+                        ui.label(
+                            RichText::new("No chart definitions match the current filter.").weak(),
+                        );
+                    }
+
+                    match pending_action {
+                        Some(PendingDefinitionAction::Toggle(id)) => {
+                            self.toggle_search_value_definition(shared, actions, registry, id);
+                        }
+                        Some(PendingDefinitionAction::Delete(id)) => {
+                            self.delete_search_value_definition(shared, actions, registry, id);
+                        }
+                        None => {}
+                    }
+                });
+        });
+    }
+
+    fn render_section_group<R>(ui: &mut Ui, add_contents: impl FnOnce(&mut Ui) -> R) -> R {
+        let visuals = ui.visuals();
+        Frame::group(ui.style())
+            .fill(visuals.faint_bg_color)
+            .stroke(visuals.widgets.noninteractive.bg_stroke)
+            .inner_margin(Margin::symmetric(12, 10))
+            .outer_margin(Margin::symmetric(4, 4))
+            .show(ui, |ui| {
+                ui.take_available_space();
+                add_contents(ui)
+            })
+            .inner
+    }
+
+    fn toggle_filter_definition(
+        &self,
+        shared: &mut SessionShared,
+        actions: &mut UiActions,
+        registry: &mut FilterRegistry,
+        id: Uuid,
+    ) {
+        let was_enabled = shared.filters.is_filter_enabled(&id);
+
+        // Library rows represent session membership, not the enabled flag.
+        if shared.filters.is_filter_applied(&id) {
+            shared.filters.unapply_filter(registry, &id);
+        } else {
+            shared.filters.apply_filter(registry, id);
+        }
+
+        if was_enabled || shared.filters.is_filter_applied(&id) {
+            self.dispatch_sync_commands(shared, actions, registry, SearchSyncTarget::Filter);
+        }
+    }
+
+    fn delete_filter_definition(
+        &self,
+        shared: &mut SessionShared,
+        actions: &mut UiActions,
+        registry: &mut FilterRegistry,
+        id: Uuid,
+    ) -> bool {
+        if !registry.can_remove_filter(&id, &shared.get_id()) {
+            return false;
+        }
+
+        let was_enabled = shared.filters.is_filter_enabled(&id);
+        registry.remove_filter(&id);
+        shared.filters.unapply_filter(registry, &id);
+
+        // Removing a disabled or unapplied definition does not change the
+        // active backend pipeline, so only enabled rows require a re-sync.
+        if was_enabled {
+            self.dispatch_sync_commands(shared, actions, registry, SearchSyncTarget::Filter);
+        }
+
+        true
+    }
+
+    fn toggle_search_value_definition(
+        &self,
+        shared: &mut SessionShared,
+        actions: &mut UiActions,
+        registry: &mut FilterRegistry,
+        id: Uuid,
+    ) {
+        let was_enabled = shared.filters.is_search_value_enabled(&id);
+
+        // Library rows represent session membership, not the enabled flag.
+        if shared.filters.is_search_value_applied(&id) {
+            shared.filters.unapply_search_value(registry, &id);
+        } else {
+            shared.filters.apply_search_value(registry, id);
+        }
+
+        if was_enabled || shared.filters.is_search_value_applied(&id) {
+            self.dispatch_sync_commands(shared, actions, registry, SearchSyncTarget::SearchValue);
+        }
+    }
+
+    fn delete_search_value_definition(
+        &self,
+        shared: &mut SessionShared,
+        actions: &mut UiActions,
+        registry: &mut FilterRegistry,
+        id: Uuid,
+    ) -> bool {
+        if !registry.can_remove_search_value(&id, &shared.get_id()) {
+            return false;
+        }
+
+        let was_enabled = shared.filters.is_search_value_enabled(&id);
+        registry.remove_search_value(&id);
+        shared.filters.unapply_search_value(registry, &id);
+
+        // Chart/search-value sync is needed only when the removed definition
+        // was contributing to the active extraction pipeline.
+        if was_enabled {
+            self.dispatch_sync_commands(shared, actions, registry, SearchSyncTarget::SearchValue);
+        }
+
+        true
+    }
+
+    /// Preserves the existing explicit sync model by dispatching the same
+    /// session commands the old library surface used after a library action.
+    fn dispatch_sync_commands(
+        &self,
+        shared: &mut SessionShared,
+        actions: &mut UiActions,
+        registry: &FilterRegistry,
+        target: SearchSyncTarget,
+    ) {
+        shared
+            .sync_search_pipelines(registry, target)
+            .into_iter()
+            .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
+    }
+
+    /// Renders a full-width name filter input and returns its edit response.
+    fn render_name_filter_input(ui: &mut Ui, hint_text: &str, query: &mut String) -> Response {
+        let response = ui.add(
+            TextEdit::singleline(query)
+                .hint_text(hint_text)
+                .desired_width(f32::INFINITY),
+        );
+        ui.add_space(5.0);
+        response
+    }
+
+    /// Renders one library definition row with a single full-width hit target.
+    fn render_library_row<FRender, FContext>(
+        &self,
+        ui: &mut Ui,
+        is_applied: bool,
+        toggle_action: PendingDefinitionAction,
+        render_ui: FRender,
+        context_menu_ui: FContext,
+    ) -> Option<PendingDefinitionAction>
+    where
+        FRender: FnOnce(&mut Ui, &mut Option<PendingDefinitionAction>),
+        FContext: FnOnce(&mut Ui, &mut Option<PendingDefinitionAction>),
+    {
+        let mut action = None;
+        const ITEM_ROW_HEIGHT: f32 = 36.0;
+        let desired_width = (ui.available_width() - 10.0).max(0.0);
+        let desired_size = vec2(desired_width, ITEM_ROW_HEIGHT);
+        let (_, item_response) = ui.allocate_exact_size(desired_size, Sense::click());
+        item_response.context_menu(|ui| context_menu_ui(ui, &mut action));
+
+        ui.scope_builder(
+            UiBuilder::new()
+                .max_rect(item_response.rect)
+                .layout(Layout::left_to_right(Align::Center)),
+            |ui| {
+                let visuals = ui.visuals();
+                let mut frame = Frame::group(ui.style())
+                    .fill(visuals.faint_bg_color)
+                    .inner_margin(Margin::symmetric(8, 4));
+                if is_applied {
+                    frame = frame
+                        .fill(visuals.widgets.active.bg_fill)
+                        .stroke(visuals.selection.stroke);
+                }
+                frame.show(ui, |ui| render_ui(ui, &mut action));
+            },
+        );
+
+        if item_response
+            .on_hover_cursor(egui::CursorIcon::PointingHand)
+            .clicked()
+        {
+            action = Some(toggle_action);
+        }
+
+        action
+    }
+
+    fn render_filter_display_row(ui: &mut Ui, row: &FilterRowView<'_>) {
+        Sides::new().shrink_left().truncate().show(
+            ui,
+            |ui| {
+                let text = if row.applied {
+                    RichText::new(row.text).strong()
+                } else {
+                    RichText::new(row.text)
+                };
+                ui.label(text);
+            },
+            |ui| {
+                Self::render_read_only_filter_flag(
+                    ui,
+                    icons::regular::ASTERISK,
+                    row.applied,
+                    row.flags.regex,
+                    "Regular Expression",
+                    row.regex_enable_eligibility,
+                );
+                Self::render_read_only_filter_flag(
+                    ui,
+                    icons::regular::TEXT_T,
+                    row.applied,
+                    row.flags.word,
+                    "Match Whole Word",
+                    &ValidationEligibility::Eligible,
+                );
+                Self::render_read_only_filter_flag(
+                    ui,
+                    icons::regular::TEXT_AA,
+                    row.applied,
+                    !row.flags.ignore_case,
+                    "Match Case",
+                    &ValidationEligibility::Eligible,
+                );
+            },
+        );
+    }
+
+    fn render_search_value_display_row(ui: &mut Ui, row: &SearchValueRowView<'_>) {
+        // Sides used to ensure we have same visuals on both filter and search values.
+        Sides::new().shrink_left().truncate().show(
+            ui,
+            |ui| {
+                let text = if row.applied {
+                    RichText::new(row.text).strong()
+                } else {
+                    RichText::new(row.text)
+                };
+                ui.label(text);
+            },
+            |_ui| {},
+        );
+    }
+
+    fn render_read_only_filter_flag(
+        ui: &mut Ui,
+        icon: &str,
+        highlighted: bool,
+        active: bool,
+        tooltip: &str,
+        eligibility: &ValidationEligibility,
+    ) {
+        let text_color = if highlighted && active {
+            ui.visuals().text_color()
+        } else {
+            ui.visuals().weak_text_color()
+        };
+        let response = ui.label(RichText::new(icon).size(14.0).color(text_color));
+        match eligibility {
+            ValidationEligibility::Eligible => {
+                response.on_hover_ui(|ui| {
+                    ui.set_max_width(ui.spacing().tooltip_width);
+
+                    ui.label(format!("{tooltip}: {}", if active { "On" } else { "Off" }));
+                });
+            }
+            ValidationEligibility::Ineligible { reason } => {
+                response.on_hover_ui(|ui| {
+                    ui.set_max_width(ui.spacing().tooltip_width);
+
+                    ui.label(format!(
+                        "{tooltip}: {}. {reason}",
+                        if active { "On" } else { "Off" }
+                    ));
+                });
+            }
+        };
+    }
+}
+
+impl DefinitionQueryState {
+    /// Refreshes the cached UUID set when the query or catalog revision changes.
+    fn update_with_revision(
+        &mut self,
+        revision: u64,
+        query_changed: bool,
+        recompute_matches: impl FnOnce(&str) -> Option<FxHashSet<Uuid>>,
+    ) {
+        if query_changed || self.cached_revision != revision {
+            self.matching_ids = recompute_matches(&self.query);
+            self.cached_revision = revision;
+        }
+    }
+
+    /// Returns `true` when the row should stay visible for the current query.
+    fn matches(&self, id: &Uuid) -> bool {
+        // `None` means no active query, so all rows remain visible.
+        self.matching_ids
+            .as_ref()
+            .is_none_or(|matching_ids| matching_ids.contains(id))
+    }
+}
+
+fn collect_matching_filter_ids(query: &str, registry: &FilterRegistry) -> Option<FxHashSet<Uuid>> {
+    let normalized_query = normalized_query(query);
+    if normalized_query.is_empty() {
+        return None;
+    }
+
+    Some(
+        registry
+            .filters_map()
+            .iter()
+            .filter_map(|(id, def)| {
+                matches_name_query(def.filter.value.as_str(), &normalized_query).then_some(*id)
+            })
+            .collect(),
+    )
+}
+
+fn collect_matching_search_value_ids(
+    query: &str,
+    registry: &FilterRegistry,
+) -> Option<FxHashSet<Uuid>> {
+    let normalized_query = normalized_query(query);
+    if normalized_query.is_empty() {
+        return None;
+    }
+
+    Some(
+        registry
+            .search_value_map()
+            .iter()
+            .filter_map(|(id, def)| {
+                matches_name_query(def.filter.value.as_str(), &normalized_query).then_some(*id)
+            })
+            .collect(),
+    )
+}
+
+fn normalized_query(query: &str) -> String {
+    query.trim().to_ascii_lowercase()
+}
+
+fn matches_name_query(text: &str, normalized_query: &str) -> bool {
+    normalized_query.is_empty() || text.to_ascii_lowercase().contains(normalized_query)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use tokio::{runtime::Runtime, sync::mpsc};
+    use uuid::Uuid;
+
+    use super::*;
+
+    use crate::{
+        host::{
+            common::parsers::ParserNames,
+            ui::registry::filters::{FilterDefinition, SearchValueDefinition},
+        },
+        session::{command::SessionCommand, types::ObserveOperation, ui::SessionInfo},
+    };
+
+    use stypes::{FileFormat, ObserveOrigin};
+
+    fn new_library() -> (LibraryUI, mpsc::Receiver<SessionCommand>) {
+        let (cmd_tx, cmd_rx) = mpsc::channel(8);
+        (LibraryUI::new(cmd_tx), cmd_rx)
+    }
+
+    fn new_shared() -> SessionShared {
+        let session_id = Uuid::new_v4();
+        let origin = ObserveOrigin::File(
+            "source".to_owned(),
+            FileFormat::Text,
+            PathBuf::from("source.log"),
+        );
+        let observe_op = ObserveOperation::new(Uuid::new_v4(), origin);
+        let session_info = SessionInfo {
+            id: session_id,
+            title: "test".to_owned(),
+            parser: ParserNames::Text,
+        };
+
+        SessionShared::new(session_info, observe_op)
+    }
+
+    fn new_actions(runtime: &Runtime) -> UiActions {
+        UiActions::new(runtime.handle().clone())
+    }
+
+    fn add_filter_definition(registry: &mut FilterRegistry, value: &str) -> Uuid {
+        let definition = FilterDefinition::new(
+            processor::search::filter::SearchFilter::plain(value).ignore_case(true),
+        );
+        let id = definition.id;
+        registry.add_filter(definition);
+        id
+    }
+
+    fn add_search_value_definition(registry: &mut FilterRegistry, value: &str) -> Uuid {
+        let definition = SearchValueDefinition::new(
+            processor::search::filter::SearchFilter::plain(value)
+                .regex(true)
+                .ignore_case(true),
+        );
+        let id = definition.id;
+        registry.add_search_value(definition);
+        id
+    }
+
+    #[test]
+    fn empty_query_matches_all() {
+        assert!(matches_name_query("status=ok", &normalized_query("")));
+        assert!(matches_name_query("status=ok", &normalized_query("   ")));
+    }
+
+    #[test]
+    fn empty_query_cache_is_none() {
+        let mut registry = FilterRegistry::default();
+        add_filter_definition(&mut registry, "status=ok");
+
+        assert!(collect_matching_filter_ids("   ", &registry).is_none());
+        assert!(collect_matching_search_value_ids("   ", &registry).is_none());
+    }
+
+    #[test]
+    fn query_matches_case_insensitively() {
+        assert!(matches_name_query("Status=Ok", &normalized_query("status")));
+        assert!(matches_name_query(
+            "duration=(\\d+)",
+            &normalized_query("DUR")
+        ));
+    }
+
+    #[test]
+    fn filter_query_cache_collects_matching_ids() {
+        let mut registry = FilterRegistry::default();
+        let matching_id = add_filter_definition(&mut registry, "Status=Ok");
+        let non_matching_id = add_filter_definition(&mut registry, "warn");
+        let matching_ids = collect_matching_filter_ids(" status ", &registry).unwrap();
+
+        assert!(matching_ids.contains(&matching_id));
+        assert!(!matching_ids.contains(&non_matching_id));
+    }
+
+    #[test]
+    fn search_value_query_cache_collects_matching_ids() {
+        let mut registry = FilterRegistry::default();
+        let matching_id = add_search_value_definition(&mut registry, "duration=(\\d+)");
+        let non_matching_id = add_search_value_definition(&mut registry, "latency=(\\d+)");
+        let matching_ids = collect_matching_search_value_ids(" DUR ", &registry).unwrap();
+
+        assert!(matching_ids.contains(&matching_id));
+        assert!(!matching_ids.contains(&non_matching_id));
+    }
+
+    #[test]
+    fn query_rejects_non_matches() {
+        assert!(!matches_name_query("status=ok", &normalized_query("warn")));
+    }
+
+    #[test]
+    fn query_state_refreshes_on_revision_change() {
+        let mut state = DefinitionQueryState {
+            query: "warn".to_owned(),
+            ..DefinitionQueryState::default()
+        };
+        let mut registry = FilterRegistry::default();
+        let first_id = add_filter_definition(&mut registry, "warn");
+
+        state.update_with_revision(registry.filter_definitions_revision(), true, |query| {
+            collect_matching_filter_ids(query, &registry)
+        });
+        assert_eq!(
+            state.matching_ids.as_ref(),
+            Some(&FxHashSet::from_iter([first_id]))
+        );
+
+        let second_id = add_filter_definition(&mut registry, "warning");
+        state.update_with_revision(registry.filter_definitions_revision(), false, |query| {
+            collect_matching_filter_ids(query, &registry)
+        });
+
+        assert_eq!(
+            state.matching_ids.as_ref(),
+            Some(&FxHashSet::from_iter([first_id, second_id]))
+        );
+
+        state.query = "   ".to_owned();
+        state.update_with_revision(registry.filter_definitions_revision(), true, |query| {
+            collect_matching_filter_ids(query, &registry)
+        });
+        assert!(state.matching_ids.is_none());
+    }
+
+    #[test]
+    fn toggle_filter_applies_and_syncs() {
+        let runtime = Runtime::new().unwrap();
+        let (library, mut cmd_rx) = new_library();
+        let mut shared = new_shared();
+        let mut actions = new_actions(&runtime);
+        let mut registry = FilterRegistry::default();
+        let filter_id = add_filter_definition(&mut registry, "status=ok");
+
+        library.toggle_filter_definition(&mut shared, &mut actions, &mut registry, filter_id);
+
+        assert!(shared.filters.is_filter_enabled(&filter_id));
+        match cmd_rx.try_recv() {
+            Ok(SessionCommand::ApplySearchFilter { filters, .. }) => {
+                assert_eq!(filters.len(), 1);
+                assert_eq!(filters[0].value, "status=ok");
+            }
+            other => panic!("expected ApplySearchFilter command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disabled_filter_toggle_unapplies() {
+        let runtime = Runtime::new().unwrap();
+        let (library, mut cmd_rx) = new_library();
+        let mut shared = new_shared();
+        let mut actions = new_actions(&runtime);
+        let mut registry = FilterRegistry::default();
+        let filter_id = add_filter_definition(&mut registry, "status=ok");
+        shared
+            .filters
+            .apply_filter_with_state(&mut registry, filter_id, false);
+
+        library.toggle_filter_definition(&mut shared, &mut actions, &mut registry, filter_id);
+
+        assert!(!shared.filters.is_filter_applied(&filter_id));
+        assert!(cmd_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn deleting_enabled_filter_syncs() {
+        let runtime = Runtime::new().unwrap();
+        let (library, mut cmd_rx) = new_library();
+        let mut shared = new_shared();
+        let mut actions = new_actions(&runtime);
+        let mut registry = FilterRegistry::default();
+        let filter_id = add_filter_definition(&mut registry, "status=ok");
+        shared.filters.apply_filter(&mut registry, filter_id);
+
+        assert!(library.delete_filter_definition(
+            &mut shared,
+            &mut actions,
+            &mut registry,
+            filter_id
+        ));
+
+        assert!(!shared.filters.is_filter_applied(&filter_id));
+        assert!(registry.get_filter(&filter_id).is_none());
+        match cmd_rx.try_recv() {
+            Ok(SessionCommand::DropSearch { operation_id }) => {
+                assert_eq!(operation_id, None);
+            }
+            other => panic!("expected DropSearch command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deleting_disabled_filter_skips_sync() {
+        let runtime = Runtime::new().unwrap();
+        let (library, mut cmd_rx) = new_library();
+        let mut shared = new_shared();
+        let mut actions = new_actions(&runtime);
+        let mut registry = FilterRegistry::default();
+        let filter_id = add_filter_definition(&mut registry, "status=ok");
+        shared
+            .filters
+            .apply_filter_with_state(&mut registry, filter_id, false);
+
+        assert!(library.delete_filter_definition(
+            &mut shared,
+            &mut actions,
+            &mut registry,
+            filter_id
+        ));
+
+        assert!(!shared.filters.is_filter_applied(&filter_id));
+        assert!(cmd_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn toggle_chart_applies_and_syncs() {
+        let runtime = Runtime::new().unwrap();
+        let (library, mut cmd_rx) = new_library();
+        let mut shared = new_shared();
+        let mut actions = new_actions(&runtime);
+        let mut registry = FilterRegistry::default();
+        let value_id = add_search_value_definition(&mut registry, "duration=(\\d+)");
+
+        library.toggle_search_value_definition(&mut shared, &mut actions, &mut registry, value_id);
+
+        assert!(shared.filters.is_search_value_enabled(&value_id));
+        match cmd_rx.try_recv() {
+            Ok(SessionCommand::ApplySearchValuesFilter { filters, .. }) => {
+                assert_eq!(filters, vec!["duration=(\\d+)".to_owned()]);
+            }
+            other => panic!("expected ApplySearchValuesFilter command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disabled_chart_toggle_unapplies() {
+        let runtime = Runtime::new().unwrap();
+        let (library, mut cmd_rx) = new_library();
+        let mut shared = new_shared();
+        let mut actions = new_actions(&runtime);
+        let mut registry = FilterRegistry::default();
+        let value_id = add_search_value_definition(&mut registry, "duration=(\\d+)");
+        shared
+            .filters
+            .apply_search_value_with_state(&mut registry, value_id, false);
+
+        library.toggle_search_value_definition(&mut shared, &mut actions, &mut registry, value_id);
+
+        assert!(!shared.filters.is_search_value_applied(&value_id));
+        assert!(cmd_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn deleting_enabled_chart_syncs() {
+        let runtime = Runtime::new().unwrap();
+        let (library, mut cmd_rx) = new_library();
+        let mut shared = new_shared();
+        let mut actions = new_actions(&runtime);
+        let mut registry = FilterRegistry::default();
+        let value_id = add_search_value_definition(&mut registry, "duration=(\\d+)");
+        shared.filters.apply_search_value(&mut registry, value_id);
+
+        assert!(library.delete_search_value_definition(
+            &mut shared,
+            &mut actions,
+            &mut registry,
+            value_id
+        ));
+
+        assert!(!shared.filters.is_search_value_applied(&value_id));
+        assert!(registry.get_search_value(&value_id).is_none());
+        match cmd_rx.try_recv() {
+            Ok(SessionCommand::DropSearchValues { operation_id }) => {
+                assert_eq!(operation_id, None);
+            }
+            other => panic!("expected DropSearchValues command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn shared_filter_cannot_be_deleted() {
+        let runtime = Runtime::new().unwrap();
+        let (library, mut cmd_rx) = new_library();
+        let mut shared = new_shared();
+        let mut actions = new_actions(&runtime);
+        let mut registry = FilterRegistry::default();
+        let filter_id = add_filter_definition(&mut registry, "status=ok");
+        shared.filters.apply_filter(&mut registry, filter_id);
+        registry.apply_filter_to_session(filter_id, Uuid::new_v4());
+
+        assert!(!library.delete_filter_definition(
+            &mut shared,
+            &mut actions,
+            &mut registry,
+            filter_id
+        ));
+
+        assert!(shared.filters.is_filter_applied(&filter_id));
+        assert!(registry.get_filter(&filter_id).is_some());
+        assert!(cmd_rx.try_recv().is_err());
+    }
+}

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/mod.rs
@@ -13,22 +13,25 @@ use crate::{
 };
 use chart::ChartUI;
 use details::DetailsUI;
+use library::LibraryUI;
 use presets::PresetsUI;
 use search::SearchUI;
 
+mod library;
+mod presets;
 mod tab_types;
 
 pub use tab_types::BottomTabType;
 
 pub mod chart;
 mod details;
-mod presets;
 mod search;
 
 #[derive(Debug)]
 pub struct BottomPanelUI {
     pub search: SearchUI,
     pub details: DetailsUI,
+    pub library: LibraryUI,
     pub presets: PresetsUI,
     pub chart: ChartUI,
 }
@@ -38,6 +41,7 @@ impl BottomPanelUI {
         Self {
             search: SearchUI::new(cmd_tx.clone(), schema),
             details: DetailsUI::default(),
+            library: LibraryUI::new(cmd_tx.clone()),
             presets: PresetsUI::new(cmd_tx.clone()),
             chart: ChartUI::new(cmd_tx),
         }
@@ -58,10 +62,11 @@ impl BottomPanelUI {
                     .render_content(shared, actions, &mut registry.filters, ui)
             }
             BottomTabType::Details => self.details.render_content(shared, ui),
-            BottomTabType::Presets => {
-                self.presets
+            BottomTabType::Library => {
+                self.library
                     .render_content(shared, actions, &mut registry.filters, ui)
             }
+            BottomTabType::Presets => self.presets.render_content(shared, actions, registry, ui),
             BottomTabType::Chart => {
                 self.chart
                     .render_content(shared, actions, &registry.filters, ui)

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/mod.rs
@@ -1,11 +1,17 @@
-use egui::{Align, Layout, RichText, ScrollArea, Ui};
+use egui::{Align, Button, Layout, Margin, RichText, ScrollArea, TextEdit, Ui, Widget, vec2};
+use processor::search::filter::SearchFilter;
+use tokio::sync::mpsc::Sender;
+use uuid::Uuid;
 
 use crate::{
     common::phosphor::icons,
-    common::validation::ValidationEligibility,
     host::ui::{
         UiActions,
-        registry::filters::{FilterDefinition, FilterRegistry},
+        registry::{
+            HostRegistry,
+            filters::{FilterDefinition, SearchValueDefinition},
+            presets::{Preset, PresetUpdateOutcome},
+        },
     },
     session::{
         command::SessionCommand,
@@ -13,229 +19,877 @@ use crate::{
     },
 };
 
-use tokio::sync::mpsc::Sender;
+use query::collect_matching_preset_ids;
 
+mod query;
+mod render;
+
+mod card_metrics {
+    pub const PRESET_CARD_WIDTH: f32 = 280.0;
+    pub const PRESET_CARD_HEIGHT: f32 = 160.0;
+    pub const PRESET_CARD_INNER_MARGIN_X: i8 = 12;
+    pub const PRESET_CARD_INNER_MARGIN_Y: i8 = 8;
+    pub const PRESET_CARD_OUTER_MARGIN_Y: i8 = 4;
+    pub const PRESET_CARD_HEADER_GAP: f32 = 4.0;
+    pub const PRESET_EDIT_ITEM_ICON_SIZE: f32 = 12.0;
+    pub const PRESET_CARD_CONTENT_WIDTH: f32 =
+        PRESET_CARD_WIDTH - (PRESET_CARD_INNER_MARGIN_X as f32 * 2.0);
+    pub const PRESET_CARD_CONTENT_HEIGHT: f32 = PRESET_CARD_HEIGHT
+        - ((PRESET_CARD_INNER_MARGIN_Y as f32 + PRESET_CARD_OUTER_MARGIN_Y as f32) * 2.0);
+}
+
+/// Immediate-mode state for the presets tab surface.
 #[derive(Debug)]
 pub struct PresetsUI {
     cmd_tx: Sender<SessionCommand>,
+    query_state: PresetQueryState,
+    edit_state: Option<PresetEditState>,
+}
+
+/// Cached name-filter state keyed by the preset catalog revision.
+#[derive(Debug, Default)]
+struct PresetQueryState {
+    query: String,
+    // `None` means the query is empty and every preset stays visible.
+    matching_ids: Option<rustc_hash::FxHashSet<Uuid>>,
+    cached_revision: u64,
+}
+
+/// Render-time metadata for a single editable preset row.
+#[derive(Debug, Clone, Copy)]
+struct PresetItemRow<'a> {
+    label: &'a str,
+    index: usize,
+    len: usize,
+}
+
+/// Logical sections shared by preset browse and edit rendering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PresetBrowseSection {
+    Filter,
+    SearchValue,
+}
+
+/// Local draft state for the single preset card currently in edit mode.
+#[derive(Debug, Clone)]
+struct PresetEditState {
+    preset_id: Uuid,
+    draft_name: String,
+    draft_filters: Vec<SearchFilter>,
+    draft_search_values: Vec<SearchFilter>,
+    // Used to autofocus the draft name exactly once when entering edit mode.
+    first_render_frame: bool,
+}
+
+/// Result of applying a preset into the current session state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PresetApplyOutcome {
+    NotFound,
+    NoChanges,
+    Applied(SearchSyncTarget),
+}
+
+/// Deferred UI intents emitted while rendering preset cards.
+#[derive(Debug, Clone)]
+enum PresetAction {
+    SaveEdit(Uuid),
+    CancelEdit(Uuid),
+    Apply(Uuid),
+    Delete(Uuid),
+    AddFilter(Uuid, SearchFilter),
+    AddSearchValue(Uuid, SearchFilter),
+    RemoveFilter(Uuid, usize),
+    RemoveSearchValue(Uuid, usize),
+    MoveFilter(Uuid, usize, usize),
+    MoveSearchValue(Uuid, usize, usize),
 }
 
 impl PresetsUI {
     pub fn new(cmd_tx: Sender<SessionCommand>) -> Self {
-        Self { cmd_tx }
+        Self {
+            cmd_tx,
+            query_state: PresetQueryState::default(),
+            edit_state: None,
+        }
     }
 
     pub fn render_content(
         &mut self,
         shared: &mut SessionShared,
         actions: &mut UiActions,
-        registry: &mut FilterRegistry,
+        registry: &mut HostRegistry,
         ui: &mut Ui,
     ) {
-        // TODO AAZ: Basic implementation for now.
-        self.render_filters_section(shared, actions, registry, ui);
-        ui.separator();
-        self.render_search_values_section(shared, actions, registry, ui);
-    }
+        self.sync_edit_state(registry);
 
-    fn render_filters_section(
-        &mut self,
-        shared: &mut SessionShared,
-        actions: &mut UiActions,
-        registry: &mut FilterRegistry,
-        ui: &mut Ui,
-    ) {
-        ui.vertical(|ui| {
-            ui.heading("Global Filter Library");
-            ui.add_space(5.0);
+        ui.allocate_ui_with_layout(
+            vec2(ui.available_width(), 23.),
+            Layout::right_to_left(Align::Center),
+            |ui| {
+                let can_create_preset = can_create_preset_from_session(shared);
+                if ui
+                    .add_enabled(
+                        can_create_preset,
+                        Button::new(RichText::new(icons::regular::PLUS).size(16.0)),
+                    )
+                    .on_hover_text("Add preset from session")
+                    .clicked()
+                {
+                    self.create_preset_from_session(shared, registry);
+                }
 
-            if registry.filters_map().is_empty() {
-                ui.label(RichText::new("No filters in library").weak());
-                return;
-            }
+                ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
+                    let query_changed = TextEdit::singleline(&mut self.query_state.query)
+                        .margin(Margin::symmetric(7, 2))
+                        .hint_text("Filter presets by name")
+                        .vertical_align(Align::Center)
+                        .min_size(ui.available_size())
+                        .ui(ui)
+                        .changed();
+                    self.query_state.update_with_revision(
+                        registry.presets.definitions_revision(),
+                        query_changed,
+                        |query| collect_matching_preset_ids(query, registry),
+                    );
 
-            ScrollArea::vertical()
-                .id_salt("presets_filters")
-                .auto_shrink(true)
-                .show(ui, |ui| {
-                    let mut to_delete = None;
+                    ui.add_space(10.0);
+                });
+            },
+        );
+        ui.add_space(8.0);
 
-                    let session_id = shared.get_id();
-                    let filters: Vec<_> = registry
-                        .filters_map()
-                        .iter()
-                        .map(|(id, def): (&uuid::Uuid, &FilterDefinition)| {
-                            (
-                                *id,
-                                def.filter.value.to_owned(),
-                                def.search_value_eligibility.clone(),
-                            )
-                        })
-                        .collect();
+        if registry.presets.presets().is_empty() {
+            ui.label(
+                RichText::new("No presets yet. Capture the current session to create one.").weak(),
+            );
+            return;
+        }
 
-                    for (id, filter_txt, eligibility) in filters {
-                        ui.horizontal(|ui| {
-                            let is_enabled = shared.filters.is_filter_enabled(&id);
-                            let is_in_session = shared.filters.is_filter_applied(&id);
-
-                            if ui.selectable_label(is_enabled, filter_txt).clicked() {
-                                if is_enabled {
-                                    shared.filters.unapply_filter(registry, &id);
-                                } else {
-                                    shared.filters.apply_filter(registry, id);
-                                }
-
-                                shared
-                                    .sync_search_pipelines(registry, SearchSyncTarget::Filter)
-                                    .into_iter()
-                                    .for_each(|cmd| {
-                                        _ = actions.try_send_command(&self.cmd_tx, cmd)
-                                    });
-                            }
-
-                            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                                let eligibility_btn = match &eligibility {
-                                    ValidationEligibility::Eligible => ui
-                                        .label(RichText::new(icons::regular::CHECK).size(12.0))
-                                        .on_hover_text("Eligible to convert into search value."),
-                                    ValidationEligibility::Ineligible { reason } => ui
-                                        .label(RichText::new(icons::regular::X).size(12.0))
-                                        .on_hover_text(reason),
-                                };
-                                eligibility_btn.on_hover_cursor(egui::CursorIcon::Help);
-
-                                let can_remove = registry.can_remove_filter(&id, &session_id);
-                                ui.add_enabled_ui(can_remove, |ui| {
-                                    let btn =
-                                        ui.button(RichText::new(icons::regular::TRASH).size(12.0));
-
-                                    let btn = if !can_remove {
-                                        let other_count = registry.filter_usage_count(&id)
-                                            - if is_in_session { 1 } else { 0 };
-                                        btn.on_disabled_hover_text(format!(
-                                            "Cannot delete: currently used in {} other session(s).",
-                                            other_count
-                                        ))
-                                    } else {
-                                        btn.on_hover_text("Delete from library")
-                                    };
-
-                                    if btn.clicked() {
-                                        to_delete = Some(id);
-                                    }
-                                });
-                            });
-                        });
-                    }
-
-                    if let Some(id) = to_delete {
-                        let was_enabled = shared.filters.is_filter_enabled(&id);
-                        registry.remove_filter(&id);
-                        shared.filters.unapply_filter(registry, &id);
-
-                        if was_enabled {
-                            shared
-                                .sync_search_pipelines(registry, SearchSyncTarget::Filter)
-                                .into_iter()
-                                .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
+        let mut pending_action = None;
+        let mut any_visible = false;
+        ScrollArea::vertical()
+            .id_salt("presets_cards")
+            // Enable on X => Scrollbar aligned on far right.
+            // Disable on Y => Avoid infinite resize when no items to show
+            // due to filters.
+            .auto_shrink([false, true])
+            .show(ui, |ui| {
+                ui.horizontal_wrapped(|ui| {
+                    for preset in registry.presets.presets() {
+                        if !self.query_state.matches(&preset.id) {
+                            continue;
                         }
+
+                        any_visible = true;
+                        self.render_preset_card(preset, registry, ui, &mut pending_action);
+                        ui.add_space(8.0);
                     }
                 });
-        });
+            });
+
+        if !any_visible {
+            ui.label(RichText::new("No presets match the current filter.").weak());
+            return;
+        }
+
+        if let Some(action) = pending_action {
+            self.handle_preset_action(action, shared, actions, registry);
+        }
     }
 
-    fn render_search_values_section(
+    fn handle_preset_action(
         &mut self,
+        action: PresetAction,
         shared: &mut SessionShared,
         actions: &mut UiActions,
-        registry: &mut FilterRegistry,
-        ui: &mut Ui,
+        registry: &mut HostRegistry,
     ) {
-        ui.vertical(|ui| {
-            ui.heading("Global Search Values Library");
-            ui.add_space(5.0);
+        match action {
+            PresetAction::SaveEdit(id) => self.save_edit(registry, id),
+            PresetAction::CancelEdit(id) => self.cancel_edit(id),
+            PresetAction::Apply(id) => {
+                let _ = self.apply_preset(shared, actions, registry, id);
+            }
+            PresetAction::Delete(id) => {
+                self.delete_preset(registry, id);
+            }
+            PresetAction::AddFilter(id, filter) => {
+                self.add_filter_to_draft(id, filter);
+            }
+            PresetAction::AddSearchValue(id, filter) => {
+                self.add_search_value_to_draft(id, filter);
+            }
+            PresetAction::RemoveFilter(id, index) => {
+                self.remove_filter_from_draft(id, index);
+            }
+            PresetAction::RemoveSearchValue(id, index) => {
+                self.remove_search_value_from_draft(id, index);
+            }
+            PresetAction::MoveFilter(id, from, to) => {
+                self.move_filter_in_draft(id, from, to);
+            }
+            PresetAction::MoveSearchValue(id, from, to) => {
+                self.move_search_value_in_draft(id, from, to);
+            }
+        }
+    }
 
-            if registry.search_value_map().is_empty() {
-                ui.label(RichText::new("No search values in library").weak());
-                return;
+    fn sync_edit_state(&mut self, registry: &HostRegistry) {
+        if self
+            .edit_state
+            .as_ref()
+            .is_some_and(|state| registry.presets.get(&state.preset_id).is_none())
+        {
+            self.edit_state = None;
+        }
+    }
+
+    fn is_editing(&self, preset_id: Uuid) -> bool {
+        self.edit_state
+            .as_ref()
+            .is_some_and(|state| state.preset_id == preset_id)
+    }
+
+    fn start_edit_from_preset(&mut self, preset: &Preset) {
+        self.edit_state = Some(PresetEditState::from_preset(preset));
+    }
+
+    fn save_edit(&mut self, registry: &mut HostRegistry, preset_id: Uuid) {
+        let Some(edit_state) = self.edit_state.as_ref() else {
+            return;
+        };
+        if edit_state.preset_id != preset_id {
+            return;
+        }
+
+        let draft_name = edit_state.draft_name.clone();
+        let draft_filters = edit_state.draft_filters.clone();
+        let draft_search_values = edit_state.draft_search_values.clone();
+        match registry.presets.update_preset(
+            preset_id,
+            draft_name,
+            draft_filters,
+            draft_search_values,
+        ) {
+            PresetUpdateOutcome::NotFound => self.sync_edit_state(registry),
+            PresetUpdateOutcome::Unchanged | PresetUpdateOutcome::Updated { .. } => {
+                self.edit_state = None;
+            }
+        }
+    }
+
+    fn cancel_edit(&mut self, preset_id: Uuid) {
+        if self
+            .edit_state
+            .as_ref()
+            .is_some_and(|state| state.preset_id == preset_id)
+        {
+            self.edit_state = None;
+        }
+    }
+
+    fn add_filter_to_draft(&mut self, preset_id: Uuid, filter: SearchFilter) -> bool {
+        let Some(edit_state) = self.edit_state.as_mut() else {
+            return false;
+        };
+        if edit_state.preset_id != preset_id || edit_state.draft_filters.contains(&filter) {
+            return false;
+        }
+
+        edit_state.draft_filters.push(filter);
+        true
+    }
+
+    fn add_search_value_to_draft(&mut self, preset_id: Uuid, search_value: SearchFilter) -> bool {
+        let Some(edit_state) = self.edit_state.as_mut() else {
+            return false;
+        };
+        if edit_state.preset_id != preset_id
+            || edit_state.draft_search_values.contains(&search_value)
+        {
+            return false;
+        }
+
+        edit_state.draft_search_values.push(search_value);
+        true
+    }
+
+    fn remove_filter_from_draft(&mut self, preset_id: Uuid, index: usize) -> bool {
+        let Some(edit_state) = self.edit_state.as_mut() else {
+            return false;
+        };
+        if edit_state.preset_id != preset_id || index >= edit_state.draft_filters.len() {
+            return false;
+        }
+
+        edit_state.draft_filters.remove(index);
+        true
+    }
+
+    fn remove_search_value_from_draft(&mut self, preset_id: Uuid, index: usize) -> bool {
+        let Some(edit_state) = self.edit_state.as_mut() else {
+            return false;
+        };
+        if edit_state.preset_id != preset_id || index >= edit_state.draft_search_values.len() {
+            return false;
+        }
+
+        edit_state.draft_search_values.remove(index);
+        true
+    }
+
+    fn move_filter_in_draft(&mut self, preset_id: Uuid, from: usize, to: usize) -> bool {
+        let Some(edit_state) = self.edit_state.as_mut() else {
+            return false;
+        };
+        if edit_state.preset_id != preset_id {
+            return false;
+        }
+
+        move_item(&mut edit_state.draft_filters, from, to)
+    }
+
+    fn move_search_value_in_draft(&mut self, preset_id: Uuid, from: usize, to: usize) -> bool {
+        let Some(edit_state) = self.edit_state.as_mut() else {
+            return false;
+        };
+        if edit_state.preset_id != preset_id {
+            return false;
+        }
+
+        move_item(&mut edit_state.draft_search_values, from, to)
+    }
+
+    fn delete_preset(&mut self, registry: &mut HostRegistry, preset_id: Uuid) -> bool {
+        if !registry.presets.remove_preset(preset_id) {
+            return false;
+        }
+
+        if self.is_editing(preset_id) {
+            self.edit_state = None;
+        }
+
+        true
+    }
+
+    fn create_preset_from_session(
+        &mut self,
+        shared: &SessionShared,
+        registry: &mut HostRegistry,
+    ) -> Uuid {
+        registry
+            .presets
+            .add_preset_from_session(shared, &registry.filters)
+    }
+
+    fn apply_preset(
+        &self,
+        shared: &mut SessionShared,
+        actions: &mut UiActions,
+        registry: &mut HostRegistry,
+        preset_id: Uuid,
+    ) -> PresetApplyOutcome {
+        let Some((filters, search_values)) = registry
+            .presets
+            .get(&preset_id)
+            .map(|preset| (preset.filters.clone(), preset.search_values.clone()))
+        else {
+            return PresetApplyOutcome::NotFound;
+        };
+
+        // Materialize preset semantics through the normal registry/session path.
+        // Existing applied rows, including disabled ones, are left as-is because
+        // dedupe reuses their ids and the applied check skips re-applying them.
+        let mut changed_filters = false;
+        for filter in filters {
+            let filter_id = registry.filters.add_filter(FilterDefinition::new(filter));
+            if shared.filters.is_filter_applied(&filter_id) {
+                continue;
             }
 
-            ScrollArea::vertical()
-                .id_salt("presets_search_values")
-                .auto_shrink(true)
-                .show(ui, |ui| {
-                    let mut to_delete = None;
-                    let session_id = shared.get_id();
-                    let values: Vec<_> = registry
-                        .search_value_map()
-                        .iter()
-                        .map(
-                            |(id, def): (
-                                &uuid::Uuid,
-                                &crate::host::ui::registry::filters::SearchValueDefinition,
-                            )| (*id, def.clone()),
-                        )
-                        .collect();
+            shared
+                .filters
+                .apply_filter(&mut registry.filters, filter_id);
+            changed_filters = true;
+        }
 
-                    for (id, search_value_def) in values {
-                        ui.horizontal(|ui| {
-                            let is_enabled = shared.filters.is_search_value_enabled(&id);
-                            let is_in_session = shared.filters.is_search_value_applied(&id);
+        let mut changed_search_values = false;
+        for search_value in search_values {
+            let value_id = registry
+                .filters
+                .add_search_value(SearchValueDefinition::new(search_value));
+            if shared.filters.is_search_value_applied(&value_id) {
+                continue;
+            }
 
-                            if ui
-                                .selectable_label(is_enabled, &search_value_def.filter.value)
-                                .clicked()
-                            {
-                                if is_enabled {
-                                    shared.filters.unapply_search_value(registry, &id);
-                                } else {
-                                    shared.filters.apply_search_value(registry, id);
-                                }
-                                shared
-                                    .sync_search_pipelines(registry, SearchSyncTarget::SearchValue)
-                                    .into_iter()
-                                    .for_each(|cmd| {
-                                        _ = actions.try_send_command(&self.cmd_tx, cmd)
-                                    });
-                            }
+            shared
+                .filters
+                .apply_search_value(&mut registry.filters, value_id);
+            changed_search_values = true;
+        }
 
-                            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                                let can_remove = registry.can_remove_search_value(&id, &session_id);
-                                ui.add_enabled_ui(can_remove, |ui| {
-                                    let btn =
-                                        ui.button(RichText::new(icons::regular::TRASH).size(12.0));
+        let outcome = match (changed_filters, changed_search_values) {
+            (false, false) => PresetApplyOutcome::NoChanges,
+            (true, false) => PresetApplyOutcome::Applied(SearchSyncTarget::Filter),
+            (false, true) => PresetApplyOutcome::Applied(SearchSyncTarget::SearchValue),
+            (true, true) => PresetApplyOutcome::Applied(SearchSyncTarget::Both),
+        };
 
-                                    let btn = if !can_remove {
-                                        let other_count = registry.search_value_usage_count(&id)
-                                            - if is_in_session { 1 } else { 0 };
-                                        btn.on_disabled_hover_text(format!(
-                                            "Cannot delete: currently used in {} other session(s).",
-                                            other_count
-                                        ))
-                                    } else {
-                                        btn.on_hover_text("Delete from library")
-                                    };
+        if let PresetApplyOutcome::Applied(target) = outcome {
+            self.dispatch_sync_commands(shared, actions, &registry.filters, target);
+        }
 
-                                    if btn.clicked() {
-                                        to_delete = Some(id);
-                                    }
-                                });
-                            });
-                        });
-                    }
+        outcome
+    }
 
-                    if let Some(id) = to_delete {
-                        let was_enabled = shared.filters.is_search_value_enabled(&id);
-                        registry.remove_search_value(&id);
-                        shared.filters.unapply_search_value(registry, &id);
-                        if was_enabled {
-                            shared
-                                .sync_search_pipelines(registry, SearchSyncTarget::SearchValue)
-                                .into_iter()
-                                .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
-                        }
-                    }
-                });
-        });
+    fn dispatch_sync_commands(
+        &self,
+        shared: &mut SessionShared,
+        actions: &mut UiActions,
+        registry: &crate::host::ui::registry::filters::FilterRegistry,
+        target: SearchSyncTarget,
+    ) {
+        // Preset apply mutates session state first, then issues the same explicit
+        // sync commands used by the rest of the search/filter UI.
+        shared
+            .sync_search_pipelines(registry, target)
+            .into_iter()
+            .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
+    }
+}
+
+fn move_item<T>(items: &mut Vec<T>, from: usize, to: usize) -> bool {
+    if from >= items.len() || to >= items.len() || from == to {
+        return false;
+    }
+
+    let item = items.remove(from);
+    items.insert(to, item);
+    true
+}
+
+fn can_create_preset_from_session(shared: &SessionShared) -> bool {
+    // Capture snapshots the full session items, not just enabled ones.
+    !shared.filters.filter_entries.is_empty() || !shared.filters.search_value_entries.is_empty()
+}
+
+impl PresetEditState {
+    fn from_preset(preset: &Preset) -> Self {
+        Self {
+            preset_id: preset.id,
+            draft_name: preset.name.clone(),
+            draft_filters: preset.filters.clone(),
+            draft_search_values: preset.search_values.clone(),
+            first_render_frame: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use tokio::{runtime::Runtime, sync::mpsc};
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::{
+        host::{
+            common::parsers::ParserNames,
+            ui::registry::{
+                HostRegistry,
+                filters::{FilterDefinition, SearchValueDefinition},
+            },
+        },
+        session::{command::SessionCommand, types::ObserveOperation, ui::SessionInfo},
+    };
+    use stypes::{FileFormat, ObserveOrigin};
+
+    fn new_presets() -> (PresetsUI, mpsc::Receiver<SessionCommand>) {
+        let (cmd_tx, cmd_rx) = mpsc::channel(8);
+        (PresetsUI::new(cmd_tx), cmd_rx)
+    }
+
+    fn new_shared() -> SessionShared {
+        let session_id = Uuid::new_v4();
+        let origin = ObserveOrigin::File(
+            "source".to_owned(),
+            FileFormat::Text,
+            PathBuf::from("source.log"),
+        );
+        let observe_op = ObserveOperation::new(Uuid::new_v4(), origin);
+        let session_info = SessionInfo {
+            id: session_id,
+            title: "test".to_owned(),
+            parser: ParserNames::Text,
+        };
+
+        SessionShared::new(session_info, observe_op)
+    }
+
+    fn new_actions(runtime: &Runtime) -> UiActions {
+        UiActions::new(runtime.handle().clone())
+    }
+
+    fn add_filter_definition(
+        registry: &mut crate::host::ui::registry::filters::FilterRegistry,
+        value: &str,
+    ) -> Uuid {
+        let definition = FilterDefinition::new(SearchFilter::plain(value).ignore_case(true));
+        let id = definition.id;
+        registry.add_filter(definition);
+        id
+    }
+
+    fn add_search_value_definition(
+        registry: &mut crate::host::ui::registry::filters::FilterRegistry,
+        value: &str,
+    ) -> Uuid {
+        let definition =
+            SearchValueDefinition::new(SearchFilter::plain(value).regex(true).ignore_case(true));
+        let id = definition.id;
+        registry.add_search_value(definition);
+        id
+    }
+
+    fn drain_commands(cmd_rx: &mut mpsc::Receiver<SessionCommand>) -> Vec<SessionCommand> {
+        let mut commands = Vec::new();
+        while let Ok(command) = cmd_rx.try_recv() {
+            commands.push(command);
+        }
+        commands
+    }
+
+    #[test]
+    fn create_requires_session_items() {
+        let mut shared = new_shared();
+        let mut registry = HostRegistry::default();
+
+        assert!(!can_create_preset_from_session(&shared));
+
+        let filter_id = add_filter_definition(&mut registry.filters, "error");
+        shared
+            .filters
+            .apply_filter(&mut registry.filters, filter_id);
+        assert!(can_create_preset_from_session(&shared));
+
+        shared
+            .filters
+            .unapply_filter(&mut registry.filters, &filter_id);
+        assert!(!can_create_preset_from_session(&shared));
+
+        let value_id = add_search_value_definition(&mut registry.filters, "duration=(\\d+)");
+        shared
+            .filters
+            .apply_search_value(&mut registry.filters, value_id);
+        assert!(can_create_preset_from_session(&shared));
+    }
+
+    #[test]
+    fn create_stays_in_browse_mode() {
+        let (mut presets, _) = new_presets();
+        let shared = new_shared();
+        let mut registry = HostRegistry::default();
+
+        let preset_id = presets.create_preset_from_session(&shared, &mut registry);
+
+        assert!(presets.edit_state.is_none());
+        assert!(registry.presets.get(&preset_id).is_some());
+    }
+
+    #[test]
+    fn delete_clears_editor() {
+        let (mut presets, _) = new_presets();
+        let mut registry = HostRegistry::default();
+        let preset_id = registry.presets.add_preset("first", vec![], vec![]);
+        presets.start_edit_from_preset(registry.presets.get(&preset_id).unwrap());
+
+        assert!(presets.delete_preset(&mut registry, preset_id));
+
+        assert!(presets.edit_state.is_none());
+    }
+
+    #[test]
+    fn edit_switches_cards() {
+        let (mut presets, _) = new_presets();
+        let mut registry = HostRegistry::default();
+        let first_id = registry.presets.add_preset("first", vec![], vec![]);
+        let second_id = registry.presets.add_preset("second", vec![], vec![]);
+        presets.start_edit_from_preset(registry.presets.get(&first_id).unwrap());
+        presets.edit_state.as_mut().unwrap().draft_name = "draft".to_owned();
+
+        presets.start_edit_from_preset(registry.presets.get(&second_id).unwrap());
+
+        let edit_state = presets.edit_state.as_ref().unwrap();
+        assert_eq!(edit_state.preset_id, second_id);
+        assert_eq!(edit_state.draft_name, "second");
+    }
+
+    #[test]
+    fn move_filter_repositions_item() {
+        let (mut presets, _) = new_presets();
+        let mut registry = HostRegistry::default();
+        let preset_id = registry.presets.add_preset(
+            "first",
+            vec![
+                SearchFilter::plain("one"),
+                SearchFilter::plain("two"),
+                SearchFilter::plain("three"),
+                SearchFilter::plain("four"),
+            ],
+            vec![],
+        );
+        presets.start_edit_from_preset(registry.presets.get(&preset_id).unwrap());
+
+        assert!(presets.move_filter_in_draft(preset_id, 1, 3));
+
+        let edit_state = presets.edit_state.as_ref().unwrap();
+        assert_eq!(
+            edit_state
+                .draft_filters
+                .iter()
+                .map(|filter| filter.value.as_str())
+                .collect::<Vec<_>>(),
+            vec!["one", "three", "four", "two"]
+        );
+    }
+
+    #[test]
+    fn cancel_discards_draft() {
+        let (mut presets, _) = new_presets();
+        let mut registry = HostRegistry::default();
+        let preset_id =
+            registry
+                .presets
+                .add_preset("first", vec![], vec![SearchFilter::plain("one")]);
+        presets.start_edit_from_preset(registry.presets.get(&preset_id).unwrap());
+        let edit_state = presets.edit_state.as_mut().unwrap();
+        edit_state.draft_name = "changed".to_owned();
+        edit_state.draft_search_values.clear();
+
+        presets.cancel_edit(preset_id);
+
+        assert!(presets.edit_state.is_none());
+        let preset = registry.presets.get(&preset_id).unwrap();
+        assert_eq!(preset.name, "first");
+        assert_eq!(preset.search_values.len(), 1);
+    }
+
+    #[test]
+    fn save_commits_draft() {
+        let (mut presets, _) = new_presets();
+        let mut registry = HostRegistry::default();
+        let first_id = registry.presets.add_preset(
+            "first",
+            vec![SearchFilter::plain("one").ignore_case(true)],
+            vec![],
+        );
+        registry.presets.add_preset("taken", vec![], vec![]);
+        registry.presets.add_preset("taken_2", vec![], vec![]);
+        presets.start_edit_from_preset(registry.presets.get(&first_id).unwrap());
+        let edit_state = presets.edit_state.as_mut().unwrap();
+        edit_state.draft_name = "taken".to_owned();
+        edit_state.draft_filters = vec![
+            SearchFilter::plain("warn").ignore_case(true),
+            SearchFilter::plain("error").ignore_case(true),
+        ];
+        edit_state.draft_search_values = vec![
+            SearchFilter::plain("duration=(\\d+)")
+                .regex(true)
+                .ignore_case(true),
+        ];
+
+        presets.save_edit(&mut registry, first_id);
+
+        let preset = registry.presets.get(&first_id).unwrap();
+        assert_eq!(preset.name, "taken_3");
+        assert_eq!(
+            preset
+                .filters
+                .iter()
+                .map(|filter| filter.value.clone())
+                .collect::<Vec<_>>(),
+            vec!["warn".to_owned(), "error".to_owned()]
+        );
+        assert_eq!(
+            preset
+                .search_values
+                .iter()
+                .map(|filter| filter.value.clone())
+                .collect::<Vec<_>>(),
+            vec!["duration=(\\d+)".to_owned()]
+        );
+        assert!(presets.edit_state.is_none());
+    }
+
+    #[test]
+    fn apply_preset_skips_existing_rows() {
+        let runtime = Runtime::new().unwrap();
+        let (presets, mut cmd_rx) = new_presets();
+        let mut shared = new_shared();
+        let mut actions = new_actions(&runtime);
+        let mut registry = HostRegistry::default();
+        let filter_id = add_filter_definition(&mut registry.filters, "error");
+        let value_id = add_search_value_definition(&mut registry.filters, "duration=(\\d+)");
+
+        shared
+            .filters
+            .apply_filter_with_state(&mut registry.filters, filter_id, false);
+        shared
+            .filters
+            .apply_search_value_with_state(&mut registry.filters, value_id, false);
+        let original_filter_colors = shared.filters.filter_entries[0].colors.clone();
+        let original_value_color = shared.filters.search_value_entries[0].color;
+        let preset_id = registry.presets.add_preset(
+            "test",
+            vec![
+                registry
+                    .filters
+                    .get_filter(&filter_id)
+                    .unwrap()
+                    .filter
+                    .clone(),
+                registry
+                    .filters
+                    .get_filter(&filter_id)
+                    .unwrap()
+                    .filter
+                    .clone(),
+            ],
+            vec![
+                registry
+                    .filters
+                    .get_search_value(&value_id)
+                    .unwrap()
+                    .filter
+                    .clone(),
+                registry
+                    .filters
+                    .get_search_value(&value_id)
+                    .unwrap()
+                    .filter
+                    .clone(),
+            ],
+        );
+
+        let outcome = presets.apply_preset(&mut shared, &mut actions, &mut registry, preset_id);
+
+        assert_eq!(outcome, PresetApplyOutcome::NoChanges);
+        assert_eq!(shared.filters.filter_entries.len(), 1);
+        assert_eq!(shared.filters.search_value_entries.len(), 1);
+        assert!(!shared.filters.filter_entries[0].enabled);
+        assert!(!shared.filters.search_value_entries[0].enabled);
+        assert_eq!(
+            shared.filters.filter_entries[0].colors,
+            original_filter_colors
+        );
+        assert_eq!(
+            shared.filters.search_value_entries[0].color,
+            original_value_color
+        );
+        assert_eq!(registry.filters.filters_map().len(), 1);
+        assert_eq!(registry.filters.search_value_map().len(), 1);
+        assert!(drain_commands(&mut cmd_rx).is_empty());
+    }
+
+    #[test]
+    fn apply_preset_appends_and_syncs() {
+        let runtime = Runtime::new().unwrap();
+        let (presets, mut cmd_rx) = new_presets();
+        let mut shared = new_shared();
+        let mut actions = new_actions(&runtime);
+        let mut registry = HostRegistry::default();
+        let existing_filter_id = add_filter_definition(&mut registry.filters, "existing");
+        let preset_id = registry.presets.add_preset(
+            "test",
+            vec![
+                SearchFilter::plain("existing").ignore_case(true),
+                SearchFilter::plain("error").ignore_case(true),
+            ],
+            vec![
+                SearchFilter::plain("duration=(\\d+)")
+                    .regex(true)
+                    .ignore_case(true),
+                SearchFilter::plain("latency=(\\d+)")
+                    .regex(true)
+                    .ignore_case(true),
+            ],
+        );
+        shared
+            .filters
+            .apply_filter(&mut registry.filters, existing_filter_id);
+
+        let outcome = presets.apply_preset(&mut shared, &mut actions, &mut registry, preset_id);
+
+        assert_eq!(outcome, PresetApplyOutcome::Applied(SearchSyncTarget::Both));
+        assert_eq!(
+            shared
+                .filters
+                .filter_entries
+                .iter()
+                .map(|item| {
+                    registry
+                        .filters
+                        .get_filter(&item.id)
+                        .unwrap()
+                        .filter
+                        .value
+                        .clone()
+                })
+                .collect::<Vec<_>>(),
+            vec!["existing".to_owned(), "error".to_owned()]
+        );
+        assert_eq!(
+            shared
+                .filters
+                .search_value_entries
+                .iter()
+                .map(|item| {
+                    registry
+                        .filters
+                        .get_search_value(&item.id)
+                        .unwrap()
+                        .filter
+                        .value
+                        .clone()
+                })
+                .collect::<Vec<_>>(),
+            vec!["duration=(\\d+)".to_owned(), "latency=(\\d+)".to_owned()]
+        );
+
+        let commands = drain_commands(&mut cmd_rx);
+        assert_eq!(commands.len(), 2);
+        match &commands[0] {
+            SessionCommand::ApplySearchFilter { filters, .. } => {
+                assert_eq!(filters.len(), 2);
+                assert_eq!(filters[0].value, "existing");
+                assert_eq!(filters[1].value, "error");
+            }
+            other => panic!("expected ApplySearchFilter command, got {other:?}"),
+        }
+        match &commands[1] {
+            SessionCommand::ApplySearchValuesFilter { filters, .. } => {
+                assert_eq!(
+                    filters,
+                    &vec!["duration=(\\d+)".to_owned(), "latency=(\\d+)".to_owned()]
+                );
+            }
+            other => panic!("expected ApplySearchValuesFilter command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_preset_handles_missing_id() {
+        let runtime = Runtime::new().unwrap();
+        let (presets, mut cmd_rx) = new_presets();
+        let mut shared = new_shared();
+        let mut actions = new_actions(&runtime);
+        let mut registry = HostRegistry::default();
+
+        let outcome =
+            presets.apply_preset(&mut shared, &mut actions, &mut registry, Uuid::new_v4());
+
+        assert_eq!(outcome, PresetApplyOutcome::NotFound);
+        assert!(drain_commands(&mut cmd_rx).is_empty());
     }
 }

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/query.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/query.rs
@@ -1,0 +1,153 @@
+//! Name-query matching and cached visibility helpers for preset cards.
+
+use rustc_hash::FxHashSet;
+use uuid::Uuid;
+
+use super::{HostRegistry, Preset, PresetQueryState};
+
+impl PresetQueryState {
+    /// Refreshes the cached visible-id set when the query or preset catalog changes.
+    pub(super) fn update_with_revision(
+        &mut self,
+        revision: u64,
+        query_changed: bool,
+        recompute_matches: impl FnOnce(&str) -> Option<FxHashSet<Uuid>>,
+    ) {
+        if query_changed || self.cached_revision != revision {
+            self.matching_ids = recompute_matches(&self.query);
+            self.cached_revision = revision;
+        }
+    }
+
+    /// Returns `true` when the preset should stay visible for the current query.
+    pub(super) fn matches(&self, preset_id: &Uuid) -> bool {
+        self.matching_ids
+            .as_ref()
+            .is_none_or(|matching_ids| matching_ids.contains(preset_id))
+    }
+}
+
+/// Normalizes user-entered query text for case-insensitive matching.
+fn normalized_query(query: &str) -> String {
+    query.trim().to_ascii_lowercase()
+}
+
+/// Returns `true` when the normalized query is empty or present in the text.
+fn matches_name_query(text: &str, normalized_query: &str) -> bool {
+    normalized_query.is_empty() || text.to_ascii_lowercase().contains(normalized_query)
+}
+
+/// Matches presets by name only; item contents do not participate in filtering.
+fn matches_preset_query(preset: &Preset, normalized_query: &str) -> bool {
+    matches_name_query(preset.name.as_str(), normalized_query)
+}
+
+/// Collects the visible preset ids for the current query.
+///
+/// Returns `None` for an empty normalized query so the caller can treat that
+/// as "show everything" without storing a full-id snapshot.
+pub(super) fn collect_matching_preset_ids(
+    query: &str,
+    registry: &HostRegistry,
+) -> Option<FxHashSet<Uuid>> {
+    let normalized_query = normalized_query(query);
+    if normalized_query.is_empty() {
+        return None;
+    }
+
+    Some(
+        registry
+            .presets
+            .presets()
+            .iter()
+            .filter_map(|preset| {
+                matches_preset_query(preset, &normalized_query).then_some(preset.id)
+            })
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use processor::search::filter::SearchFilter;
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn preset(name: &str) -> Preset {
+        Preset {
+            id: Uuid::new_v4(),
+            name: name.to_owned(),
+            filters: vec![SearchFilter::plain("filter")],
+            search_values: vec![],
+        }
+    }
+
+    #[test]
+    fn empty_query_matches_all() {
+        let preset = preset("Errors");
+
+        assert!(matches_preset_query(&preset, &normalized_query("")));
+        assert!(matches_preset_query(&preset, &normalized_query("   ")));
+    }
+
+    #[test]
+    fn query_matches_name() {
+        let preset = preset("Error Group");
+
+        assert!(matches_preset_query(&preset, &normalized_query("error")));
+    }
+
+    #[test]
+    fn empty_query_cache_is_none() {
+        let mut registry = HostRegistry::default();
+        registry.presets.add_preset("Errors", vec![], vec![]);
+
+        assert!(collect_matching_preset_ids("   ", &registry).is_none());
+    }
+
+    #[test]
+    fn query_cache_collects_matching_ids() {
+        let mut registry = HostRegistry::default();
+        let matching_id = registry.presets.add_preset("Status Errors", vec![], vec![]);
+        let non_matching_id = registry.presets.add_preset("Warnings", vec![], vec![]);
+        let matching_ids = collect_matching_preset_ids(" status ", &registry).unwrap();
+
+        assert!(matching_ids.contains(&matching_id));
+        assert!(!matching_ids.contains(&non_matching_id));
+    }
+
+    #[test]
+    fn query_ignores_items() {
+        let preset = Preset {
+            filters: vec![SearchFilter::plain("error")],
+            ..preset("Alpha")
+        };
+
+        assert!(!matches_preset_query(&preset, &normalized_query("error")));
+    }
+
+    #[test]
+    fn query_state_refreshes_on_revision_change() {
+        let mut state = PresetQueryState {
+            query: "warn".to_owned(),
+            ..PresetQueryState::default()
+        };
+        let mut registry = HostRegistry::default();
+        let first_id = registry.presets.add_preset("warn", vec![], vec![]);
+
+        state.update_with_revision(registry.presets.definitions_revision(), true, |query| {
+            collect_matching_preset_ids(query, &registry)
+        });
+        assert!(state.matches(&first_id));
+
+        let second_id = registry.presets.add_preset("warn later", vec![], vec![]);
+
+        assert!(!state.matches(&second_id));
+
+        state.update_with_revision(registry.presets.definitions_revision(), false, |query| {
+            collect_matching_preset_ids(query, &registry)
+        });
+        assert!(state.matches(&second_id));
+    }
+}

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/render.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/render.rs
@@ -1,0 +1,625 @@
+//! Preset card rendering for browse and edit modes.
+
+use egui::{
+    Align, Button, Frame, Key, Layout, Margin, RichText, ScrollArea, Sense, Sides, StrokeKind,
+    TextEdit, Ui, UiBuilder, vec2,
+};
+
+use super::{
+    HostRegistry, Preset, PresetAction, PresetBrowseSection, PresetItemRow, PresetsUI,
+    SearchFilter, card_metrics, icons,
+};
+
+impl PresetsUI {
+    /// Renders a single fixed-size preset card in browse or edit mode.
+    pub(super) fn render_preset_card(
+        &mut self,
+        preset: &Preset,
+        registry: &HostRegistry,
+        ui: &mut Ui,
+        pending_action: &mut Option<PresetAction>,
+    ) {
+        let is_editing = self.is_editing(preset.id);
+        ui.allocate_ui_with_layout(
+            vec2(
+                card_metrics::PRESET_CARD_WIDTH,
+                card_metrics::PRESET_CARD_HEIGHT,
+            ),
+            Layout::top_down(Align::Min),
+            |ui| {
+                let visuals = ui.visuals();
+                let mut frame = Frame::group(ui.style())
+                    .fill(visuals.faint_bg_color)
+                    .inner_margin(Margin::symmetric(
+                        card_metrics::PRESET_CARD_INNER_MARGIN_X,
+                        card_metrics::PRESET_CARD_INNER_MARGIN_Y,
+                    ))
+                    .outer_margin(Margin::symmetric(
+                        0,
+                        card_metrics::PRESET_CARD_OUTER_MARGIN_Y,
+                    ));
+                if is_editing {
+                    frame = frame
+                        .fill(visuals.widgets.open.bg_fill)
+                        .stroke(visuals.selection.stroke);
+                }
+
+                frame.show(ui, |ui| {
+                    // Lock the inner card size so long content cannot widen or
+                    // stretch cards inside the wrapped layout.
+                    ui.set_width(card_metrics::PRESET_CARD_CONTENT_WIDTH);
+                    ui.set_height(card_metrics::PRESET_CARD_CONTENT_HEIGHT);
+                    if is_editing {
+                        self.render_edit_header(preset.id, ui, pending_action);
+                    } else {
+                        self.render_browse_header(preset, ui, pending_action);
+                    }
+
+                    ui.add_space(card_metrics::PRESET_CARD_HEADER_GAP);
+
+                    ScrollArea::vertical()
+                        .id_salt(("preset_card_body", preset.id))
+                        .auto_shrink(false)
+                        .show(ui, |ui| {
+                            Frame::NONE
+                                .inner_margin(Margin {
+                                    left: 1,
+                                    right: 6,
+                                    top: 0,
+                                    bottom: 0,
+                                })
+                                .show(ui, |ui| {
+                                    if is_editing {
+                                        self.render_editing_body(
+                                            preset.id,
+                                            registry,
+                                            ui,
+                                            pending_action,
+                                        );
+                                    } else {
+                                        self.render_browse_body(preset, ui);
+                                    }
+                                });
+                        });
+                });
+            },
+        );
+    }
+
+    /// Renders the browse-mode header actions for a preset card.
+    fn render_browse_header(
+        &mut self,
+        preset: &Preset,
+        ui: &mut Ui,
+        pending_action: &mut Option<PresetAction>,
+    ) {
+        ui.horizontal(|ui| {
+            ui.label(RichText::new(preset.name.as_str()).strong());
+            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                if ui
+                    .button(RichText::new(icons::regular::TRASH).size(14.0))
+                    .on_hover_text("Delete preset")
+                    .clicked()
+                {
+                    *pending_action = Some(PresetAction::Delete(preset.id));
+                }
+                if ui
+                    .button(RichText::new(icons::regular::PENCIL_SIMPLE).size(14.0))
+                    .on_hover_text("Edit preset")
+                    .clicked()
+                {
+                    self.start_edit_from_preset(preset);
+                }
+                if ui
+                    .button(RichText::new(icons::regular::PLAY).size(14.0))
+                    .on_hover_text("Apply preset")
+                    .clicked()
+                {
+                    *pending_action = Some(PresetAction::Apply(preset.id));
+                }
+            });
+        });
+    }
+
+    /// Renders the read-only preset contents below the card header.
+    fn render_browse_body(&self, preset: &Preset, ui: &mut Ui) {
+        self.render_browse_section(PresetBrowseSection::Filter, &preset.filters, ui);
+        ui.separator();
+        self.render_browse_section(PresetBrowseSection::SearchValue, &preset.search_values, ui);
+    }
+
+    /// Renders one browse section and its current item list.
+    fn render_browse_section(
+        &self,
+        section: PresetBrowseSection,
+        items: &[SearchFilter],
+        ui: &mut Ui,
+    ) {
+        ui.label(section_title(section.title(), items.len()));
+
+        if items.is_empty() {
+            ui.label(RichText::new(section.empty_text()).weak());
+            return;
+        }
+
+        for item in items {
+            match section {
+                PresetBrowseSection::Filter => self.render_filter_row(ui, item),
+                PresetBrowseSection::SearchValue => self.render_search_value_row(ui, item),
+            }
+        }
+    }
+
+    /// Renders a browse row for a filter, including its semantic flags.
+    fn render_filter_row(&self, ui: &mut Ui, filter: &SearchFilter) {
+        Self::item_frame(ui).show(ui, |ui| {
+            Sides::new().shrink_left().truncate().show(
+                ui,
+                |ui| {
+                    ui.label(filter.value.as_str());
+                },
+                |ui| {
+                    self.render_filter_flag(ui, icons::regular::ASTERISK, filter.is_regex());
+                    self.render_filter_flag(ui, icons::regular::TEXT_T, filter.is_word());
+                    self.render_filter_flag(ui, icons::regular::TEXT_AA, !filter.is_ignore_case());
+                },
+            );
+        });
+    }
+
+    /// Renders a browse row for a chart/search-value entry.
+    fn render_search_value_row(&self, ui: &mut Ui, filter: &SearchFilter) {
+        Self::item_frame(ui).show(ui, |ui| {
+            Sides::new().shrink_left().truncate().show(
+                ui,
+                |ui| {
+                    ui.label(filter.value.as_str());
+                },
+                |_ui| {},
+            );
+        });
+    }
+
+    /// Returns the shared background-only row frame used across browse and edit lists.
+    fn item_frame(ui: &Ui) -> Frame {
+        Frame::new()
+            .fill(ui.visuals().panel_fill)
+            .inner_margin(Margin::symmetric(6, 4))
+    }
+
+    /// Renders a filter flag icon with active or weak emphasis.
+    fn render_filter_flag(&self, ui: &mut Ui, icon: &str, active: bool) {
+        let color = if active {
+            ui.visuals().text_color()
+        } else {
+            ui.visuals().weak_text_color()
+        };
+        ui.label(RichText::new(icon).size(12.0).color(color));
+    }
+
+    /// Renders the editable filter and chart lists for the active draft.
+    fn render_editing_body(
+        &mut self,
+        preset_id: uuid::Uuid,
+        registry: &HostRegistry,
+        ui: &mut Ui,
+        pending_action: &mut Option<PresetAction>,
+    ) {
+        let Some(edit_state) = self.edit_state.as_ref() else {
+            return;
+        };
+
+        self.render_edit_filters_section(
+            preset_id,
+            &edit_state.draft_filters,
+            registry,
+            ui,
+            pending_action,
+        );
+        ui.separator();
+        self.render_edit_search_values_section(
+            preset_id,
+            &edit_state.draft_search_values,
+            registry,
+            ui,
+            pending_action,
+        );
+    }
+
+    /// Renders the edit-mode header, including scoped save and cancel shortcuts.
+    fn render_edit_header(
+        &mut self,
+        preset_id: uuid::Uuid,
+        ui: &mut Ui,
+        pending_action: &mut Option<PresetAction>,
+    ) {
+        let Some(edit_state) = self.edit_state.as_mut() else {
+            return;
+        };
+        if edit_state.preset_id != preset_id {
+            return;
+        }
+
+        let draft_name_id = ui.id().with(("preset_edit_name", preset_id));
+        let draft_name_has_focus = ui.memory(|memory| memory.has_focus(draft_name_id));
+        let enter_pressed = ui.input_mut(|input| {
+            // Scope save to the draft-name field so other controls, including
+            // the top preset search box, do not trigger it.
+            draft_name_has_focus && input.consume_key(egui::Modifiers::NONE, Key::Enter)
+        });
+
+        ui.allocate_ui_with_layout(
+            vec2(ui.available_width(), 16.0),
+            Layout::right_to_left(Align::Center),
+            |ui| {
+                if ui
+                    .button(RichText::new(icons::regular::CHECK).size(14.0))
+                    .on_hover_text("Save preset")
+                    .clicked()
+                    || enter_pressed
+                {
+                    *pending_action = Some(PresetAction::SaveEdit(preset_id));
+                }
+
+                let mut cancel_edit = ui
+                    .button(RichText::new(icons::regular::X).size(14.0))
+                    .on_hover_text("Cancel edit")
+                    .clicked();
+
+                ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
+                    let mut text_edit = TextEdit::singleline(&mut edit_state.draft_name)
+                        .id(draft_name_id)
+                        .desired_width(f32::INFINITY)
+                        .show(ui);
+
+                    // Input text will lose focus directly on pressing escape which can
+                    // be used as indicator of escape pressed while input text in focus.
+                    let escape_pressed = text_edit.response.lost_focus()
+                        && text_edit
+                            .response
+                            .ctx
+                            .input(|input| input.key_pressed(Key::Escape));
+
+                    if escape_pressed {
+                        cancel_edit = true;
+                    }
+
+                    if edit_state.first_render_frame {
+                        // Entering edit mode should focus the draft name once,
+                        // without re-stealing focus on later frames.
+                        text_edit.state.cursor.set_char_range(None);
+                        text_edit.state.store(ui.ctx(), text_edit.response.id);
+                        text_edit.response.request_focus();
+                        edit_state.first_render_frame = false;
+                    }
+                });
+
+                if cancel_edit {
+                    *pending_action = Some(PresetAction::CancelEdit(preset_id));
+                }
+            },
+        );
+    }
+
+    /// Renders the editable filter section and its add menu.
+    fn render_edit_filters_section(
+        &self,
+        preset_id: uuid::Uuid,
+        draft_filters: &[SearchFilter],
+        registry: &HostRegistry,
+        ui: &mut Ui,
+        pending_action: &mut Option<PresetAction>,
+    ) {
+        ui.horizontal(|ui| {
+            ui.label(RichText::new(section_title("Filters", draft_filters.len())).strong());
+            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                ui.menu_button(
+                    RichText::new(icons::regular::PLUS)
+                        .size(card_metrics::PRESET_EDIT_ITEM_ICON_SIZE),
+                    |ui| {
+                        ui.set_max_width(150.0);
+                        // This allocation will happen only when the menu is opened
+                        // making it not worthy for caching optimizations.
+                        let mut filters =
+                            registry.filters.filters_map().values().collect::<Vec<_>>();
+                        // Keep the picker stable across frames instead of exposing
+                        // registry hash-map iteration order.
+                        filters.sort_unstable_by(|left, right| {
+                            let left = &left.filter;
+                            let right = &right.filter;
+                            left.value
+                                .cmp(&right.value)
+                                .then_with(|| left.is_regex().cmp(&right.is_regex()))
+                                .then_with(|| left.is_word().cmp(&right.is_word()))
+                                .then_with(|| {
+                                    (!left.is_ignore_case()).cmp(&(!right.is_ignore_case()))
+                                })
+                        });
+
+                        if filters.is_empty() {
+                            ui.label(RichText::new("No filter definitions in library").weak());
+                        }
+
+                        for definition in filters {
+                            let already_added = draft_filters.contains(&definition.filter);
+                            let response = ui
+                                .add_enabled_ui(!already_added, |ui| {
+                                    render_filter_picker_button(ui, &definition.filter)
+                                })
+                                .inner
+                                .on_disabled_hover_text("Already in preset");
+                            if response.clicked() {
+                                *pending_action = Some(PresetAction::AddFilter(
+                                    preset_id,
+                                    definition.filter.clone(),
+                                ));
+                                ui.close();
+                            }
+                        }
+                    },
+                )
+                .response
+                .on_hover_text("Add filter");
+            });
+        });
+
+        if draft_filters.is_empty() {
+            ui.label(RichText::new("No filters in this preset").weak());
+            return;
+        }
+
+        for (index, filter) in draft_filters.iter().enumerate() {
+            self.render_edit_item_row(
+                PresetItemRow {
+                    label: filter.value.as_str(),
+                    index,
+                    len: draft_filters.len(),
+                },
+                ui,
+                |from, to| PresetAction::MoveFilter(preset_id, from, to),
+                |row| PresetAction::RemoveFilter(preset_id, row),
+                pending_action,
+            );
+        }
+    }
+
+    /// Renders the editable chart section and its add menu.
+    fn render_edit_search_values_section(
+        &self,
+        preset_id: uuid::Uuid,
+        draft_search_values: &[SearchFilter],
+        registry: &HostRegistry,
+        ui: &mut Ui,
+        pending_action: &mut Option<PresetAction>,
+    ) {
+        ui.horizontal(|ui| {
+            ui.label(RichText::new(section_title("Charts", draft_search_values.len())).strong());
+            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                ui.menu_button(
+                    RichText::new(icons::regular::PLUS)
+                        .size(card_metrics::PRESET_EDIT_ITEM_ICON_SIZE),
+                    |ui| {
+                        let mut values = registry
+                            .filters
+                            .search_value_map()
+                            .values()
+                            .collect::<Vec<_>>();
+                        // Keep the picker stable across frames instead of exposing
+                        // registry hash-map iteration order.
+                        values.sort_by(|left, right| left.filter.value.cmp(&right.filter.value));
+
+                        if values.is_empty() {
+                            ui.label(RichText::new("No chart definitions in library").weak());
+                        }
+
+                        for definition in values {
+                            let already_added = draft_search_values.contains(&definition.filter);
+                            let response = ui
+                                .add_enabled(
+                                    !already_added,
+                                    Button::new(definition.filter.value.as_str()),
+                                )
+                                .on_disabled_hover_text("Already in preset");
+                            if response.clicked() {
+                                *pending_action = Some(PresetAction::AddSearchValue(
+                                    preset_id,
+                                    definition.filter.clone(),
+                                ));
+                                ui.close();
+                            }
+                        }
+                    },
+                )
+                .response
+                .on_hover_text("Add chart");
+            });
+        });
+
+        if draft_search_values.is_empty() {
+            ui.label(RichText::new("No charts in this preset").weak());
+            return;
+        }
+
+        for (index, filter) in draft_search_values.iter().enumerate() {
+            self.render_edit_item_row(
+                PresetItemRow {
+                    label: filter.value.as_str(),
+                    index,
+                    len: draft_search_values.len(),
+                },
+                ui,
+                |from, to| PresetAction::MoveSearchValue(preset_id, from, to),
+                |row| PresetAction::RemoveSearchValue(preset_id, row),
+                pending_action,
+            );
+        }
+    }
+
+    /// Renders one editable preset row and emits deferred mutations for its controls.
+    fn render_edit_item_row<FMove, FRemove>(
+        &self,
+        row: PresetItemRow<'_>,
+        ui: &mut Ui,
+        move_action: FMove,
+        remove_action: FRemove,
+        pending_action: &mut Option<PresetAction>,
+    ) where
+        FMove: Fn(usize, usize) -> PresetAction,
+        FRemove: Fn(usize) -> PresetAction,
+    {
+        Sides::new().shrink_left().truncate().show(
+            ui,
+            |ui| {
+                ui.label(row.label);
+            },
+            |ui| {
+                // Mutations are deferred until after rendering so the
+                // immediate-mode traversal does not edit the active list in place.
+                if ui
+                    .button(
+                        RichText::new(icons::regular::TRASH)
+                            .size(card_metrics::PRESET_EDIT_ITEM_ICON_SIZE),
+                    )
+                    .on_hover_text("Remove from preset")
+                    .clicked()
+                {
+                    *pending_action = Some(remove_action(row.index));
+                }
+
+                let can_move_down = row.index + 1 < row.len;
+                if ui
+                    .add_enabled(
+                        can_move_down,
+                        Button::new(
+                            RichText::new(icons::regular::CARET_DOWN)
+                                .size(card_metrics::PRESET_EDIT_ITEM_ICON_SIZE),
+                        ),
+                    )
+                    .on_hover_text("Move down")
+                    .clicked()
+                {
+                    *pending_action = Some(move_action(row.index, row.index + 1));
+                }
+
+                let can_move_up = row.index > 0;
+                if ui
+                    .add_enabled(
+                        can_move_up,
+                        Button::new(
+                            RichText::new(icons::regular::CARET_UP)
+                                .size(card_metrics::PRESET_EDIT_ITEM_ICON_SIZE),
+                        ),
+                    )
+                    .on_hover_text("Move up")
+                    .clicked()
+                {
+                    *pending_action = Some(move_action(row.index, row.index - 1));
+                }
+            },
+        );
+    }
+}
+
+impl PresetBrowseSection {
+    /// Returns the user-facing title for the browse/edit section header.
+    fn title(self) -> &'static str {
+        match self {
+            Self::Filter => "Filters",
+            Self::SearchValue => "Charts",
+        }
+    }
+
+    /// Returns the empty-state copy for the browse/edit section body.
+    fn empty_text(self) -> &'static str {
+        match self {
+            Self::Filter => "No filters in this preset",
+            Self::SearchValue => "No charts in this preset",
+        }
+    }
+}
+
+/// Formats a section header with its current item count.
+fn section_title(title: &str, count: usize) -> String {
+    format!("{title} ({count})")
+}
+
+fn render_filter_picker_button(ui: &mut Ui, filter: &SearchFilter) -> egui::Response {
+    let desired_size = vec2(ui.available_width(), ui.spacing().interact_size.y);
+    let (_, response) = ui.allocate_exact_size(desired_size, Sense::click());
+    let button_padding = ui.spacing().button_padding;
+
+    // `interact(&response)` already chose hovered/active/inactive visuals.
+    let visuals = ui.style().interact(&response);
+    let active_color = visuals.text_color();
+    let inactive_color = if response.enabled() {
+        ui.visuals().weak_text_color()
+    } else {
+        active_color.gamma_multiply(0.6)
+    };
+
+    // This guard only avoids emitting paint for rows clipped out of the menu.
+    if ui.is_rect_visible(response.rect) {
+        ui.painter().rect(
+            response.rect.expand(visuals.expansion),
+            visuals.corner_radius,
+            visuals.weak_bg_fill,
+            visuals.bg_stroke,
+            StrokeKind::Inside,
+        );
+    }
+
+    // Keep the button hitbox and hover visuals from egui while rendering the
+    // label/flags with `Sides` so the left text truncates before the icons move.
+    let mut overlay_ui = ui.new_child(
+        UiBuilder::new()
+            .max_rect(response.rect.shrink2(button_padding))
+            .layout(Layout::left_to_right(Align::Center)),
+    );
+    Sides::new().shrink_left().truncate().show(
+        &mut overlay_ui,
+        |ui| {
+            ui.label(RichText::new(filter.value.as_str()).color(active_color));
+        },
+        |ui| {
+            let icon_size = 12.0;
+            ui.label(
+                RichText::new(icons::regular::ASTERISK)
+                    .size(icon_size)
+                    .color(if filter.is_regex() {
+                        active_color
+                    } else {
+                        inactive_color
+                    }),
+            );
+            ui.label(RichText::new(icons::regular::TEXT_T).size(icon_size).color(
+                if filter.is_word() {
+                    active_color
+                } else {
+                    inactive_color
+                },
+            ));
+            ui.label(
+                RichText::new(icons::regular::TEXT_AA)
+                    .size(icon_size)
+                    .color(if !filter.is_ignore_case() {
+                        active_color
+                    } else {
+                        inactive_color
+                    }),
+            );
+        },
+    );
+
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::section_title;
+
+    #[test]
+    fn section_title_shows_count() {
+        assert_eq!(section_title("Filters", 3), "Filters (3)");
+        assert_eq!(section_title("Charts", 0), "Charts (0)");
+    }
+}

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/tab_types.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/tab_types.rs
@@ -4,6 +4,7 @@ use std::fmt::Display;
 pub enum BottomTabType {
     Search,
     Details,
+    Library,
     Presets,
     Chart,
 }
@@ -14,6 +15,7 @@ impl BottomTabType {
         match BottomTabType::Search {
             BottomTabType::Search => {}
             BottomTabType::Details => {}
+            BottomTabType::Library => {}
             BottomTabType::Presets => {}
             BottomTabType::Chart => {}
         };
@@ -21,6 +23,7 @@ impl BottomTabType {
         &[
             BottomTabType::Search,
             BottomTabType::Details,
+            BottomTabType::Library,
             BottomTabType::Presets,
             BottomTabType::Chart,
         ]
@@ -32,8 +35,28 @@ impl Display for BottomTabType {
         match self {
             BottomTabType::Search => f.write_str("Search"),
             BottomTabType::Details => f.write_str("Details"),
-            BottomTabType::Presets => f.write_str("Presets/History"),
+            BottomTabType::Library => f.write_str("Library"),
+            BottomTabType::Presets => f.write_str("Presets"),
             BottomTabType::Chart => f.write_str("Chart"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_keeps_library_order() {
+        assert_eq!(
+            BottomTabType::all(),
+            &[
+                BottomTabType::Search,
+                BottomTabType::Details,
+                BottomTabType::Library,
+                BottomTabType::Presets,
+                BottomTabType::Chart,
+            ]
+        );
     }
 }

--- a/application/apps/indexer/gui/application/src/session/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/mod.rs
@@ -1,7 +1,6 @@
 use std::rc::Rc;
 
 use egui::{CentralPanel, Frame, Margin, SidePanel, TopBottomPanel, Ui};
-use shared::SessionShared;
 use tokio::sync::mpsc::Sender;
 
 use crate::{
@@ -40,7 +39,7 @@ mod side_panel;
 mod status_bar;
 
 pub use bottom_panel::chart;
-pub use shared::SessionInfo;
+pub use shared::{SessionInfo, SessionShared};
 
 #[derive(Debug)]
 pub struct Session {
@@ -144,14 +143,16 @@ impl Session {
                 bottom_panel.render_content(shared, actions, registry, ui);
             });
 
-        CentralPanel::default().show_inside(ui, |ui| {
-            // We need to give a unique id for the direct parent of each table because
-            // they will be used as identifiers for table state to avoid ID clashes between
-            // tables from different tabs (different sessions).
-            ui.push_id(shared.get_id(), |ui| {
-                logs_table.render_content(shared, actions, ui);
+        CentralPanel::default()
+            .frame(Frame::central_panel(ui.style()).inner_margin(Margin::symmetric(4, 0)))
+            .show_inside(ui, |ui| {
+                // We need to give a unique id for the direct parent of each table because
+                // they will be used as identifiers for table state to avoid ID clashes between
+                // tables from different tabs (different sessions).
+                ui.push_id(shared.get_id(), |ui| {
+                    logs_table.render_content(shared, actions, ui);
+                });
             });
-        });
 
         self.handle_signals();
     }


### PR DESCRIPTION
This PR:
* Introduce two tabs to manage filters and charts.
* First tab is Library tab as global registry for filters and charts from all session where users can apply any of them directly without having to define a preset.
* Second tab is Presets which allow users to define their presets giving them names and enabling them for edit the presets.
* Sessions will reference library items while presets will be applied as copied to the sessions.
* Multiple refactoring and UI improvements