### PR TITLE
Native: Fixes & Refactoring for home view

### DIFF
--- a/application/apps/indexer/gui/application/src/host/ui/home/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/mod.rs
@@ -5,8 +5,8 @@ use crate::host::{
     notification::AppNotification,
     ui::{
         APP_SETTINGS, UiActions,
-        home::settings::{FavoriteFolder, HomeSettings, SessionConfig},
         actions::FileDialogOptions,
+        home::state::{FavoriteFolder, HomeUiState, SessionConfig},
     },
 };
 use egui::{Align, Button, CentralPanel, CollapsingHeader, Layout, RichText, SidePanel, Ui};
@@ -14,76 +14,69 @@ use tokio::sync::mpsc::Sender;
 
 use std::{env, mem::take, path::PathBuf};
 
-pub mod settings;
+pub mod state;
 
 const ACTION_FILES_ID: &str = "action_files";
 const FAVORITES_FOLDER_ID: &str = "favorites_folder";
 
 #[derive(Debug)]
-pub struct HomeScreen {
-    pub home_settings: HomeSettings,
+pub struct HomeView {
+    pub state: HomeUiState,
     pub data_path: PathBuf,
     cmd_tx: Sender<HostCommand>,
 }
 
-impl HomeScreen {
+impl HomeView {
     pub fn new(cmd_tx: Sender<HostCommand>) -> Self {
         let dir = env::current_dir().expect("Failed to get current working directory");
         let path = dir.join(APP_SETTINGS);
-        let state = HomeSettings::load(&path).unwrap_or_default();
+        let state = HomeUiState::load(&path);
 
-        HomeScreen {
-            home_settings: state,
+        HomeView {
+            state,
             data_path: path,
             cmd_tx,
         }
     }
 
     pub fn save(&self) {
-        self.home_settings.save(&self.data_path);
+        if let Err(err) = self.state.save(&self.data_path) {
+            log::error!("Failed to persist home UI state: {err:#}");
+        }
     }
 
     pub fn render_content(&mut self, actions: &mut UiActions, ui: &mut Ui) {
-        ui.centered_and_justified(|ui| {
-            home_screen(ui, actions, &mut self.home_settings, &self.cmd_tx);
+        let Self { state, cmd_tx, .. } = self;
+
+        SidePanel::left("quick actions")
+            .width_range(50.0..=150.0)
+            .default_width(100.)
+            .resizable(true)
+            .show_inside(ui, |ui| {
+                ui.with_layout(Layout::top_down_justified(Align::LEFT), |ui| {
+                    draw_quick_actions(ui, actions, cmd_tx);
+                });
+            });
+
+        SidePanel::right("favorite folders")
+            .width_range(250.0..=750.0)
+            .default_width(350.)
+            .resizable(true)
+            .show_inside(ui, |ui| {
+                ui.with_layout(Layout::top_down_justified(Align::LEFT), |ui| {
+                    ui.add_space(5.0);
+                    ui.heading("Favorite folders");
+                    draw_favorite_folders(ui, actions, state, cmd_tx);
+                });
+            });
+
+        CentralPanel::default().show_inside(ui, |ui| {
+            ui.with_layout(Layout::top_down_justified(Align::LEFT), |ui| {
+                ui.heading("Recently opened");
+                draw_recent_sessions(ui, actions, state, cmd_tx);
+            });
         });
     }
-}
-
-pub fn home_screen(
-    ui: &mut egui::Ui,
-    actions: &mut UiActions,
-    state: &mut HomeSettings,
-    cmd_tx: &Sender<HostCommand>,
-) {
-    SidePanel::left("quick actions")
-        .width_range(50.0..=150.0)
-        .default_width(100.)
-        .resizable(true)
-        .show_inside(ui, |ui| {
-            ui.with_layout(Layout::top_down_justified(Align::LEFT), |ui| {
-                draw_quick_actions(ui, actions, cmd_tx);
-            });
-        });
-
-    SidePanel::right("favorite folders")
-        .width_range(250.0..=750.0)
-        .default_width(350.)
-        .resizable(true)
-        .show_inside(ui, |ui| {
-            ui.with_layout(Layout::top_down_justified(Align::LEFT), |ui| {
-                ui.add_space(5.0);
-                ui.heading("Favorite folders");
-                draw_favorite_folders(ui, actions, state, cmd_tx);
-            });
-        });
-
-    CentralPanel::default().show_inside(ui, |ui| {
-        ui.with_layout(Layout::top_down_justified(Align::LEFT), |ui| {
-            ui.heading("Recently opened");
-            draw_recent_sessions(ui, actions, state, cmd_tx);
-        });
-    });
 }
 
 pub fn draw_quick_actions(
@@ -181,7 +174,7 @@ fn action_button(
 fn draw_recent_sessions(
     ui: &mut egui::Ui,
     actions: &mut UiActions,
-    state: &mut HomeSettings,
+    state: &mut HomeUiState,
     cmd_tx: &Sender<HostCommand>,
 ) {
     egui::ScrollArea::vertical()
@@ -286,6 +279,7 @@ fn open_new_configuration(
             actions.try_send_command(cmd_tx, cmd);
         }
         Err(err) => {
+            log::warn!("Failed to open new configuration from Home view: {err}");
             actions.add_notification(AppNotification::Error(format!("{}", err)));
         }
     }
@@ -302,6 +296,7 @@ fn open_previous_configuration(
             actions.try_send_command(cmd_tx, cmd);
         }
         Err(err) => {
+            log::warn!("Failed to open previous configuration from Home view: {err}");
             actions.add_notification(AppNotification::Error(format!("{}", err)));
         }
     }
@@ -310,7 +305,7 @@ fn open_previous_configuration(
 fn draw_favorite_folders(
     ui: &mut egui::Ui,
     actions: &mut UiActions,
-    state: &mut HomeSettings,
+    state: &mut HomeUiState,
     cmd_tx: &Sender<HostCommand>,
 ) {
     if let Some(paths) = actions.file_dialog.take_output(FAVORITES_FOLDER_ID) {
@@ -337,8 +332,7 @@ fn draw_favorite_folders(
                 {
                     actions.file_dialog.pick_folder(
                         FAVORITES_FOLDER_ID,
-                        FileDialogOptions::new()
-                            .title("Select Favorites Folder")
+                        FileDialogOptions::new().title("Select Favorites Folder"),
                     );
                 }
 
@@ -398,9 +392,10 @@ fn draw_favorite_folders(
                             remove_path = Some(folder.path.clone());
                         }
 
-                        for (file_name, size_info) in &folder.files {
+                        for file in &folder.files {
                             if !state.favorite_search.is_empty()
-                                && !file_name
+                                && !file
+                                    .name
                                     .to_lowercase()
                                     .contains(&state.favorite_search.to_lowercase())
                             {
@@ -416,14 +411,14 @@ fn draw_favorite_folders(
                                         )
                                         .small(),
                                     )
-                                    .on_hover_text(format!("Open file ({})", size_info))
+                                    .on_hover_text(format!("Open file ({})", file.size_txt))
                                     .clicked()
                                 {
-                                    let param = [folder.path.join(file_name)].to_vec();
+                                    let param = [folder.path.join(&file.name)].to_vec();
                                     let cmd = HostCommand::OpenFiles(param);
                                     actions.try_send_command(cmd_tx, cmd);
                                 }
-                                ui.label(file_name);
+                                ui.label(&file.name);
                             });
                         }
                     });

--- a/application/apps/indexer/gui/application/src/host/ui/home/state.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/state.rs
@@ -1,9 +1,12 @@
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::{fmt, fs, path::PathBuf};
+use std::{fmt, fs, io::ErrorKind, mem, path::PathBuf};
 use stypes::{FileFormat, ObserveOptions, ObserveOrigin, ParserType, Transport};
 
+use crate::host::common::file_utls;
+
 #[derive(Serialize, Deserialize, Default, Debug)]
-pub struct HomeSettings {
+pub struct HomeUiState {
     pub recent_sessions: Vec<RecentSession>,
     pub favorite_folders: Vec<FavoriteFolder>,
 
@@ -13,31 +16,70 @@ pub struct HomeSettings {
     pub favorite_collapse: bool,
 }
 
-impl HomeSettings {
-    pub fn load(path: &std::path::Path) -> Option<Self> {
-        if let Ok(data) = fs::read_to_string(path) {
-            let mut settings: HomeSettings = serde_json::from_str(&data).unwrap_or_default();
-            settings.update_configurations();
-            settings.update_favorites();
-            Some(settings)
-        } else {
-            None
-        }
+impl HomeUiState {
+    pub fn load(path: &std::path::Path) -> Self {
+        let data = match fs::read_to_string(path) {
+            Ok(data) => data,
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                return Self::default();
+            }
+            Err(err) => {
+                log::error!(
+                    "Failed to read home UI state from {}: {err}",
+                    path.display()
+                );
+                return Self::default();
+            }
+        };
+
+        let mut settings = match serde_json::from_str::<HomeUiState>(&data) {
+            Ok(settings) => settings,
+            Err(err) => {
+                log::error!(
+                    "Failed to parse home UI state from {}: {err}",
+                    path.display()
+                );
+                return Self::default();
+            }
+        };
+
+        settings.update_configurations();
+        settings.update_favorites();
+        settings
     }
 
-    pub fn save(&self, path: &std::path::Path) {
-        if let Ok(data) = serde_json::to_string_pretty(self) {
-            let _ = fs::write(path, data);
-        }
+    pub fn save(&self, path: &std::path::Path) -> Result<()> {
+        let data =
+            serde_json::to_string_pretty(self).context("Failed to serialize home UI state")?;
+        fs::write(path, data)
+            .with_context(|| format!("Failed to write home UI state to {}", path.display()))
     }
 
     pub fn update_configurations(&mut self) {
-        for session in &mut self.recent_sessions {
-            session.configurations.retain(|cfg| cfg.validate().is_ok());
-        }
+        self.recent_sessions.retain_mut(|session| {
+            let mut valid_configurations = Vec::with_capacity(session.configurations.len());
+            let mut invalid_details = Vec::new();
 
-        self.recent_sessions
-            .retain(|session| !session.configurations.is_empty());
+            for config in mem::take(&mut session.configurations) {
+                match config.validate() {
+                    Ok(()) => valid_configurations.push(config),
+                    Err(err) => invalid_details.push(format!("{config}: {err}")),
+                }
+            }
+
+            session.configurations = valid_configurations;
+
+            if !invalid_details.is_empty() {
+                let invalid_count = invalid_details.len();
+                log::warn!(
+                    "Removed {invalid_count} invalid recent configuration(s) from session \"{}\": {}",
+                    session.title,
+                    invalid_details.join("; ")
+                );
+            }
+
+            !session.configurations.is_empty()
+        });
     }
 
     pub fn update_favorites(&mut self) {
@@ -59,21 +101,13 @@ pub struct RecentSession {
 impl RecentSession {
     /// Get a template for a new configuration, if supported.
     pub fn new_configuration(&self) -> Option<&SessionConfig> {
-        if let Some(cfg) = self.configurations.first() {
-            return match &cfg.options.origin {
-                ObserveOrigin::File(_, format, _) => {
-                    if *format == FileFormat::Text {
-                        None
-                    } else {
-                        Some(cfg)
-                    }
-                }
-                ObserveOrigin::Concat(_) => Some(cfg),
-                ObserveOrigin::Stream(_, _) => None,
-            };
-        }
-
-        None
+        self.configurations
+            .first()
+            .and_then(|cfg| match &cfg.options.origin {
+                ObserveOrigin::File(_, format, _) if *format == FileFormat::Text => None,
+                ObserveOrigin::File(..) | ObserveOrigin::Concat(..) => Some(cfg),
+                ObserveOrigin::Stream(..) => None,
+            })
     }
 }
 
@@ -242,7 +276,19 @@ pub struct FavoriteFolder {
     pub path: PathBuf,
 
     #[serde(skip)]
-    pub files: Vec<(String, String)>,
+    pub files: Vec<FileUiInfo>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FileUiInfo {
+    pub name: String,
+    pub size_txt: String,
+}
+
+impl FileUiInfo {
+    fn new(name: String, size_txt: String) -> Self {
+        Self { name, size_txt }
+    }
 }
 
 impl FavoriteFolder {
@@ -256,25 +302,55 @@ impl FavoriteFolder {
     pub fn scan(&mut self) {
         self.files.clear();
 
-        if let Ok(entries) = std::fs::read_dir(&self.path) {
-            for entry in entries.flatten() {
-                if let Ok(metadata) = entry.metadata() {
-                    if metadata.file_type().is_symlink() {
-                        continue;
-                    }
+        let entries = match std::fs::read_dir(&self.path) {
+            Ok(entries) => entries,
+            Err(err) => {
+                log::error!(
+                    "Failed to scan favorite folder {}: {err}",
+                    self.path.display()
+                );
+                return;
+            }
+        };
 
-                    if metadata.is_file() {
-                        let file_name = entry.file_name().to_string_lossy().to_string();
-                        if file_name.starts_with('.') {
-                            continue;
-                        }
-
-                        let size = metadata.len();
-                        let size_info = file_size(size);
-
-                        self.files.push((file_name, size_info));
-                    }
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(err) => {
+                    log::warn!(
+                        "Failed to read an entry in favorite folder {}: {err}",
+                        self.path.display()
+                    );
+                    continue;
                 }
+            };
+
+            let metadata = match entry.metadata() {
+                Ok(metadata) => metadata,
+                Err(err) => {
+                    log::warn!(
+                        "Failed to read metadata for {} while scanning favorite folder {}: {err}",
+                        entry.path().display(),
+                        self.path.display()
+                    );
+                    continue;
+                }
+            };
+
+            if metadata.file_type().is_symlink() {
+                continue;
+            }
+
+            if metadata.is_file() {
+                let file_name = entry.file_name().to_string_lossy().to_string();
+                if file_name.starts_with('.') {
+                    continue;
+                }
+
+                let size = metadata.len();
+                let size_info = file_utls::format_file_size(size);
+
+                self.files.push(FileUiInfo::new(file_name, size_info));
             }
         }
     }
@@ -285,25 +361,4 @@ fn file_name(path: &PathBuf) -> String {
         .and_then(|f| f.to_str())
         .map(|s| s.to_string())
         .unwrap_or_else(|| format!("{:?}", path))
-}
-
-fn file_size(bytes: u64) -> String {
-    const KB: f64 = 1024.0;
-    const MB: f64 = KB * 1024.0;
-    const GB: f64 = MB * 1024.0;
-    const TB: f64 = GB * 1024.0;
-
-    let bytes = bytes as f64;
-
-    if bytes >= TB {
-        format!("{:.2} TB", bytes / TB)
-    } else if bytes >= GB {
-        format!("{:.2} GB", bytes / GB)
-    } else if bytes >= MB {
-        format!("{:.2} MB", bytes / MB)
-    } else if bytes >= KB {
-        format!("{:.2} KB", bytes / KB)
-    } else {
-        format!("{} B", bytes as u64)
-    }
 }

--- a/application/apps/indexer/gui/application/src/host/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/mod.rs
@@ -21,7 +21,7 @@ use crate::{
         message::HostMessage,
         service::HostService,
         ui::{
-            home::HomeScreen,
+            home::HomeView,
             notification::NotificationUi,
             session_setup::state::{
                 parsers::ParserConfig,
@@ -256,7 +256,7 @@ impl Host {
         } = state;
 
         match active_tab {
-            TabType::Home => self.state.home_screen.render_content(ui_actions, ui),
+            TabType::Home => self.state.home_view.render_content(ui_actions, ui),
             TabType::Session(id) => sessions
                 .get_mut(&id)
                 .expect("Session with provieded ID from active tab must exist")
@@ -366,7 +366,7 @@ impl eframe::App for Host {
 
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
         trace!("App Shutdown requested.");
-        self.state.home_screen.save();
+        self.state.home_view.save();
 
         let (confirm_tx, confirm_rx) = std::sync::mpsc::channel();
         let cmd = HostCommand::OnShutdown { confirm_tx };

--- a/application/apps/indexer/gui/application/src/host/ui/state/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/state/mod.rs
@@ -10,8 +10,8 @@ use crate::{
     host::{
         command::HostCommand,
         ui::{
-            HomeScreen, UiActions,
-            home::settings::RecentSession,
+            HomeView, UiActions,
+            home::state::RecentSession,
             multi_setup::{MultiFileSetup, state::MultiFileState},
             registry::HostRegistry,
             session_setup::{SessionSetup, state::SessionSetupState},
@@ -26,7 +26,7 @@ const MAX_RECENT_SESSIONS: usize = 100;
 
 #[derive(Debug)]
 pub struct HostState {
-    pub home_screen: HomeScreen,
+    pub home_view: HomeView,
     pub active_tab_idx: usize,
     pub tabs: Vec<TabType>,
     pub sessions: FxHashMap<Uuid, Session>,
@@ -49,7 +49,7 @@ pub struct PanelsVisibility {
 impl HostState {
     pub fn new(cmd_tx: Sender<HostCommand>) -> Self {
         Self {
-            home_screen: HomeScreen::new(cmd_tx),
+            home_view: HomeView::new(cmd_tx),
             active_tab_idx: 0,
             tabs: vec![TabType::Home],
             sessions: FxHashMap::default(),
@@ -77,7 +77,7 @@ impl HostState {
     ) {
         if let Some(config) = &session.session_config {
             let now = Utc::now().timestamp() as u64;
-            let recent = &mut self.home_screen.home_settings.recent_sessions;
+            let recent = &mut self.home_view.state.recent_sessions;
 
             if let Some(entry) = recent
                 .iter_mut()

--- a/application/apps/indexer/gui/application/src/host/ui/tabs.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/tabs.rs
@@ -22,7 +22,7 @@ pub enum TabType {
 
 pub fn render_all_tabs(state: &mut HostState, actions: &mut UiActions, ui: &mut Ui) {
     let HostState {
-        home_screen: _,
+        home_view: _,
         active_tab_idx,
         tabs,
         sessions,

--- a/application/apps/indexer/gui/application/src/session/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/mod.rs
@@ -3,7 +3,7 @@
 use stypes::ComputationError;
 
 use crate::{
-    host::ui::home::settings::SessionConfig,
+    host::ui::home::state::SessionConfig,
     session::{communication::UiHandle, types::ObserveOperation, ui::SessionInfo},
 };
 

--- a/application/apps/indexer/gui/application/src/session/service/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/service/mod.rs
@@ -15,7 +15,7 @@ use crate::{
         notification::AppNotification,
         service::file::get_file_format,
         ui::{
-            home::settings::SessionConfig,
+            home::state::SessionConfig,
             session_setup::state::{
                 SessionSetupState,
                 parsers::ParserConfig,


### PR DESCRIPTION
* Rename home setting to home state & Home screen to home view.
* Introduce Names struct instead of tuples.
* Use global formatting function removing duplications.
* Log errors instead of swallowing them silently.
* Small refactoring to avoid large if let blocks.