### PR TITLE
Text: Fix skipping last line with no break-line

### DIFF
--- a/application/apps/indexer/parsers/src/text.rs
+++ b/application/apps/indexer/parsers/src/text.rs
@@ -43,10 +43,11 @@ impl SingleParser for StringTokenizer {
             };
             ParseOutput::new(msg_size + 1, Some(string_msg.into()))
         } else {
+            let content = String::from_utf8_lossy(input);
             ParseOutput::new(
                 input.len(),
                 Some(ParseYield::from(StringMessage {
-                    content: String::new(),
+                    content: content.to_string(),
                 })),
             )
         };
@@ -103,5 +104,20 @@ mod tests {
             _ => panic!("Second message did not match"),
         }
         assert!(items_iter.next().is_none());
+    }
+
+    #[test]
+    fn trailing_line_without_newline() {
+        let mut parser = StringTokenizer {};
+        let content = b"{\"key\":\"value\"}";
+
+        let out = parser.parse_item(content, None).unwrap();
+
+        match out.message {
+            Some(ParseYield::Message(StringMessage { content }))
+                if content.eq("{\"key\":\"value\"}") => {}
+            _ => panic!("Trailing line did not match"),
+        }
+        assert_eq!(out.consumed, content.len());
     }
 }

--- a/application/apps/indexer/processor/src/producer/tests/single_parse.rs
+++ b/application/apps/indexer/processor/src/producer/tests/single_parse.rs
@@ -1,13 +1,16 @@
 //! Tests for parsers returning single value always
 
-use std::collections::VecDeque;
+use std::{collections::VecDeque, io::Cursor};
 
 use super::mock_byte_source::*;
 use super::mock_parser::*;
 use super::*;
 
-use parsers::{Error as ParseError, ParseYield};
-use sources::Error;
+use parsers::{
+    Error as ParseError, ParseYield,
+    text::{StringMessage, StringTokenizer},
+};
+use sources::{Error, binary::raw::BinaryByteSource};
 
 use crate::producer::MessageProducer;
 
@@ -44,6 +47,38 @@ async fn byte_source_fail() {
     assert!(res.is_err_and(|err| matches!(err, ProduceError::SourceError(..))));
 
     assert!(collector.get_records().is_empty());
+}
+
+#[tokio::test]
+async fn text_keeps_unterminated_line() {
+    let parser = StringTokenizer {};
+    let source = BinaryByteSource::new(Cursor::new(b"{\"key\":\"value\"}".to_vec()));
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::<StringMessage>::default();
+
+    let summary = producer.produce_next(&mut collector).await.unwrap();
+    match summary {
+        ProduceSummary::Processed {
+            bytes_consumed,
+            messages_count,
+            skipped_bytes,
+        } => {
+            assert_eq!(messages_count, 1);
+            assert_eq!(bytes_consumed, 15);
+            assert_eq!(skipped_bytes, 0);
+        }
+        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+            panic!("Summary should be Processed but got {summary:?}");
+        }
+    }
+
+    let records = collector.get_records();
+    assert_eq!(records.len(), 1);
+    let ParseYield::Message(message) = &records[0] else {
+        panic!("Expected one text message");
+    };
+    assert_eq!(message.to_string(), "{\"key\":\"value\"}");
 }
 
 #[tokio::test]


### PR DESCRIPTION
This PR closes #2519 

* Fix skipping the last line if it doesn't end with a break-line char for text parser.
* Add unit tests to cover this case