### PR TITLE
Native: Recent sessions in stream session setups

### DIFF
--- a/application/apps/indexer/gui/application/src/host/ui/home/recent.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/recent.rs
@@ -3,23 +3,21 @@
 //! This module renders the recent-sessions panel and forwards reopen actions to
 //! the host service.
 
-use egui::{
-    Align, Button, Label, Layout, Response, RichText, Sense, Sides, Ui, UiBuilder, Widget, vec2,
-};
+use egui::{Ui, Widget, vec2};
 use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
 
 use crate::{
-    common::{phosphor::icons, ui::substring_matcher::SubstringMatcher},
+    common::ui::substring_matcher::SubstringMatcher,
     host::{
         command::{HostCommand, OpenRecentSessionParam},
         common::ui_utls::sized_singleline_text_edit,
         ui::{
             UiActions,
-            storage::{
-                RecentSessionReopenMode, RecentSessionSnapshot, RecentSessionSource,
-                RecentSessionsStorage,
+            recent_session::{
+                RecentSessionRowAction, RecentSessionRowOptions, render_recent_session_row,
             },
+            storage::{RecentSessionReopenMode, RecentSessionSnapshot, RecentSessionsStorage},
         },
     },
 };
@@ -85,7 +83,14 @@ impl RecentSessionsUi {
                         }
 
                         any_visible = true;
-                        self.render_recent_item(ui, actions, session, &mut remove_session);
+
+                        const OPTIONS: RecentSessionRowOptions = RecentSessionRowOptions {
+                            show_clean_open: true,
+                        };
+
+                        if let Some(action) = render_recent_session_row(ui, session, &OPTIONS) {
+                            self.apply_row_action(actions, session, action, &mut remove_session);
+                        }
                         ui.add_space(4.0);
                     }
 
@@ -102,148 +107,30 @@ impl RecentSessionsUi {
             });
     }
 
