### PR TITLE
Native: Use `nucleo` for UI quick filtering & Add search for recent sessions

### DIFF
--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -79,6 +79,7 @@ chrono-tz = "0.8"
 serialport = "4.8"
 rustc-hash = "2.1"
 enum-iterator = "2"
+nucleo-matcher = "0.3"
 
 clap = { version = "4", features = ["derive"] }
 

--- a/application/apps/indexer/gui/application/Cargo.toml
+++ b/application/apps/indexer/gui/application/Cargo.toml
@@ -45,6 +45,7 @@ regex.workspace = true
 regex-syntax.workspace = true
 enum-iterator.workspace = true
 blake3.workspace = true
+nucleo-matcher.workspace = true
 
 #TODO: Replace env logger with log4rs
 env_logger.workspace = true

--- a/application/apps/indexer/gui/application/src/common/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/common/ui/mod.rs
@@ -1,2 +1,3 @@
 pub mod buttons;
+pub mod substring_matcher;
 pub mod tab_strip;

--- a/application/apps/indexer/gui/application/src/common/ui/substring_matcher.rs
+++ b/application/apps/indexer/gui/application/src/common/ui/substring_matcher.rs
@@ -1,0 +1,121 @@
+//! Case-insensitive literal substring matching for small UI-side filters.
+//!
+//! This wraps `nucleo-matcher` behind a tiny API suited for egui state.
+//! Queries are built explicitly on text changes and reused during row matching.
+
+use std::ops::Not;
+
+use nucleo_matcher::{
+    Matcher, Utf32Str,
+    pattern::{Atom, AtomKind, CaseMatching, Normalization},
+};
+
+/// Reusable case-insensitive literal substring matcher for UI text filtering.
+#[derive(Debug, Clone, Default)]
+pub struct SubstringMatcher {
+    matcher: Matcher,
+    query: Option<Atom>,
+    text_buf: Vec<char>,
+}
+
+impl SubstringMatcher {
+    /// Rebuilds the compiled query for subsequent literal substring matches.
+    ///
+    /// Passing an empty string clears the current query and resets the matcher.
+    ///
+    /// # Note:
+    /// Call this when the user-entered query changes, not on every frame.
+    pub fn build_query(&mut self, query: &str) {
+        self.query = query.is_empty().not().then(|| {
+            Atom::new(
+                query,
+                CaseMatching::Ignore,
+                Normalization::Never,
+                AtomKind::Substring,
+                false,
+            )
+        });
+    }
+
+    /// Returns whether a non-empty query is currently built.
+    pub fn has_query(&self) -> bool {
+        self.query.is_some()
+    }
+
+    /// Returns whether `text` matches the current query.
+    ///
+    /// An empty query matches all input text.
+    pub fn matches(&mut self, text: &str) -> bool {
+        let Some(query) = self.query.as_ref() else {
+            return true;
+        };
+
+        query
+            .score(Utf32Str::new(text, &mut self.text_buf), &mut self.matcher)
+            .is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SubstringMatcher;
+
+    #[test]
+    fn empty_query_matches_all_text() {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query("");
+
+        assert!(!matcher.has_query());
+        assert!(matcher.matches("alpha"));
+        assert!(matcher.matches(""));
+    }
+
+    #[test]
+    fn matches_literal_substring_ignoring_case() {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query("Err");
+
+        assert!(matcher.has_query());
+        assert!(matcher.matches("status error"));
+        assert!(!matcher.matches("warning"));
+    }
+
+    #[test]
+    fn treats_special_characters_as_literal_text() {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query("^foo");
+
+        assert!(matcher.matches("xx^FoObar"));
+        assert!(!matcher.matches("xxfoobar"));
+    }
+
+    #[test]
+    fn does_not_trim_whitespace_queries() {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query(" ");
+
+        assert!(matcher.has_query());
+        assert!(matcher.matches("a b"));
+        assert!(!matcher.matches("ab"));
+    }
+
+    #[test]
+    fn supports_unicode_case_insensitive_matching() {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query("ä");
+
+        assert!(matcher.matches("xxÄyy"));
+        assert!(!matcher.matches("xxyy"));
+    }
+
+    #[test]
+    fn replaces_previous_query() {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query("foo");
+        assert!(matcher.matches("foo"));
+
+        matcher.build_query("bar");
+        assert!(!matcher.matches("foo"));
+        assert!(matcher.matches("bar"));
+    }
+}

--- a/application/apps/indexer/gui/application/src/host/common/app_style.rs
+++ b/application/apps/indexer/gui/application/src/host/common/app_style.rs
@@ -44,6 +44,11 @@ fn apply_global_color_styles(visuals: &mut Visuals) {
         accent_bg.gamma_multiply(0.9)
     };
 
+    // `faint_bg_color` should be darker than the general background in light mode.
+    if !dark_mode {
+        visuals.faint_bg_color = egui::Color32::from_gray(246);
+    }
+
     visuals.selection.bg_fill = active_fill;
     visuals.selection.stroke.color = accent_stroke;
 

--- a/application/apps/indexer/gui/application/src/host/service/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/service/mod.rs
@@ -269,7 +269,10 @@ impl HostService {
             FileFormat::Text => ParserConfig::Text,
             FileFormat::Binary => {
                 if Self::is_dlt_file(&file_path) {
-                    ParserConfig::Dlt(DltParserConfig::new(true, Some(vec![file_path.clone()])))
+                    ParserConfig::Dlt(Box::new(DltParserConfig::new(
+                        true,
+                        Some(vec![file_path.clone()]),
+                    )))
                 } else {
                     return Err(HostError::InitSessionError(InitSessionError::Other(
                         format!(
@@ -448,7 +451,7 @@ impl HostService {
                         }
                         _ => {}
                     }
-                    ParserConfig::Dlt(DltParserConfig::new(true, Some(files.clone())))
+                    ParserConfig::Dlt(Box::new(DltParserConfig::new(true, Some(files.clone()))))
                 }
             };
 
@@ -522,7 +525,7 @@ impl HostService {
         };
 
         let parser = match parser {
-            ParserNames::Dlt => ParserConfig::Dlt(DltParserConfig::new(false, None)),
+            ParserNames::Dlt => ParserConfig::Dlt(Box::new(DltParserConfig::new(false, None))),
             ParserNames::SomeIP => ParserConfig::SomeIP(SomeIpParserConfig::default()),
             ParserNames::Text => ParserConfig::Text,
             ParserNames::Plugins => todo!(),
@@ -717,10 +720,18 @@ impl HostService {
 
         let parser = match parser {
             ParserConfig::Dlt(config) => {
+                let DltParserConfig {
+                    with_storage_header,
+                    log_level,
+                    fibex_files,
+                    timezone,
+                    dlt_tables,
+                    ..
+                } = *config;
                 let (app_ids, ctx_ids, ecu_ids) = (
-                    config.dlt_tables.app_table.selected_ids,
-                    config.dlt_tables.ctx_table.selected_ids,
-                    config.dlt_tables.ecu_table.selected_ids,
+                    dlt_tables.app_table.selected_ids,
+                    dlt_tables.ctx_table.selected_ids,
+                    dlt_tables.ecu_table.selected_ids,
                 );
 
                 let app_id_count = app_ids.len() as i64;
@@ -737,7 +748,7 @@ impl HostService {
                     .then(|| ecu_ids.into_iter().collect::<Vec<String>>());
 
                 let filter_config = DltFilterConfig {
-                    min_log_level: Some(config.log_level as u8),
+                    min_log_level: Some(log_level as u8),
                     app_ids,
                     ecu_ids,
                     context_ids,
@@ -745,9 +756,8 @@ impl HostService {
                     context_id_count,
                 };
 
-                let fibex_file_paths = config.fibex_files.is_empty().not().then(|| {
-                    config
-                        .fibex_files
+                let fibex_file_paths = fibex_files.is_empty().not().then(|| {
+                    fibex_files
                         .into_iter()
                         .map(|p| p.path.to_string_lossy().to_string())
                         .collect()
@@ -756,8 +766,8 @@ impl HostService {
                 let dlt_config = DltParserSettings {
                     filter_config: Some(filter_config),
                     fibex_file_paths,
-                    with_storage_header: config.with_storage_header,
-                    tz: config.timezone,
+                    with_storage_header,
+                    tz: timezone,
                     fibex_metadata: None,
                 };
 

--- a/application/apps/indexer/gui/application/src/host/ui/home/file_explorer.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/file_explorer.rs
@@ -12,7 +12,7 @@ use egui::{
 };
 use tokio::sync::mpsc::Sender;
 
-use crate::common::phosphor::icons;
+use crate::common::{phosphor::icons, ui::substring_matcher::SubstringMatcher};
 use crate::host::common::ui_utls::{sized_singleline_text_edit, truncate_path_to_width};
 use crate::host::{
     command::{HostCommand, ScanFavoriteFoldersParam},
@@ -28,6 +28,7 @@ const FAVORITES_FOLDER_ID: &str = "favorites_folder";
 #[derive(Debug)]
 pub struct FileExplorerUi {
     favorite_search: String,
+    favorite_search_matcher: SubstringMatcher,
     cmd_tx: Sender<HostCommand>,
 }
 
@@ -36,6 +37,7 @@ impl FileExplorerUi {
     pub fn new(cmd_tx: Sender<HostCommand>) -> Self {
         Self {
             favorite_search: String::new(),
+            favorite_search_matcher: SubstringMatcher::default(),
             cmd_tx,
         }
     }
@@ -50,8 +52,6 @@ impl FileExplorerUi {
     ) {
         let busy_label = favorite_folders_busy_label(file_explorer);
         let busy = busy_label.is_some();
-        let search_filter = self.favorite_search.to_lowercase();
-        let has_search_filter = !search_filter.is_empty();
 
         ui.add_space(5.0);
         Label::new(RichText::new("Favorite folders").heading())
@@ -128,10 +128,16 @@ impl FileExplorerUi {
                     )
                     .hint_text("Type to filter...");
 
-                    ui.add_enabled(!busy, txt_input);
+                    let response = ui.add_enabled(!busy, txt_input);
+                    if response.changed() {
+                        self.favorite_search_matcher
+                            .build_query(&self.favorite_search);
+                    }
                 });
             },
         );
+
+        let has_search_filter = self.favorite_search_matcher.has_query();
 
         ui.add_space(2.0);
 
@@ -229,7 +235,7 @@ impl FileExplorerUi {
                     folder_state.show_body_indented(&header_response, ui, |ui| {
                         for file in &folder.files {
                             if has_search_filter
-                                && !file.name.to_lowercase().contains(&search_filter)
+                                && !self.favorite_search_matcher.matches(file.name.as_str())
                             {
                                 continue;
                             }

--- a/application/apps/indexer/gui/application/src/host/ui/home/recent.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/recent.rs
@@ -10,9 +10,10 @@ use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
 
 use crate::{
-    common::phosphor::icons,
+    common::{phosphor::icons, ui::substring_matcher::SubstringMatcher},
     host::{
         command::{HostCommand, OpenRecentSessionParam},
+        common::ui_utls::sized_singleline_text_edit,
         ui::{
             UiActions,
             storage::{
@@ -25,6 +26,8 @@ use crate::{
 
 #[derive(Debug)]
 pub struct RecentSessionsUi {
+    query: String,
+    matcher: SubstringMatcher,
     cmd_tx: Sender<HostCommand>,
     /// Arbitrary value to avoid persisting scroll state after app restart.
     scroll_salt: Uuid,
@@ -34,6 +37,8 @@ impl RecentSessionsUi {
     /// Creates the home-screen recent-sessions UI controller.
     pub fn new(cmd_tx: Sender<HostCommand>) -> Self {
         Self {
+            query: String::new(),
+            matcher: SubstringMatcher::default(),
             cmd_tx,
             scroll_salt: Uuid::new_v4(),
         }
@@ -48,28 +53,48 @@ impl RecentSessionsUi {
         ui: &mut Ui,
     ) {
         ui.heading("Recently opened");
+        ui.add_space(4.0);
+
+        let query_changed =
+            sized_singleline_text_edit(ui, &mut self.query, vec2(ui.available_width(), 27.0), 7)
+                .hint_text("Filter recent sessions")
+                .ui(ui)
+                .changed();
+        if query_changed {
+            self.matcher.build_query(self.query.trim());
+        }
+
+        ui.add_space(4.0);
 
         egui::ScrollArea::vertical()
             .id_salt(("recent_files_scroll", self.scroll_salt))
             .show(ui, |ui| {
-                ui.label("List of recently opened sessions.");
-                ui.add_space(5.0);
-
                 if recent_sessions.sessions.is_empty() {
                     ui.weak("No recent sessions yet.");
                     return;
                 }
 
+                let has_query = self.matcher.has_query();
+                let mut any_visible = false;
                 let remove_session = {
                     let mut remove_session = None;
 
                     for session in &recent_sessions.sessions {
+                        if !matches_recent_session_query(&mut self.matcher, session) {
+                            continue;
+                        }
+
+                        any_visible = true;
                         self.render_recent_item(ui, actions, session, &mut remove_session);
                         ui.add_space(4.0);
                     }
 
                     remove_session
                 };
+
+                if !any_visible && has_query {
+                    ui.label("No recent sessions match the current filter.");
+                }
 
                 if let Some(source_key) = remove_session {
                     recent_sessions.remove_session(&source_key);
@@ -236,6 +261,13 @@ impl RecentSessionsUi {
     }
 }
 
+fn matches_recent_session_query(
+    matcher: &mut SubstringMatcher,
+    session: &RecentSessionSnapshot,
+) -> bool {
+    matcher.matches(session.title()) || matcher.matches(session.summary())
+}
+
 fn render_source_badge(ui: &mut Ui, session: &RecentSessionSnapshot) {
     let icon = source_badge_icon(session);
     let icon = RichText::new(icon).size(19.0);
@@ -259,4 +291,100 @@ fn recent_action_button(icon: &'static str) -> Button<'static> {
     Button::new(RichText::new(icon).size(16.0))
         .frame(false)
         .frame_when_inactive(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use stypes::{FileFormat, ParserType, TCPTransportConfig, Transport};
+
+    use super::{
+        RecentSessionSnapshot, RecentSessionSource, SubstringMatcher, matches_recent_session_query,
+    };
+
+    fn file_session(path: &str, parser: ParserType) -> RecentSessionSnapshot {
+        RecentSessionSnapshot::new(
+            1,
+            vec![RecentSessionSource::File {
+                format: FileFormat::Text,
+                path: PathBuf::from(path),
+            }],
+            parser,
+            Default::default(),
+        )
+    }
+
+    fn stream_session(bind_addr: &str) -> RecentSessionSnapshot {
+        RecentSessionSnapshot::new(
+            1,
+            vec![RecentSessionSource::Stream {
+                transport: Transport::TCP(TCPTransportConfig {
+                    bind_addr: bind_addr.to_owned(),
+                }),
+            }],
+            ParserType::Text(()),
+            Default::default(),
+        )
+    }
+
+    fn build_matcher(query: &str) -> SubstringMatcher {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query(query.trim());
+        matcher
+    }
+
+    #[test]
+    fn empty_query_matches_all_sessions() {
+        let session = file_session("alpha.log", ParserType::Text(()));
+
+        assert!(matches_recent_session_query(
+            &mut build_matcher(""),
+            &session
+        ));
+        assert!(matches_recent_session_query(
+            &mut build_matcher("   "),
+            &session
+        ));
+    }
+
+    #[test]
+    fn query_matches_title_ignoring_case() {
+        let session = file_session("ErrorTrace.log", ParserType::Text(()));
+
+        assert!(matches_recent_session_query(
+            &mut build_matcher("error"),
+            &session
+        ));
+    }
+
+    #[test]
+    fn query_matches_summary_ignoring_case() {
+        let session = file_session("trace.log", ParserType::Text(()));
+
+        assert!(matches_recent_session_query(
+            &mut build_matcher("plain"),
+            &session
+        ));
+    }
+
+    #[test]
+    fn query_matches_stream_summary() {
+        let session = stream_session("127.0.0.1:5555");
+
+        assert!(matches_recent_session_query(
+            &mut build_matcher("tcp"),
+            &session
+        ));
+    }
+
+    #[test]
+    fn query_does_not_match_tooltip_only_text() {
+        let session = file_session("/logs/alpha.log", ParserType::Text(()));
+
+        assert!(!matches_recent_session_query(
+            &mut build_matcher("/logs"),
+            &session
+        ));
+    }
 }

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/side_config/dlt.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/side_config/dlt.rs
@@ -43,26 +43,32 @@ fn timezone_selector(config: &mut DltParserConfig, ui: &mut Ui) {
     ui.label(RichText::new("Select the utc timezone (optional)").small());
     ui.add_space(5.0);
 
-    ui.text_edit_singleline(&mut config.timezone_filter);
+    let response = ui.text_edit_singleline(&mut config.timezone_filter);
+    if response.changed() {
+        config.timezone_matcher.build_query(&config.timezone_filter);
+    }
 
-    ScrollArea::vertical().max_height(100.0).show(ui, |ui| {
-        for (name, offset) in config
-            .timezone_list
-            .iter()
-            .filter(|(name, _)| name.to_lowercase().contains(&config.timezone_filter))
-        {
-            let hours = *offset as f32 / (60.0 * 60.0);
-            let rounded = (hours * 10.0).round() / 10.0;
-            let display = format!("{name} ({:+.1})", rounded);
-
-            if ui
-                .selectable_label(config.timezone.as_ref().is_some_and(|t| t == name), display)
-                .clicked()
+    ScrollArea::vertical()
+        .max_height(100.0)
+        .auto_shrink([false, true])
+        .show(ui, |ui| {
+            for (name, offset) in config
+                .timezone_list
+                .iter()
+                .filter(|(name, _)| config.timezone_matcher.matches(name))
             {
-                config.timezone = Some(name.to_owned());
+                let hours = *offset as f32 / (60.0 * 60.0);
+                let rounded = (hours * 10.0).round() / 10.0;
+                let display = format!("{name} ({:+.1})", rounded);
+
+                if ui
+                    .selectable_label(config.timezone.as_ref().is_some_and(|t| t == name), display)
+                    .clicked()
+                {
+                    config.timezone = Some(name.to_owned());
+                }
             }
-        }
-    });
+        });
 
     ui.add_space(5.0);
     let content = if let Some(tz) = config.timezone.as_ref() {

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/state/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/state/mod.rs
@@ -34,15 +34,18 @@ impl SessionSetupState {
     pub fn update_parser(&mut self, parser: ParserNames) {
         self.parser = match parser {
             ParserNames::Dlt => match &self.source {
-                ByteSourceConfig::File(file) => {
-                    ParserConfig::Dlt(DltParserConfig::new(true, Some(vec![file.path.clone()])))
-                }
-                ByteSourceConfig::Concat(files) => ParserConfig::Dlt(DltParserConfig::new(
+                ByteSourceConfig::File(file) => ParserConfig::Dlt(Box::new(DltParserConfig::new(
                     true,
-                    Some(files.iter().map(|f| f.path.clone()).collect()),
-                )),
+                    Some(vec![file.path.clone()]),
+                ))),
+                ByteSourceConfig::Concat(files) => {
+                    ParserConfig::Dlt(Box::new(DltParserConfig::new(
+                        true,
+                        Some(files.iter().map(|f| f.path.clone()).collect()),
+                    )))
+                }
                 ByteSourceConfig::Stream(..) => {
-                    ParserConfig::Dlt(DltParserConfig::new(false, None))
+                    ParserConfig::Dlt(Box::new(DltParserConfig::new(false, None)))
                 }
             },
             ParserNames::SomeIP => ParserConfig::SomeIP(SomeIpParserConfig::new()),

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/state/parsers/dlt.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/state/parsers/dlt.rs
@@ -9,7 +9,10 @@ use chrono_tz::Tz;
 use itertools::Itertools;
 
 use super::FibexFileInfo;
-use crate::host::common::dlt_stats::{DltStatistics, LevelDistribution};
+use crate::{
+    common::ui::substring_matcher::SubstringMatcher,
+    host::common::dlt_stats::{DltStatistics, LevelDistribution},
+};
 
 /// DLT Configurations to be used in front-end
 #[derive(Debug, Clone)]
@@ -20,6 +23,7 @@ pub struct DltParserConfig {
     pub fibex_files: Vec<FibexFileInfo>,
     pub timezone: Option<String>,
     pub timezone_filter: String,
+    pub timezone_matcher: SubstringMatcher,
     pub timezone_list: Vec<(String, i32)>,
     pub dlt_statistics: Option<Box<DltStatistics>>,
     pub dlt_summary: Box<DltSummary>,
@@ -35,6 +39,7 @@ impl DltParserConfig {
             fibex_files: Vec::new(),
             timezone: None,
             timezone_filter: String::new(),
+            timezone_matcher: SubstringMatcher::default(),
             timezone_list: Self::timezone_list(),
             dlt_statistics: None,
             dlt_summary: Box::new(DltSummary::default()),
@@ -77,6 +82,7 @@ impl DltParserConfig {
             timezone: settings.tz.to_owned(),
             timezone_list: Self::timezone_list(),
             timezone_filter: String::default(),
+            timezone_matcher: SubstringMatcher::default(),
             dlt_statistics: None,
             dlt_summary: Box::new(DltSummary::default()),
             dlt_tables: Box::new(DltTables::default()),

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/state/parsers/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/state/parsers/mod.rs
@@ -11,7 +11,7 @@ use crate::host::ui::session_setup::state::parsers::someip::SomeIpParserConfig;
 /// Parser Configurations to be used in the front-end.
 #[derive(Debug, Clone)]
 pub enum ParserConfig {
-    Dlt(DltParserConfig),
+    Dlt(Box<DltParserConfig>),
     SomeIP(SomeIpParserConfig),
     Text,
     Plugins,
@@ -20,9 +20,8 @@ pub enum ParserConfig {
 impl ParserConfig {
     pub fn from_observe_options(options: &ObserveOptions) -> Self {
         match &options.parser {
-            stypes::ParserType::Dlt(settings) => Self::Dlt(DltParserConfig::from_observe_options(
-                settings,
-                &options.origin,
+            stypes::ParserType::Dlt(settings) => Self::Dlt(Box::new(
+                DltParserConfig::from_observe_options(settings, &options.origin),
             )),
             stypes::ParserType::SomeIp(settings) => {
                 Self::SomeIP(SomeIpParserConfig::from_parser_settings(settings))

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/library/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/library/mod.rs
@@ -7,7 +7,9 @@ use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
 
 use crate::{
-    common::{phosphor::icons, validation::ValidationEligibility},
+    common::{
+        phosphor::icons, ui::substring_matcher::SubstringMatcher, validation::ValidationEligibility,
+    },
     host::ui::{UiActions, registry::filters::FilterRegistry},
     session::{
         command::SessionCommand,
@@ -32,6 +34,7 @@ pub struct LibraryUI {
 #[derive(Debug, Default)]
 struct DefinitionQueryState {
     query: String,
+    matcher: SubstringMatcher,
     matching_ids: Option<FxHashSet<Uuid>>,
     cached_revision: u64,
 }
@@ -117,7 +120,7 @@ impl LibraryUI {
             self.filter_state.update_with_revision(
                 registry.filter_definitions_revision(),
                 query_changed,
-                |query| collect_matching_filter_ids(query, registry),
+                |matcher| collect_matching_filter_ids(matcher, registry),
             );
 
             ScrollArea::vertical()
@@ -218,7 +221,7 @@ impl LibraryUI {
             self.chart_state.update_with_revision(
                 registry.search_value_definitions_revision(),
                 query_changed,
-                |query| collect_matching_search_value_ids(query, registry),
+                |matcher| collect_matching_search_value_ids(matcher, registry),
             );
 
             ScrollArea::vertical()
@@ -568,10 +571,14 @@ impl DefinitionQueryState {
         &mut self,
         revision: u64,
         query_changed: bool,
-        recompute_matches: impl FnOnce(&str) -> Option<FxHashSet<Uuid>>,
+        recompute_matches: impl FnOnce(&mut SubstringMatcher) -> Option<FxHashSet<Uuid>>,
     ) {
+        if query_changed {
+            self.matcher.build_query(self.query.trim());
+        }
+
         if query_changed || self.cached_revision != revision {
-            self.matching_ids = recompute_matches(&self.query);
+            self.matching_ids = recompute_matches(&mut self.matcher);
             self.cached_revision = revision;
         }
     }
@@ -585,9 +592,11 @@ impl DefinitionQueryState {
     }
 }
 
-fn collect_matching_filter_ids(query: &str, registry: &FilterRegistry) -> Option<FxHashSet<Uuid>> {
-    let normalized_query = normalized_query(query);
-    if normalized_query.is_empty() {
+fn collect_matching_filter_ids(
+    matcher: &mut SubstringMatcher,
+    registry: &FilterRegistry,
+) -> Option<FxHashSet<Uuid>> {
+    if !matcher.has_query() {
         return None;
     }
 
@@ -595,19 +604,16 @@ fn collect_matching_filter_ids(query: &str, registry: &FilterRegistry) -> Option
         registry
             .filters_map()
             .iter()
-            .filter_map(|(id, def)| {
-                matches_name_query(def.filter.value.as_str(), &normalized_query).then_some(*id)
-            })
+            .filter_map(|(id, def)| matcher.matches(def.filter.value.as_str()).then_some(*id))
             .collect(),
     )
 }
 
 fn collect_matching_search_value_ids(
-    query: &str,
+    matcher: &mut SubstringMatcher,
     registry: &FilterRegistry,
 ) -> Option<FxHashSet<Uuid>> {
-    let normalized_query = normalized_query(query);
-    if normalized_query.is_empty() {
+    if !matcher.has_query() {
         return None;
     }
 
@@ -615,19 +621,9 @@ fn collect_matching_search_value_ids(
         registry
             .search_value_map()
             .iter()
-            .filter_map(|(id, def)| {
-                matches_name_query(def.filter.value.as_str(), &normalized_query).then_some(*id)
-            })
+            .filter_map(|(id, def)| matcher.matches(def.filter.value.as_str()).then_some(*id))
             .collect(),
     )
-}
-
-fn normalized_query(query: &str) -> String {
-    query.trim().to_ascii_lowercase()
-}
-
-fn matches_name_query(text: &str, normalized_query: &str) -> bool {
-    normalized_query.is_empty() || text.to_ascii_lowercase().contains(normalized_query)
 }
 
 #[cfg(test)]
@@ -695,10 +691,19 @@ mod tests {
         id
     }
 
+    fn build_matcher(query: &str) -> SubstringMatcher {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query(query.trim());
+        matcher
+    }
+
     #[test]
     fn empty_query_matches_all() {
-        assert!(matches_name_query("status=ok", &normalized_query("")));
-        assert!(matches_name_query("status=ok", &normalized_query("   ")));
+        let mut matcher = build_matcher("");
+        assert!(matcher.matches("status=ok"));
+
+        let mut matcher = build_matcher("   ");
+        assert!(matcher.matches("status=ok"));
     }
 
     #[test]
@@ -706,17 +711,17 @@ mod tests {
         let mut registry = FilterRegistry::default();
         add_filter_definition(&mut registry, "status=ok");
 
-        assert!(collect_matching_filter_ids("   ", &registry).is_none());
-        assert!(collect_matching_search_value_ids("   ", &registry).is_none());
+        assert!(collect_matching_filter_ids(&mut build_matcher("   "), &registry).is_none());
+        assert!(collect_matching_search_value_ids(&mut build_matcher("   "), &registry).is_none());
     }
 
     #[test]
     fn query_matches_case_insensitively() {
-        assert!(matches_name_query("Status=Ok", &normalized_query("status")));
-        assert!(matches_name_query(
-            "duration=(\\d+)",
-            &normalized_query("DUR")
-        ));
+        let mut matcher = build_matcher("status");
+        assert!(matcher.matches("Status=Ok"));
+
+        let mut matcher = build_matcher("DUR");
+        assert!(matcher.matches("duration=(\\d+)"));
     }
 
     #[test]
@@ -724,7 +729,8 @@ mod tests {
         let mut registry = FilterRegistry::default();
         let matching_id = add_filter_definition(&mut registry, "Status=Ok");
         let non_matching_id = add_filter_definition(&mut registry, "warn");
-        let matching_ids = collect_matching_filter_ids(" status ", &registry).unwrap();
+        let matching_ids =
+            collect_matching_filter_ids(&mut build_matcher(" status "), &registry).unwrap();
 
         assert!(matching_ids.contains(&matching_id));
         assert!(!matching_ids.contains(&non_matching_id));
@@ -735,7 +741,8 @@ mod tests {
         let mut registry = FilterRegistry::default();
         let matching_id = add_search_value_definition(&mut registry, "duration=(\\d+)");
         let non_matching_id = add_search_value_definition(&mut registry, "latency=(\\d+)");
-        let matching_ids = collect_matching_search_value_ids(" DUR ", &registry).unwrap();
+        let matching_ids =
+            collect_matching_search_value_ids(&mut build_matcher(" DUR "), &registry).unwrap();
 
         assert!(matching_ids.contains(&matching_id));
         assert!(!matching_ids.contains(&non_matching_id));
@@ -743,7 +750,8 @@ mod tests {
 
     #[test]
     fn query_rejects_non_matches() {
-        assert!(!matches_name_query("status=ok", &normalized_query("warn")));
+        let mut matcher = build_matcher("warn");
+        assert!(!matcher.matches("status=ok"));
     }
 
     #[test]
@@ -755,8 +763,8 @@ mod tests {
         let mut registry = FilterRegistry::default();
         let first_id = add_filter_definition(&mut registry, "warn");
 
-        state.update_with_revision(registry.filter_definitions_revision(), true, |query| {
-            collect_matching_filter_ids(query, &registry)
+        state.update_with_revision(registry.filter_definitions_revision(), true, |matcher| {
+            collect_matching_filter_ids(matcher, &registry)
         });
         assert_eq!(
             state.matching_ids.as_ref(),
@@ -764,8 +772,8 @@ mod tests {
         );
 
         let second_id = add_filter_definition(&mut registry, "warning");
-        state.update_with_revision(registry.filter_definitions_revision(), false, |query| {
-            collect_matching_filter_ids(query, &registry)
+        state.update_with_revision(registry.filter_definitions_revision(), false, |matcher| {
+            collect_matching_filter_ids(matcher, &registry)
         });
 
         assert_eq!(
@@ -774,8 +782,8 @@ mod tests {
         );
 
         state.query = "   ".to_owned();
-        state.update_with_revision(registry.filter_definitions_revision(), true, |query| {
-            collect_matching_filter_ids(query, &registry)
+        state.update_with_revision(registry.filter_definitions_revision(), true, |matcher| {
+            collect_matching_filter_ids(matcher, &registry)
         });
         assert!(state.matching_ids.is_none());
     }

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/mod.rs
@@ -5,7 +5,10 @@ use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
 
 use crate::{
-    common::{phosphor::icons, ui::buttons},
+    common::{
+        phosphor::icons,
+        ui::{buttons, substring_matcher::SubstringMatcher},
+    },
     host::{
         command::{ExportPresetsParam, HostCommand},
         common::ui_utls::sized_singleline_text_edit,
@@ -63,6 +66,7 @@ pub struct PresetsUI {
 #[derive(Debug, Default)]
 struct PresetQueryState {
     query: String,
+    matcher: SubstringMatcher,
     // `None` means the query is empty and every preset stays visible.
     matching_ids: Option<rustc_hash::FxHashSet<Uuid>>,
     cached_revision: u64,
@@ -219,7 +223,7 @@ impl PresetsUI {
                     self.query_state.update_with_revision(
                         registry.presets.definitions_revision(),
                         query_changed,
-                        |query| collect_matching_preset_ids(query, registry),
+                        |matcher| collect_matching_preset_ids(matcher, registry),
                     );
 
                     ui.add_space(10.0);
@@ -958,7 +962,7 @@ mod tests {
         presets.query_state.update_with_revision(
             registry.presets.definitions_revision(),
             true,
-            |query| collect_matching_preset_ids(query, &registry),
+            |matcher| collect_matching_preset_ids(matcher, &registry),
         );
 
         presets.select_filtered_for_export(&registry);

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/query.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/query.rs
@@ -3,6 +3,8 @@
 use rustc_hash::FxHashSet;
 use uuid::Uuid;
 
+use crate::common::ui::substring_matcher::SubstringMatcher;
+
 use super::{HostRegistry, Preset, PresetQueryState};
 
 impl PresetQueryState {
@@ -11,10 +13,14 @@ impl PresetQueryState {
         &mut self,
         revision: u64,
         query_changed: bool,
-        recompute_matches: impl FnOnce(&str) -> Option<FxHashSet<Uuid>>,
+        recompute_matches: impl FnOnce(&mut SubstringMatcher) -> Option<FxHashSet<Uuid>>,
     ) {
+        if query_changed {
+            self.matcher.build_query(self.query.trim());
+        }
+
         if query_changed || self.cached_revision != revision {
-            self.matching_ids = recompute_matches(&self.query);
+            self.matching_ids = recompute_matches(&mut self.matcher);
             self.cached_revision = revision;
         }
     }
@@ -27,19 +33,9 @@ impl PresetQueryState {
     }
 }
 
-/// Normalizes user-entered query text for case-insensitive matching.
-fn normalized_query(query: &str) -> String {
-    query.trim().to_ascii_lowercase()
-}
-
-/// Returns `true` when the normalized query is empty or present in the text.
-fn matches_name_query(text: &str, normalized_query: &str) -> bool {
-    normalized_query.is_empty() || text.to_ascii_lowercase().contains(normalized_query)
-}
-
 /// Matches presets by name only; item contents do not participate in filtering.
-fn matches_preset_query(preset: &Preset, normalized_query: &str) -> bool {
-    matches_name_query(preset.name.as_str(), normalized_query)
+fn matches_preset_query(preset: &Preset, matcher: &mut SubstringMatcher) -> bool {
+    matcher.matches(preset.name.as_str())
 }
 
 /// Collects the visible preset ids for the current query.
@@ -47,11 +43,10 @@ fn matches_preset_query(preset: &Preset, normalized_query: &str) -> bool {
 /// Returns `None` for an empty normalized query so the caller can treat that
 /// as "show everything" without storing a full-id snapshot.
 pub(super) fn collect_matching_preset_ids(
-    query: &str,
+    matcher: &mut SubstringMatcher,
     registry: &HostRegistry,
 ) -> Option<FxHashSet<Uuid>> {
-    let normalized_query = normalized_query(query);
-    if normalized_query.is_empty() {
+    if !matcher.has_query() {
         return None;
     }
 
@@ -60,9 +55,7 @@ pub(super) fn collect_matching_preset_ids(
             .presets
             .presets()
             .iter()
-            .filter_map(|preset| {
-                matches_preset_query(preset, &normalized_query).then_some(preset.id)
-            })
+            .filter_map(|preset| matches_preset_query(preset, matcher).then_some(preset.id))
             .collect(),
     )
 }
@@ -83,19 +76,25 @@ mod tests {
         }
     }
 
+    fn build_matcher(query: &str) -> SubstringMatcher {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query(query.trim());
+        matcher
+    }
+
     #[test]
     fn empty_query_matches_all() {
         let preset = preset("Errors");
 
-        assert!(matches_preset_query(&preset, &normalized_query("")));
-        assert!(matches_preset_query(&preset, &normalized_query("   ")));
+        assert!(matches_preset_query(&preset, &mut build_matcher("")));
+        assert!(matches_preset_query(&preset, &mut build_matcher("   ")));
     }
 
     #[test]
     fn query_matches_name() {
         let preset = preset("Error Group");
 
-        assert!(matches_preset_query(&preset, &normalized_query("error")));
+        assert!(matches_preset_query(&preset, &mut build_matcher("error")));
     }
 
     #[test]
@@ -103,7 +102,7 @@ mod tests {
         let mut registry = HostRegistry::default();
         registry.presets.add_preset("Errors", vec![], vec![]);
 
-        assert!(collect_matching_preset_ids("   ", &registry).is_none());
+        assert!(collect_matching_preset_ids(&mut build_matcher("   "), &registry).is_none());
     }
 
     #[test]
@@ -111,7 +110,8 @@ mod tests {
         let mut registry = HostRegistry::default();
         let matching_id = registry.presets.add_preset("Status Errors", vec![], vec![]);
         let non_matching_id = registry.presets.add_preset("Warnings", vec![], vec![]);
-        let matching_ids = collect_matching_preset_ids(" status ", &registry).unwrap();
+        let matching_ids =
+            collect_matching_preset_ids(&mut build_matcher(" status "), &registry).unwrap();
 
         assert!(matching_ids.contains(&matching_id));
         assert!(!matching_ids.contains(&non_matching_id));
@@ -124,7 +124,7 @@ mod tests {
             ..preset("Alpha")
         };
 
-        assert!(!matches_preset_query(&preset, &normalized_query("error")));
+        assert!(!matches_preset_query(&preset, &mut build_matcher("error")));
     }
 
     #[test]
@@ -136,8 +136,8 @@ mod tests {
         let mut registry = HostRegistry::default();
         let first_id = registry.presets.add_preset("warn", vec![], vec![]);
 
-        state.update_with_revision(registry.presets.definitions_revision(), true, |query| {
-            collect_matching_preset_ids(query, &registry)
+        state.update_with_revision(registry.presets.definitions_revision(), true, |matcher| {
+            collect_matching_preset_ids(matcher, &registry)
         });
         assert!(state.matches(&first_id));
 
@@ -145,8 +145,8 @@ mod tests {
 
         assert!(!state.matches(&second_id));
 
-        state.update_with_revision(registry.presets.definitions_revision(), false, |query| {
-            collect_matching_preset_ids(query, &registry)
+        state.update_with_revision(registry.presets.definitions_revision(), false, |matcher| {
+            collect_matching_preset_ids(matcher, &registry)
         });
         assert!(state.matches(&second_id));
     }


### PR DESCRIPTION
This PR Provides:

* Use `nucleo` crate for the matcher for quick filtering for lists with input text
* Add UI search for recent session in home view
* Adjust faint color in light mode 