### PR TITLE
Native: Improve home view layout & Various other improvements & fixes

### DIFF
--- a/application/apps/indexer/gui/application/src/common/comm_utls.rs
+++ b/application/apps/indexer/gui/application/src/common/comm_utls.rs
@@ -2,8 +2,8 @@
 
 use tokio::sync::mpsc::error::SendError;
 
-/// Evaluate send results waking up the UI when successful returning `true`
-/// Otherwise, it will log the error and return `false`
+/// Evaluate send results waking up the UI when successful and returning `true`.
+/// Otherwise, log the dropped delivery at trace level and return `false`.
 pub fn evaluate_send_res<T>(
     egui_ctx: &egui::Context,
     send_result: Result<(), SendError<T>>,
@@ -14,7 +14,7 @@ pub fn evaluate_send_res<T>(
             true
         }
         Err(error) => {
-            log::error!("Communication Error. {error}");
+            log::trace!("UI channel delivery dropped: {error}");
             false
         }
     }

--- a/application/apps/indexer/gui/application/src/common/ui/tab_strip.rs
+++ b/application/apps/indexer/gui/application/src/common/ui/tab_strip.rs
@@ -493,6 +493,12 @@ fn render_tab(
             }
         })
         .unwrap_or(fg);
+    let show_close_button = selected
+        || body_response.hovered()
+        || body_response.has_focus()
+        || close_response.as_ref().is_some_and(|response| {
+            response.hovered() || response.is_pointer_button_down_on() || response.has_focus()
+        });
 
     if ui.is_rect_visible(rect) {
         // Tab chrome and close icons must respect the logical strip viewport so they do not paint
@@ -519,7 +525,9 @@ fn render_tab(
             add_content,
         );
 
-        if let Some(close_rect) = rects.close_rect {
+        if show_close_button
+            && let Some(close_rect) = rects.close_rect
+        {
             painter.text(
                 close_rect.center(),
                 Align2::CENTER_CENTER,

--- a/application/apps/indexer/gui/application/src/host/command.rs
+++ b/application/apps/indexer/gui/application/src/host/command.rs
@@ -74,6 +74,7 @@ pub struct StartSessionParam {
 pub struct OpenRecentSessionParam {
     pub snapshot: RecentSessionSnapshot,
     pub mode: RecentSessionReopenMode,
+    pub session_setup_id: Option<Uuid>,
 }
 
 #[derive(Debug, Clone)]

--- a/application/apps/indexer/gui/application/src/host/service/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/service/mod.rs
@@ -168,8 +168,9 @@ impl HostService {
                 self.start_session(source, parser, session_setup_id).await?;
             }
             HostCommand::OpenRecentSession(params) => {
+                let session_setup_id = params.session_setup_id;
                 let request = storage::recent::resolve_open_request(*params)?;
-                self.open_recent_session(request).await?;
+                self.open_recent_session(request, session_setup_id).await?;
             }
             HostCommand::ImportPresets(path) => {
                 self.import_presets(path).await?;
@@ -219,6 +220,7 @@ impl HostService {
     async fn open_recent_session(
         &self,
         request: RecentSessionOpenRequest,
+        session_setup_id: Option<Uuid>,
     ) -> Result<(), HostError> {
         match request {
             RecentSessionOpenRequest::Restore {
@@ -238,7 +240,7 @@ impl HostService {
                     .senders
                     .send_message(HostMessage::SessionCreated {
                         session: Box::new(session),
-                        session_setup_id: None,
+                        session_setup_id,
                     })
                     .await;
             }

--- a/application/apps/indexer/gui/application/src/host/service/storage/recent.rs
+++ b/application/apps/indexer/gui/application/src/host/service/storage/recent.rs
@@ -54,7 +54,11 @@ pub fn load_sessions() -> Result<Box<RecentSessionsStorage>, StorageError> {
 pub fn resolve_open_request(
     params: OpenRecentSessionParam,
 ) -> Result<RecentSessionOpenRequest, HostError> {
-    let OpenRecentSessionParam { snapshot, mode } = params;
+    let OpenRecentSessionParam {
+        snapshot,
+        mode,
+        session_setup_id: _,
+    } = params;
 
     match mode {
         RecentSessionReopenMode::RestoreSession => resolve_restore_request(snapshot, true),
@@ -533,11 +537,13 @@ mod tests {
         let restore_request = resolve_open_request(OpenRecentSessionParam {
             snapshot: snapshot.clone(),
             mode: RecentSessionReopenMode::RestoreSession,
+            session_setup_id: None,
         })
         .expect("restore request should resolve");
         let parser_request = resolve_open_request(OpenRecentSessionParam {
             snapshot,
             mode: RecentSessionReopenMode::RestoreParserConfiguration,
+            session_setup_id: None,
         })
         .expect("parser restore request should resolve");
 
@@ -589,6 +595,7 @@ mod tests {
         let request = resolve_open_request(OpenRecentSessionParam {
             snapshot,
             mode: RecentSessionReopenMode::RestoreSession,
+            session_setup_id: None,
         })
         .expect("multi-stream restore should resolve");
 
@@ -627,6 +634,7 @@ mod tests {
         let request = resolve_open_request(OpenRecentSessionParam {
             snapshot,
             mode: RecentSessionReopenMode::RestoreSession,
+            session_setup_id: None,
         })
         .expect("multi-file restore should resolve");
 

--- a/application/apps/indexer/gui/application/src/host/ui/home/file_explorer.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/file_explorer.rs
@@ -24,6 +24,7 @@ use crate::host::{
 };
 
 const FAVORITES_FOLDER_ID: &str = "favorites_folder";
+const TEXT_EDIT_HEIGHT: f32 = 25.0;
 
 #[derive(Debug)]
 pub struct FileExplorerUi {
@@ -70,7 +71,7 @@ impl FileExplorerUi {
         }
 
         ui.allocate_ui_with_layout(
-            vec2(ui.available_width(), 20.),
+            vec2(ui.available_width(), TEXT_EDIT_HEIGHT),
             Layout::right_to_left(Align::Center),
             |ui| {
                 let icon_size = 15.0;
@@ -123,8 +124,8 @@ impl FileExplorerUi {
                     let txt_input = sized_singleline_text_edit(
                         ui,
                         &mut self.favorite_search,
-                        ui.available_size(),
-                        3,
+                        vec2(ui.available_width(), TEXT_EDIT_HEIGHT),
+                        7,
                     )
                     .hint_text("Type to filter...");
 
@@ -292,7 +293,7 @@ impl FileExplorerUi {
             }
         });
 
-        if !busy && response.double_clicked() {
+        if !busy && response.clicked() {
             self.open_favorite_file(actions, folder_path.join(&file.name));
         }
 

--- a/application/apps/indexer/gui/application/src/host/ui/home/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/mod.rs
@@ -9,14 +9,23 @@ use crate::common::phosphor::icons;
 use crate::host::{
     command::HostCommand,
     common::{parsers::ParserNames, sources::StreamNames, ui_utls::general_group_frame},
-    ui::{UiActions, actions::FileDialogOptions, state::PanelsVisibility, storage::HostStorage},
+    ui::{
+        UiActions,
+        actions::FileDialogOptions,
+        state::PanelsVisibility,
+        storage::{HostStorage, RecentSessionsStorage},
+    },
 };
 
 mod file_explorer;
 mod recent;
 
 const ACTION_FILES_ID: &str = "action_files";
-const QUICK_ACTIONS_WIDTH: f32 = 45.0;
+const QUICK_ACTIONS_WIDE_WIDTH: f32 = 274.0;
+const RECENT_SESSIONS_MAX_WIDTH: f32 = 720.0;
+const PANEL_GAP_WIDTH: f32 = 4.0;
+const WIDE_LAYOUT_WIDTH: f32 =
+    QUICK_ACTIONS_WIDE_WIDTH + RECENT_SESSIONS_MAX_WIDTH + (PANEL_GAP_WIDTH * 3.);
 
 #[derive(Debug)]
 pub struct HomeView {
@@ -44,6 +53,8 @@ impl HomeView {
         panels_visibility: &PanelsVisibility,
         ui: &mut Ui,
     ) {
+        self.handle_pending_file_dialog(actions);
+
         Panel::right("favorite folders")
             .size_range(100.0..=750.0)
             .default_size(350.)
@@ -54,83 +65,200 @@ impl HomeView {
             });
 
         CentralPanel::default().show_inside(ui, |ui| {
+            // Layout rules:
+            // - Wide views show the horizontal quick actions and center them with recent sessions.
+            // - Smaller views switch to the narrow quick-actions rail and let recent sessions
+            //   fill the remaining width.
             let available_height = ui.available_height();
+            let show_wide_quick_actions = ui.available_width() >= WIDE_LAYOUT_WIDTH;
 
-            ui.horizontal_top(|ui| {
-                ui.allocate_ui_with_layout(
-                    vec2(QUICK_ACTIONS_WIDTH, available_height),
-                    Layout::top_down(Align::Center),
-                    |ui| {
-                        general_group_frame(ui)
-                            .inner_margin(Margin::symmetric(0, 2))
-                            .show(ui, |ui| {
-                                ui.take_available_height();
-                                ui.set_width(ui.available_width());
-                                render_quick_actions(ui, actions, &self.cmd_tx);
-                            });
-                    },
-                );
+            if show_wide_quick_actions {
+                // Center the fixed-width quick-actions + recent-sessions block as one unit.
 
-                ui.allocate_ui_with_layout(
-                    vec2(ui.available_width(), available_height),
-                    Layout::top_down(Align::Min),
-                    |ui| {
-                        general_group_frame(ui).show(ui, |ui| {
-                            ui.take_available_width();
-                            self.recent_sessions.render_content(
-                                actions,
-                                &mut storage.recent_sessions,
+                ui.with_layout(Layout::top_down(Align::Center), |ui| {
+                    ui.allocate_ui_with_layout(
+                        vec2(WIDE_LAYOUT_WIDTH, available_height),
+                        Layout::left_to_right(Align::Min),
+                        |ui| {
+                            self.render_wide_quick_actions(ui, actions);
+                            self.render_recent_sessions_panel(
                                 ui,
+                                &mut storage.recent_sessions,
+                                actions,
+                                RECENT_SESSIONS_MAX_WIDTH,
+                                available_height,
                             );
+                        },
+                    );
+                });
+            } else {
+                // In compact mode the actions collapse to a narrow rail and recent sessions take the rest.
+                ui.horizontal_top(|ui| {
+                    self.render_compact_quick_actions(ui, actions);
+                    self.render_recent_sessions_panel(
+                        ui,
+                        &mut storage.recent_sessions,
+                        actions,
+                        ui.available_width(),
+                        available_height,
+                    );
+                });
+            }
+        });
+    }
+
+    fn handle_pending_file_dialog(&self, actions: &mut UiActions) {
+        if let Some(paths) = actions.file_dialog.take_output(ACTION_FILES_ID)
+            && !paths.is_empty()
+        {
+            actions.try_send_command(&self.cmd_tx, HostCommand::OpenFiles(paths));
+        }
+    }
+
+    // Width is chosen by the outer layout: fixed in wide mode, remaining space in compact mode.
+    fn render_recent_sessions_panel(
+        &mut self,
+        ui: &mut Ui,
+        recent_sessions: &mut RecentSessionsStorage,
+        actions: &mut UiActions,
+        width: f32,
+        height: f32,
+    ) {
+        ui.allocate_ui_with_layout(vec2(width, height), Layout::top_down(Align::Min), |ui| {
+            general_group_frame(ui).show(ui, |ui| {
+                ui.take_available_width();
+                self.recent_sessions
+                    .render_content(actions, recent_sessions, ui);
+            });
+        });
+    }
+
+    fn render_wide_quick_actions(&self, ui: &mut egui::Ui, actions: &mut UiActions) {
+        ui.allocate_ui(vec2(QUICK_ACTIONS_WIDE_WIDTH, 0.0), |ui| {
+            general_group_frame(ui)
+                .inner_margin(Margin::same(8))
+                .show(ui, |ui| {
+                    let button_size = egui::vec2(80.0, 72.0);
+
+                    ui.horizontal_centered(|ui| {
+                        action_button(
+                            ui,
+                            button_size,
+                            icons::regular::FOLDER,
+                            "File(s)",
+                            true,
+                            || {
+                                actions.file_dialog.pick_files(
+                                    ACTION_FILES_ID,
+                                    FileDialogOptions::new().title("Open files(s)"),
+                                );
+                            },
+                        );
+
+                        let connections_button = action_button(
+                            ui,
+                            button_size,
+                            icons::regular::PLUGS_CONNECTED,
+                            "Connections",
+                            true,
+                            || {},
+                        );
+
+                        egui::Popup::menu(&connections_button).show(|ui| {
+                            render_connections_menu(ui, actions, &self.cmd_tx);
                         });
-                    },
-                );
-            });
+
+                        action_button(
+                            ui,
+                            button_size,
+                            icons::regular::TERMINAL,
+                            "Terminal",
+                            true,
+                            || {
+                                actions.try_send_command(
+                                    &self.cmd_tx,
+                                    HostCommand::ConnectionSessionSetup {
+                                        stream: StreamNames::Process,
+                                        parser: ParserNames::Text,
+                                    },
+                                );
+                            },
+                        );
+                    });
+                });
         });
     }
-}
 
-fn render_quick_actions(ui: &mut egui::Ui, actions: &mut UiActions, cmd_tx: &Sender<HostCommand>) {
-    if let Some(paths) = actions.file_dialog.take_output(ACTION_FILES_ID)
-        && !paths.is_empty()
-    {
-        actions.try_send_command(cmd_tx, HostCommand::OpenFiles(paths));
+    fn render_compact_quick_actions(&self, ui: &mut egui::Ui, actions: &mut UiActions) {
+        const QUICK_ACTIONS_COMPACT_WIDTH: f32 = 55.0;
+
+        ui.allocate_ui_with_layout(
+            vec2(QUICK_ACTIONS_COMPACT_WIDTH, ui.available_height()),
+            Layout::top_down(Align::Center),
+            |ui| {
+                general_group_frame(ui)
+                    .inner_margin(Margin::same(4))
+                    .show(ui, |ui| {
+                        ui.take_available_height();
+                        ui.set_width(ui.available_width());
+
+                        const QUICK_ACTIONS_COMPACT_BUTTON_HEIGHT: f32 = 44.0;
+                        let button_size =
+                            egui::vec2(ui.available_width(), QUICK_ACTIONS_COMPACT_BUTTON_HEIGHT);
+
+                        egui::ScrollArea::vertical()
+                            .id_salt("quick_actions_scroll")
+                            .show(ui, |ui| {
+                                action_button(
+                                    ui,
+                                    button_size,
+                                    icons::regular::FOLDER,
+                                    "File(s)",
+                                    false,
+                                    || {
+                                        actions.file_dialog.pick_files(
+                                            ACTION_FILES_ID,
+                                            FileDialogOptions::new().title("Open files(s)"),
+                                        );
+                                    },
+                                );
+                                ui.add_space(4.0);
+
+                                let connections_button = action_button(
+                                    ui,
+                                    button_size,
+                                    icons::regular::PLUGS_CONNECTED,
+                                    "Connections",
+                                    false,
+                                    || {},
+                                );
+                                ui.add_space(4.0);
+
+                                egui::Popup::menu(&connections_button).show(|ui| {
+                                    render_connections_menu(ui, actions, &self.cmd_tx);
+                                });
+
+                                action_button(
+                                    ui,
+                                    button_size,
+                                    icons::regular::TERMINAL,
+                                    "Terminal",
+                                    false,
+                                    || {
+                                        actions.try_send_command(
+                                            &self.cmd_tx,
+                                            HostCommand::ConnectionSessionSetup {
+                                                stream: StreamNames::Process,
+                                                parser: ParserNames::Text,
+                                            },
+                                        );
+                                    },
+                                );
+                            });
+                    });
+            },
+        );
     }
-
-    let item_size = egui::vec2(ui.available_width(), 44.0);
-
-    egui::ScrollArea::vertical()
-        .id_salt("quick_actions_scroll")
-        .show(ui, |ui| {
-            action_button(ui, item_size, icons::regular::FOLDER, "File(s)", || {
-                actions.file_dialog.pick_files(
-                    ACTION_FILES_ID,
-                    FileDialogOptions::new().title("Open files(s)"),
-                );
-            });
-
-            let connections_button = action_button(
-                ui,
-                item_size,
-                icons::regular::PLUGS_CONNECTED,
-                "Connections",
-                || {},
-            );
-
-            egui::Popup::menu(&connections_button).show(|ui| {
-                render_connections_menu(ui, actions, cmd_tx);
-            });
-
-            action_button(ui, item_size, icons::regular::TERMINAL, "Terminal", || {
-                actions.try_send_command(
-                    cmd_tx,
-                    HostCommand::ConnectionSessionSetup {
-                        stream: StreamNames::Process,
-                        parser: ParserNames::Text,
-                    },
-                );
-            });
-        });
 }
 
 fn action_button(
@@ -138,10 +266,12 @@ fn action_button(
     size: egui::Vec2,
     icon: &str,
     label: &str,
+    show_label: bool,
     on_click: impl FnOnce(),
 ) -> egui::Response {
     ui.push_id(format!("quick_action_{}", label.to_lowercase()), |ui| {
         let (rect, response) = ui.allocate_exact_size(size, egui::Sense::click());
+        let response = response.on_hover_cursor(egui::CursorIcon::PointingHand);
 
         let visuals = ui.style().interact(&response);
 
@@ -157,7 +287,12 @@ fn action_button(
                 egui::Layout::top_down_justified(egui::Align::Center),
                 |ui| {
                     ui.add_space(2.0);
-                    ui.label(egui::RichText::new(icon).size(22.0));
+                    ui.label(egui::RichText::new(icon).size(if show_label { 20.0 } else { 22.0 }));
+
+                    if show_label {
+                        ui.add_space(2.0);
+                        ui.label(egui::RichText::new(label).size(12.0));
+                    }
                 },
             );
         });
@@ -168,7 +303,6 @@ fn action_button(
             on_click();
         }
 
-        ui.add_space(4.0);
         response
     })
     .inner

--- a/application/apps/indexer/gui/application/src/host/ui/home/recent.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/recent.rs
@@ -143,6 +143,7 @@ impl RecentSessionsUi {
         let cmd = HostCommand::OpenRecentSession(Box::new(OpenRecentSessionParam {
             snapshot: snapshot.clone(),
             mode,
+            session_setup_id: None,
         }));
         actions.try_send_command(&self.cmd_tx, cmd);
     }

--- a/application/apps/indexer/gui/application/src/host/ui/recent_session.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/recent_session.rs
@@ -38,6 +38,7 @@ pub fn render_recent_session_row(
         ui.allocate_exact_size(vec2(ui.available_width(), ROW_HEIGHT), Sense::click());
     let mut action = None;
 
+    let response = response.on_hover_cursor(egui::CursorIcon::PointingHand);
     response.context_menu(|ui| render_row_menu(ui, session, options, &mut action));
 
     if response.hovered() {
@@ -78,7 +79,7 @@ pub fn render_recent_session_row(
             );
     });
 
-    if response.double_clicked() && action.is_none() {
+    if response.clicked() && action.is_none() {
         action = Some(RecentSessionRowAction::RestoreSession);
     }
 
@@ -94,7 +95,7 @@ fn render_row_actions(
     ui.horizontal_centered(|ui| {
         if recent_action_button(icons::regular::ARROW_COUNTER_CLOCKWISE)
             .ui(ui)
-            .on_hover_text("Restore session")
+            .on_hover_text("Open with all saved session settings, including filters and charts")
             .clicked()
         {
             *action = Some(RecentSessionRowAction::RestoreSession);
@@ -102,7 +103,9 @@ fn render_row_actions(
 
         if recent_action_button(icons::regular::SLIDERS_HORIZONTAL)
             .ui(ui)
-            .on_hover_text("Open with saved parser configuration")
+            .on_hover_text(
+                "Open with only the saved parser settings. Filters, charts, and other session settings will not be restored",
+            )
             .clicked()
         {
             *action = Some(RecentSessionRowAction::RestoreParserConfiguration);
@@ -115,7 +118,9 @@ fn render_row_actions(
                     recent_action_button(icons::regular::ARROW_SQUARE_OUT),
                 )
                 .on_hover_text("Open as a fresh session without restoring saved state")
-                .on_disabled_hover_text("Clean open is currently only available for file sessions");
+                .on_disabled_hover_text(
+                    "Open fresh session is currently only available for file sessions",
+                );
 
             if clean_open.clicked() {
                 *action = Some(RecentSessionRowAction::OpenClean);

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/mod.rs
@@ -44,6 +44,7 @@ pub fn render_content(
         ByteSourceConfig::File(file) => render_files(slice::from_ref(file), parser, ui),
         ByteSourceConfig::Concat(files) => render_files(files, parser, ui),
         ByteSourceConfig::Stream(stream) => {
+            let session_setup_id = *id;
             let current_stream = StreamNames::from(&*stream);
             let current_parser = ParserNames::from(&*parser);
             let get_frame = |ui: &mut Ui| {
@@ -65,9 +66,10 @@ pub fn render_content(
                     ui.add_space(10.);
 
                     ScrollArea::vertical()
-                        .id_salt(("stream_setup_recent", id))
+                        .id_salt(("stream_setup_recent", session_setup_id))
                         .show(ui, |ui| {
                             recent::render_matching_recent_sessions(
+                                session_setup_id,
                                 current_stream,
                                 current_parser,
                                 recent_sessions,

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/recent.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/recent.rs
@@ -16,6 +16,7 @@ use crate::host::{
 };
 
 pub fn render_matching_recent_sessions(
+    session_setup_id: uuid::Uuid,
     current_stream: StreamNames,
     current_parser: ParserNames,
     recent_sessions: &mut RecentSessionsStorage,
@@ -48,6 +49,7 @@ pub fn render_matching_recent_sessions(
                         actions,
                         session.clone(),
                         RecentSessionReopenMode::RestoreSession,
+                        Some(session_setup_id),
                     );
                 }
                 RecentSessionRowAction::RestoreParserConfiguration => {
@@ -56,6 +58,7 @@ pub fn render_matching_recent_sessions(
                         actions,
                         session.clone(),
                         RecentSessionReopenMode::RestoreParserConfiguration,
+                        Some(session_setup_id),
                     );
                 }
                 RecentSessionRowAction::OpenClean => {
@@ -86,7 +89,12 @@ fn open_recent_session(
     actions: &mut UiActions,
     snapshot: RecentSessionSnapshot,
     mode: RecentSessionReopenMode,
+    session_setup_id: Option<uuid::Uuid>,
 ) {
-    let cmd = HostCommand::OpenRecentSession(Box::new(OpenRecentSessionParam { snapshot, mode }));
+    let cmd = HostCommand::OpenRecentSession(Box::new(OpenRecentSessionParam {
+        snapshot,
+        mode,
+        session_setup_id,
+    }));
     actions.try_send_command(cmd_tx, cmd);
 }

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_bar.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_bar.rs
@@ -1,14 +1,14 @@
 use tokio::sync::mpsc::Sender;
 
 use egui::{
-    Align, Frame, Id, Key, Layout, Margin, Modifiers, RichText, Stroke, TextEdit, Ui, Widget, vec2,
+    Align, Button, Frame, Id, Key, Layout, Margin, Modifiers, RichText, Stroke, TextEdit, Ui,
+    Widget, vec2,
 };
 use processor::search::filter::SearchFilter;
 
 use crate::{
     common::{
         phosphor::{self, icons},
-        ui::buttons,
         validation::{ValidationEligibility, validate_filter},
     },
     host::{
@@ -222,10 +222,7 @@ impl SearchBar {
                                 });
 
                             let mut add_btn = ui
-                                .add_enabled(
-                                    disabled_reason.is_none(),
-                                    buttons::bottom_panel_icon(save_txt),
-                                )
+                                .add_enabled(disabled_reason.is_none(), Button::new(save_txt))
                                 .on_hover_text("Add to Filters");
 
                             if let Some(reason) = disabled_reason {
@@ -263,7 +260,7 @@ impl SearchBar {
                             let mut add_btn = ui
                                 .add_enabled(
                                     disabled_reason.is_none(),
-                                    buttons::bottom_panel_icon(icons::regular::CHART_LINE),
+                                    Button::new(icons::regular::CHART_LINE),
                                 )
                                 .on_hover_text("Add to Search Values");
 
@@ -291,7 +288,7 @@ impl SearchBar {
                             }
                         }
 
-                        if buttons::bottom_panel_icon(icons::regular::X)
+                        if Button::new(icons::regular::X)
                             .ui(ui)
                             .on_hover_text("Remove filter")
                             .clicked()

--- a/application/apps/indexer/session/src/handlers/search.rs
+++ b/application/apps/indexer/session/src/handlers/search.rs
@@ -45,7 +45,7 @@ struct SearchOutput {
 /// though release is still progressing. We bound retries to keep this handover
 /// window tolerant without risking an unbounded wait.
 async fn wait_until_search_dropped(state: &SessionStateAPI) -> Result<(), stypes::NativeError> {
-    const RETRY_ATTEMPTS: u8 = 10;
+    const RETRY_ATTEMPTS: u8 = 30;
     const RETRY_DELAY_MS: u64 = 15;
 
     for attempt in 0..RETRY_ATTEMPTS {

--- a/application/apps/indexer/session/src/handlers/search_values.rs
+++ b/application/apps/indexer/session/src/handlers/search_values.rs
@@ -39,7 +39,7 @@ struct ValueSearchResults {
 async fn wait_until_search_values_dropped(
     state: &SessionStateAPI,
 ) -> Result<(), stypes::NativeError> {
-    const RETRY_ATTEMPTS: u8 = 10;
+    const RETRY_ATTEMPTS: u8 = 30;
     const RETRY_DELAY_MS: u64 = 15;
 
     for attempt in 0..RETRY_ATTEMPTS {


### PR DESCRIPTION
This PR includes:

### Home Layout:
Layout now has two modes:
* Wide with wide quick actions where quick action will stay centralized
  in home view to avoid expanding too much.
* Narrow quick actions when size is too narrow for wide quick action
  buttons.

### Fixes & Improvements
- Fix buttons search bar are too big.
- Make error on dropping search more reclines by giving it more retries.
- Avoid logging errors when channels are UI dropped as it's normal
  behavior for channels to be closed on closing chipmunk.
- Open recent session from streams view closes that tab.
- Recent sessions and file explorer items open with one click + Change
  mouse cursor.
- improve tooltips for action button in recent view
- Session Tabs: Show close button when tab is active or hovered only
- Make text input in file explorer slightly bigger.