-    fn render_recent_item(
+    fn apply_row_action(
         &self,
-        ui: &mut Ui,
         actions: &mut UiActions,
         session: &RecentSessionSnapshot,
-        remove_session: &mut Option<std::sync::Arc<str>>,
-    ) -> Response {
-        const ROW_HEIGHT: f32 = 50.0;
-        // Make sure to update this If row height changed.
-        const TEXT_BLOCK_TOP_SPACING: f32 = 8.0;
-
-        let (rect, response) =
-            ui.allocate_exact_size(vec2(ui.available_width(), ROW_HEIGHT), Sense::click());
-
-        response.context_menu(|ui| self.render_row_menu(ui, actions, session, remove_session));
-
-        if response.hovered() {
-            ui.painter()
-                .rect_filled(rect, 0.0, ui.visuals().widgets.hovered.bg_fill);
-        }
-
-        const CONTENT_PADDING_X: f32 = 8.0;
-        const CONTENT_PADDING_Y: f32 = 0.0;
-        let content_rect = rect.shrink2(vec2(CONTENT_PADDING_X, CONTENT_PADDING_Y));
-
-        ui.scope_builder(UiBuilder::new().max_rect(content_rect), |ui| {
-            Sides::new()
-                .shrink_left()
-                .truncate()
-                .height(ROW_HEIGHT)
-                .show(
-                    ui,
-                    |ui| {
-                        let content = ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
-                            ui.take_available_width();
-                            render_source_badge(ui, session);
-                            ui.vertical(|ui| {
-                                // We need to to add space here manually because it's not possible
-                                // to a center this vertically.
-                                ui.add_space(TEXT_BLOCK_TOP_SPACING);
-                                Label::new(RichText::new(session.title()).strong())
-                                    .truncate()
-                                    .ui(ui);
-
-                                Label::new(RichText::new(session.summary()).size(13.0))
-                                    .truncate()
-                                    .ui(ui);
-                            });
-                        });
-                        content.response.on_hover_ui(|ui| {
-                            ui.set_max_width(ui.spacing().tooltip_width);
-                            ui.label(session.tooltip());
-                        });
-                    },
-                    |ui| {
-                        ui.horizontal_centered(|ui| {
-                            if recent_action_button(icons::regular::ARROW_COUNTER_CLOCKWISE)
-                                .ui(ui)
-                                .on_hover_text("Restore session")
-                                .clicked()
-                            {
-                                self.open_recent_session(
-                                    actions,
-                                    session,
-                                    RecentSessionReopenMode::RestoreSession,
-                                );
-                            }
-
-                            if recent_action_button(icons::regular::SLIDERS_HORIZONTAL)
-                                .ui(ui)
-                                .on_hover_text("Open with saved parser configuration")
-                                .clicked()
-                            {
-                                self.open_recent_session(
-                                    actions,
-                                    session,
-                                    RecentSessionReopenMode::RestoreParserConfiguration,
-                                );
-                            }
-
-                            let clean_open = ui
-                                .add_enabled(
-                                    session.supports_clean_open(),
-                                    recent_action_button(icons::regular::ARROW_SQUARE_OUT),
-                                )
-                                .on_hover_text(
-                                    "Open as a fresh session without restoring saved state",
-                                )
-                                .on_disabled_hover_text(
-                                    "Clean open is currently only available for file sessions",
-                                );
-
-                            if clean_open.clicked() {
-                                self.open_recent_session(
-                                    actions,
-                                    session,
-                                    RecentSessionReopenMode::OpenClean,
-                                );
-                            }
-                        });
-                    },
-                );
-        });
-
-        if response.double_clicked() {
-            self.open_recent_session(actions, session, RecentSessionReopenMode::RestoreSession);
-        }
-
-        response
-    }
-
-    fn render_row_menu(
-        &self,
-        ui: &mut Ui,
-        actions: &mut UiActions,
-        session: &RecentSessionSnapshot,
+        action: RecentSessionRowAction,
         remove_session: &mut Option<std::sync::Arc<str>>,
     ) {
-        if ui.button("Restore session").clicked() {
-            self.open_recent_session(actions, session, RecentSessionReopenMode::RestoreSession);
-            ui.close();
-        }
-
-        if ui.button("Restore parser settings").clicked() {
-            self.open_recent_session(
-                actions,
-                session,
-                RecentSessionReopenMode::RestoreParserConfiguration,
-            );
-            ui.close();
-        }
-
-        if session.supports_clean_open() && ui.button("Open without saved state").clicked() {
-            self.open_recent_session(actions, session, RecentSessionReopenMode::OpenClean);
-            ui.close();
-        }
-
-        ui.separator();
-
-        if ui.button("Remove").clicked() {
-            *remove_session = Some(session.source_key.clone());
-            ui.close();
+        match action {
+            RecentSessionRowAction::RestoreSession => {
+                self.open_recent_session(actions, session, RecentSessionReopenMode::RestoreSession);
+            }
+            RecentSessionRowAction::RestoreParserConfiguration => {
+                self.open_recent_session(
+                    actions,
+                    session,
+                    RecentSessionReopenMode::RestoreParserConfiguration,
+                );
+            }
+            RecentSessionRowAction::OpenClean => {
+                self.open_recent_session(actions, session, RecentSessionReopenMode::OpenClean);
+            }
+            RecentSessionRowAction::Remove => {
+                *remove_session = Some(session.source_key.clone());
+            }
         }
     }
 
@@ -268,39 +155,16 @@ fn matches_recent_session_query(
     matcher.matches(session.title()) || matcher.matches(session.summary())
 }
 
-fn render_source_badge(ui: &mut Ui, session: &RecentSessionSnapshot) {
-    let icon = source_badge_icon(session);
-    let icon = RichText::new(icon).size(19.0);
-    Label::new(icon).ui(ui);
-}
-
-fn source_badge_icon(session: &RecentSessionSnapshot) -> &'static str {
-    match session.sources().first() {
-        Some(RecentSessionSource::File { .. }) => icons::regular::FILE,
-        Some(RecentSessionSource::Stream { transport }) => match transport {
-            stypes::Transport::Process(_) => icons::regular::TERMINAL_WINDOW,
-            stypes::Transport::TCP(_) => icons::regular::PLUGS_CONNECTED,
-            stypes::Transport::UDP(_) => icons::regular::BROADCAST,
-            stypes::Transport::Serial(_) => icons::regular::USB,
-        },
-        None => icons::regular::FILE,
-    }
-}
-
-fn recent_action_button(icon: &'static str) -> Button<'static> {
-    Button::new(RichText::new(icon).size(16.0))
-        .frame(false)
-        .frame_when_inactive(false)
-}
-
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
     use stypes::{FileFormat, ParserType, TCPTransportConfig, Transport};
 
-    use super::{
-        RecentSessionSnapshot, RecentSessionSource, SubstringMatcher, matches_recent_session_query,
+    use super::matches_recent_session_query;
+    use crate::{
+        common::ui::substring_matcher::SubstringMatcher,
+        host::ui::storage::{RecentSessionSnapshot, RecentSessionSource},
     };
 
     fn file_session(path: &str, parser: ParserType) -> RecentSessionSnapshot {

--- a/application/apps/indexer/gui/application/src/host/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/mod.rs
@@ -43,6 +43,7 @@ pub mod home;
 mod menu;
 pub mod multi_setup;
 mod notification;
+mod recent_session;
 pub mod registry;
 pub mod session_setup;
 pub mod state;
@@ -301,7 +302,7 @@ impl Host {
             TabType::SessionSetup(id) => session_setups
                 .get_mut(&id)
                 .expect("Session Setup with provided ID form active tab must exist")
-                .render_content(ui_actions, ui),
+                .render_content(ui_actions, &mut storage.recent_sessions, ui),
             TabType::MultiFileSetup(id) => multi_setups
                 .get_mut(&id)
                 .expect("Multiple files setups with provided ID from active tab must exist")

--- a/application/apps/indexer/gui/application/src/host/ui/recent_session.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/recent_session.rs
@@ -1,0 +1,179 @@
+//! Shared recent-session row rendering used by host UI surfaces.
+
+use egui::{Align, Button, Label, Layout, RichText, Sense, Sides, Ui, UiBuilder, Widget, vec2};
+
+use crate::{
+    common::phosphor::icons,
+    host::ui::storage::{RecentSessionSnapshot, RecentSessionSource},
+};
+
+const ROW_HEIGHT: f32 = 50.0;
+// Keep in sync with the current two-line row layout.
+const TEXT_BLOCK_TOP_SPACING: f32 = 8.0;
+const CONTENT_PADDING_X: f32 = 8.0;
+const CONTENT_PADDING_Y: f32 = 0.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecentSessionRowAction {
+    RestoreSession,
+    RestoreParserConfiguration,
+    OpenClean,
+    Remove,
+}
+
+/// Row-level feature flags for one recent-session entry.
+#[derive(Debug, Clone, Default)]
+pub struct RecentSessionRowOptions {
+    /// Enables the clean-open button and menu action for surfaces that support it.
+    pub show_clean_open: bool,
+}
+
+/// Renders one recent-session row and returns the user action triggered on it.
+pub fn render_recent_session_row(
+    ui: &mut Ui,
+    session: &RecentSessionSnapshot,
+    options: &RecentSessionRowOptions,
+) -> Option<RecentSessionRowAction> {
+    let (rect, response) =
+        ui.allocate_exact_size(vec2(ui.available_width(), ROW_HEIGHT), Sense::click());
+    let mut action = None;
+
+    response.context_menu(|ui| render_row_menu(ui, session, options, &mut action));
+
+    if response.hovered() {
+        ui.painter()
+            .rect_filled(rect, 0.0, ui.visuals().widgets.hovered.bg_fill);
+    }
+
+    let content_rect = rect.shrink2(vec2(CONTENT_PADDING_X, CONTENT_PADDING_Y));
+
+    ui.scope_builder(UiBuilder::new().max_rect(content_rect), |ui| {
+        Sides::new()
+            .shrink_left()
+            .truncate()
+            .height(ROW_HEIGHT)
+            .show(
+                ui,
+                |ui| {
+                    let content = ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
+                        ui.take_available_width();
+                        render_source_badge(ui, session);
+                        ui.vertical(|ui| {
+                            ui.add_space(TEXT_BLOCK_TOP_SPACING);
+                            Label::new(RichText::new(session.title()).strong())
+                                .truncate()
+                                .ui(ui);
+
+                            Label::new(RichText::new(session.summary()).size(13.0))
+                                .truncate()
+                                .ui(ui);
+                        });
+                    });
+                    content.response.on_hover_ui(|ui| {
+                        ui.set_max_width(ui.spacing().tooltip_width);
+                        ui.label(session.tooltip());
+                    });
+                },
+                |ui| render_row_actions(ui, session, options, &mut action),
+            );
+    });
+
+    if response.double_clicked() && action.is_none() {
+        action = Some(RecentSessionRowAction::RestoreSession);
+    }
+
+    action
+}
+
+fn render_row_actions(
+    ui: &mut Ui,
+    session: &RecentSessionSnapshot,
+    options: &RecentSessionRowOptions,
+    action: &mut Option<RecentSessionRowAction>,
+) {
+    ui.horizontal_centered(|ui| {
+        if recent_action_button(icons::regular::ARROW_COUNTER_CLOCKWISE)
+            .ui(ui)
+            .on_hover_text("Restore session")
+            .clicked()
+        {
+            *action = Some(RecentSessionRowAction::RestoreSession);
+        }
+
+        if recent_action_button(icons::regular::SLIDERS_HORIZONTAL)
+            .ui(ui)
+            .on_hover_text("Open with saved parser configuration")
+            .clicked()
+        {
+            *action = Some(RecentSessionRowAction::RestoreParserConfiguration);
+        }
+
+        if options.show_clean_open {
+            let clean_open = ui
+                .add_enabled(
+                    session.supports_clean_open(),
+                    recent_action_button(icons::regular::ARROW_SQUARE_OUT),
+                )
+                .on_hover_text("Open as a fresh session without restoring saved state")
+                .on_disabled_hover_text("Clean open is currently only available for file sessions");
+
+            if clean_open.clicked() {
+                *action = Some(RecentSessionRowAction::OpenClean);
+            }
+        }
+    });
+}
+
+fn render_row_menu(
+    ui: &mut Ui,
+    session: &RecentSessionSnapshot,
+    options: &RecentSessionRowOptions,
+    action: &mut Option<RecentSessionRowAction>,
+) {
+    if ui.button("Restore session").clicked() {
+        *action = Some(RecentSessionRowAction::RestoreSession);
+    }
+
+    if ui.button("Restore parser settings").clicked() {
+        *action = Some(RecentSessionRowAction::RestoreParserConfiguration);
+    }
+
+    if options.show_clean_open
+        && session.supports_clean_open()
+        && ui.button("Open without saved state").clicked()
+    {
+        *action = Some(RecentSessionRowAction::OpenClean);
+    }
+
+    ui.separator();
+
+    if ui.button("Remove").clicked() {
+        *action = Some(RecentSessionRowAction::Remove);
+    }
+}
+
+fn render_source_badge(ui: &mut Ui, session: &RecentSessionSnapshot) {
+    let icon = source_badge_icon(session);
+    let icon = RichText::new(icon).size(19.0);
+
+    Label::new(icon).ui(ui);
+}
+
+fn source_badge_icon(session: &RecentSessionSnapshot) -> &'static str {
+    match session.sources().first() {
+        Some(RecentSessionSource::File { .. }) => icons::regular::FILE,
+        Some(RecentSessionSource::Stream { transport }) => match transport {
+            stypes::Transport::Process(_) => icons::regular::TERMINAL_WINDOW,
+            stypes::Transport::TCP(_) => icons::regular::PLUGS_CONNECTED,
+            stypes::Transport::UDP(_) => icons::regular::BROADCAST,
+            stypes::Transport::Serial(_) => icons::regular::USB,
+        },
+        None => icons::regular::FILE,
+    }
+}
+
+fn recent_action_button(icon: &'static str) -> Button<'static> {
+    Button::new(RichText::new(icon).size(16.0))
+        .frame(false)
+        .frame_when_inactive(false)
+}

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/mod.rs
@@ -1,9 +1,15 @@
 use core::slice;
 
-use egui::{Align, Layout, Margin, TextEdit, Ui};
+use egui::{Align, Layout, Margin, ScrollArea, TextEdit, Ui};
+use tokio::sync::mpsc::Sender;
 
 use crate::host::{
-    common::ui_utls::{general_group_frame, show_validation_message},
+    command::HostCommand,
+    common::{
+        parsers::ParserNames,
+        sources::StreamNames,
+        ui_utls::{general_group_frame, show_validation_message},
+    },
     ui::{
         UiActions,
         session_setup::{
@@ -14,26 +20,67 @@ use crate::host::{
                 sources::{ByteSourceConfig, SourceFileInfo, StreamConfig},
             },
         },
+        storage::RecentSessionsStorage,
     },
 };
 
 mod dlt;
 pub mod process;
+mod recent;
 mod serial;
 mod tcp;
 pub mod udp;
 
 pub fn render_content(
     state: &mut SessionSetupState,
+    recent_sessions: &mut RecentSessionsStorage,
+    cmd_tx: &Sender<HostCommand>,
     actions: &mut UiActions,
     ui: &mut Ui,
 ) -> RenderOutcome {
-    let SessionSetupState { source, parser, .. } = state;
+    let SessionSetupState { id, source, parser } = state;
 
     match source {
         ByteSourceConfig::File(file) => render_files(slice::from_ref(file), parser, ui),
         ByteSourceConfig::Concat(files) => render_files(files, parser, ui),
-        ByteSourceConfig::Stream(stream) => render_stream(stream, actions, ui),
+        ByteSourceConfig::Stream(stream) => {
+            let current_stream = StreamNames::from(&*stream);
+            let current_parser = ParserNames::from(&*parser);
+            let get_frame = |ui: &mut Ui| {
+                general_group_frame(ui)
+                    .inner_margin(Margin::symmetric(10, 4))
+                    .outer_margin(Margin::symmetric(10, 4))
+            };
+            let mut output = RenderOutcome::None;
+
+            ui.with_layout(Layout::top_down_justified(Align::Min), |ui| {
+                get_frame(ui).show(ui, |ui| {
+                    ui.heading("Connection");
+                    ui.add_space(10.);
+                    output = render_stream_connection(stream, actions, ui);
+                });
+
+                get_frame(ui).show(ui, |ui| {
+                    ui.heading("Recent");
+                    ui.add_space(10.);
+
+                    ScrollArea::vertical()
+                        .id_salt(("stream_setup_recent", id))
+                        .show(ui, |ui| {
+                            recent::render_matching_recent_sessions(
+                                current_stream,
+                                current_parser,
+                                recent_sessions,
+                                cmd_tx,
+                                actions,
+                                ui,
+                            )
+                        });
+                });
+            });
+
+            output
+        }
     }
 }
 
@@ -51,33 +98,17 @@ fn render_files(
     }
 }
 
-/// Render main configuration for streams sources.
-fn render_stream(stream: &mut StreamConfig, actions: &mut UiActions, ui: &mut Ui) -> RenderOutcome {
-    let get_frame = |ui: &mut Ui| {
-        general_group_frame(ui)
-            .inner_margin(Margin::symmetric(10, 4))
-            .outer_margin(Margin::symmetric(10, 4))
-    };
-    let mut output = RenderOutcome::None;
-    ui.with_layout(Layout::top_down_justified(Align::Min), |ui| {
-        get_frame(ui).show(ui, |ui| {
-            ui.heading("Connection");
-            ui.add_space(10.);
-            output = match stream {
-                StreamConfig::Process(config) => process::render_connection(config, actions, ui),
-                StreamConfig::Tcp(config) => tcp::render_connection(config, ui),
-                StreamConfig::Udp(config) => udp::render_connection(config, ui),
-                StreamConfig::Serial(config) => serial::render_connection(config, ui),
-            };
-        });
-
-        get_frame(ui).show(ui, |ui| {
-            ui.heading("Recent");
-            ui.add_space(10.);
-        });
-    });
-
-    output
+fn render_stream_connection(
+    stream: &mut StreamConfig,
+    actions: &mut UiActions,
+    ui: &mut Ui,
+) -> RenderOutcome {
+    match stream {
+        StreamConfig::Process(config) => process::render_connection(config, actions, ui),
+        StreamConfig::Tcp(config) => tcp::render_connection(config, ui),
+        StreamConfig::Udp(config) => udp::render_connection(config, ui),
+        StreamConfig::Serial(config) => serial::render_connection(config, ui),
+    }
 }
 
 /// Specifies the needed functionality to be used with the function [`render_socket_address`].

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/recent.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/recent.rs
@@ -1,0 +1,92 @@
+//! Matching recent-session list for the stream session-setup surface.
+
+use egui::Ui;
+use tokio::sync::mpsc::Sender;
+
+use crate::host::{
+    command::{HostCommand, OpenRecentSessionParam},
+    common::{parsers::ParserNames, sources::StreamNames},
+    ui::{
+        UiActions,
+        recent_session::{
+            RecentSessionRowAction, RecentSessionRowOptions, render_recent_session_row,
+        },
+        storage::{RecentSessionReopenMode, RecentSessionSnapshot, RecentSessionsStorage},
+    },
+};
+
+pub fn render_matching_recent_sessions(
+    current_stream: StreamNames,
+    current_parser: ParserNames,
+    recent_sessions: &mut RecentSessionsStorage,
+    cmd_tx: &Sender<HostCommand>,
+    actions: &mut UiActions,
+    ui: &mut Ui,
+) {
+    let mut has_matches = false;
+
+    let mut remove_session = None;
+
+    for session in &recent_sessions.sessions {
+        if session.parser_kind() != current_parser || session.stream_kind() != Some(current_stream)
+        {
+            continue;
+        }
+
+        has_matches = true;
+
+        const OPTIONS: RecentSessionRowOptions = RecentSessionRowOptions {
+            show_clean_open: false,
+        };
+
+        let render_action = render_recent_session_row(ui, session, &OPTIONS);
+        if let Some(action) = render_action {
+            match action {
+                RecentSessionRowAction::RestoreSession => {
+                    open_recent_session(
+                        cmd_tx,
+                        actions,
+                        session.clone(),
+                        RecentSessionReopenMode::RestoreSession,
+                    );
+                }
+                RecentSessionRowAction::RestoreParserConfiguration => {
+                    open_recent_session(
+                        cmd_tx,
+                        actions,
+                        session.clone(),
+                        RecentSessionReopenMode::RestoreParserConfiguration,
+                    );
+                }
+                RecentSessionRowAction::OpenClean => {
+                    debug_assert!(
+                        false,
+                        "Clean open is disabled in session setup recent sessions"
+                    );
+                }
+                RecentSessionRowAction::Remove => {
+                    remove_session = Some(session.source_key.clone());
+                }
+            }
+        }
+        ui.add_space(4.0);
+    }
+
+    if !has_matches {
+        ui.label("No matching recent sessions yet.");
+    }
+
+    if let Some(source_key) = remove_session {
+        recent_sessions.remove_session(&source_key);
+    }
+}
+
+fn open_recent_session(
+    cmd_tx: &Sender<HostCommand>,
+    actions: &mut UiActions,
+    snapshot: RecentSessionSnapshot,
+    mode: RecentSessionReopenMode,
+) {
+    let cmd = HostCommand::OpenRecentSession(Box::new(OpenRecentSessionParam { snapshot, mode }));
+    actions.try_send_command(cmd_tx, cmd);
+}

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     host::{
         command::HostCommand,
         common::{file_utls, parsers::ParserNames, sources::StreamNames},
-        ui::UiActions,
+        ui::{UiActions, storage::RecentSessionsStorage},
     },
 };
 use state::{SessionSetupState, sources::ByteSourceConfig};
@@ -57,7 +57,12 @@ impl SessionSetup {
         actions.try_send_command(&self.cmd_tx, HostCommand::CloseSessionSetup(self.id()));
     }
 
-    pub fn render_content(&mut self, actions: &mut UiActions, ui: &mut Ui) {
+    pub fn render_content(
+        &mut self,
+        actions: &mut UiActions,
+        recent_sessions: &mut RecentSessionsStorage,
+        ui: &mut Ui,
+    ) {
         Panel::top("selection_panel")
             .exact_size(40.)
             .show_inside(ui, |ui| {
@@ -77,7 +82,13 @@ impl SessionSetup {
 
         CentralPanel::default().show_inside(ui, |ui| {
             ui.centered_and_justified(|ui| {
-                let outcome = main_config::render_content(&mut self.state, actions, ui);
+                let outcome = main_config::render_content(
+                    &mut self.state,
+                    recent_sessions,
+                    &self.cmd_tx,
+                    actions,
+                    ui,
+                );
                 match outcome {
                     RenderOutcome::CollectStatistics => {
                         if self.state.is_valid() {

--- a/application/apps/indexer/gui/application/src/host/ui/storage/recent/session.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/storage/recent/session.rs
@@ -13,7 +13,7 @@ use processor::search::filter::SearchFilter;
 use stypes::{FileFormat, ObserveOptions, ObserveOrigin, ParserType, Transport};
 use uuid::Uuid;
 
-use crate::host::common::parsers::ParserNames;
+use crate::host::common::{parsers::ParserNames, sources::StreamNames};
 
 use super::source_key;
 
@@ -152,6 +152,27 @@ impl RecentSessionSnapshot {
 
     pub fn rebuild_cache(&mut self) {
         self.cache = build_cache(&self.sources, &self.parser, &self.state);
+    }
+
+    pub fn parser_kind(&self) -> ParserNames {
+        ParserNames::from(&self.parser)
+    }
+
+    /// Sessions only persist one stream kind, so the first stream source defines the kind.
+    pub fn stream_kind(&self) -> Option<StreamNames> {
+        match self.sources.first()? {
+            RecentSessionSource::File { .. } => None,
+            RecentSessionSource::Stream { transport } => {
+                let stream_name = match transport {
+                    Transport::Process(_) => StreamNames::Process,
+                    Transport::TCP(_) => StreamNames::Tcp,
+                    Transport::UDP(_) => StreamNames::Udp,
+                    Transport::Serial(_) => StreamNames::Serial,
+                };
+
+                Some(stream_name)
+            }
+        }
     }
 
     /// Rebuilds the startup observe plan for restore-style reopen flows.
@@ -516,6 +537,65 @@ mod tests {
         ));
 
         assert_eq!(snapshot.summary(), "1 file • Plain Text");
+    }
+
+    #[test]
+    fn parser_kind_ignores_configuration_details() {
+        let snapshot = snapshot_from_observe_options(ObserveOptions {
+            origin: ObserveOrigin::Stream(
+                String::new(),
+                Transport::TCP(TCPTransportConfig {
+                    bind_addr: String::from("127.0.0.1:5556"),
+                }),
+            ),
+            parser: ParserType::SomeIp(stypes::SomeIpParserSettings {
+                fibex_file_paths: Some(vec![String::from("/tmp/one.xml")]),
+            }),
+        });
+
+        assert_eq!(
+            snapshot.parser_kind(),
+            crate::host::common::parsers::ParserNames::SomeIP
+        );
+    }
+
+    #[test]
+    fn stream_kind_uses_first_stream_source() {
+        let snapshot = RecentSessionSnapshot::new(
+            1,
+            vec![
+                RecentSessionSource::Stream {
+                    transport: Transport::UDP(UDPTransportConfig {
+                        bind_addr: String::from("127.0.0.1:5000"),
+                        multicast: Vec::new(),
+                    }),
+                },
+                RecentSessionSource::Stream {
+                    transport: Transport::UDP(UDPTransportConfig {
+                        bind_addr: String::from("127.0.0.1:5001"),
+                        multicast: Vec::new(),
+                    }),
+                },
+            ],
+            ParserType::Text(()),
+            Default::default(),
+        );
+
+        assert_eq!(
+            snapshot.stream_kind(),
+            Some(crate::host::common::sources::StreamNames::Udp)
+        );
+    }
+
+    #[test]
+    fn file_snapshot_has_no_stream_kind() {
+        let snapshot = snapshot_from_observe_options(ObserveOptions::file(
+            PathBuf::from("first.log"),
+            stypes::FileFormat::Text,
+            ParserType::Text(()),
+        ));
+
+        assert!(snapshot.stream_kind().is_none());
     }
 
     #[test]


### PR DESCRIPTION
This PR:
* Extend recent session in session setup views for stream sources.
* Move shared rendering into new central modules to avoid code duplication