### PR TITLE
Native: Focus input texts when newly visible & UI improvements

### DIFF
--- a/application/apps/indexer/gui/application/src/common/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/common/ui/mod.rs
@@ -1,3 +1,4 @@
 pub mod buttons;
 pub mod substring_matcher;
 pub mod tab_strip;
+pub mod visibility_tracker;

--- a/application/apps/indexer/gui/application/src/common/ui/tab_strip.rs
+++ b/application/apps/indexer/gui/application/src/common/ui/tab_strip.rs
@@ -525,9 +525,7 @@ fn render_tab(
             add_content,
         );
 
-        if show_close_button
-            && let Some(close_rect) = rects.close_rect
-        {
+        if show_close_button && let Some(close_rect) = rects.close_rect {
             painter.text(
                 close_rect.center(),
                 Align2::CENTER_CENTER,

--- a/application/apps/indexer/gui/application/src/common/ui/visibility_tracker.rs
+++ b/application/apps/indexer/gui/application/src/common/ui/visibility_tracker.rs
@@ -1,0 +1,84 @@
+//! Frame-based visibility transition tracking for immediate-mode UI.
+//!
+//! In egui a widget does not have a retained visibility lifecycle. If a branch is not rendered in
+//! a frame, the widget simply does not exist for that frame. `VisibilityTracker` stores the last
+//! frame in which a caller marked something as visible and reports when that thing becomes visible
+//! again.
+
+use egui::Ui;
+
+/// Tracks whether something is visible in consecutive egui frames.
+///
+/// Call [`Self::is_newly_visible`] exactly once in each frame where the tracked thing is actually
+/// rendered. The method returns `true` on the first observed frame and again after one or more
+/// frames where it was not marked visible.
+///
+/// This is useful for one-shot UI work tied to visibility transitions, such as requesting focus,
+/// resetting transient animation state, or scrolling an item into view.
+#[derive(Debug, Clone, Default)]
+pub struct VisibilityTracker {
+    last_visible_frame: Option<u64>,
+}
+
+impl VisibilityTracker {
+    /// Marks the tracked thing as visible in the current frame.
+    ///
+    /// Returns `true` when this is the first visible frame observed by the tracker, or when one or
+    /// more egui frames elapsed since the previous visible frame.
+    ///
+    /// The tracker only knows about frames where this method is called. If a widget is rendered in
+    /// every frame, this returns `true` once and then `false` in subsequent frames. If rendering is
+    /// skipped for at least one frame, the next call returns `true` again.
+    pub fn is_newly_visible(&mut self, ui: &Ui) -> bool {
+        let frame_nr = ui.cumulative_frame_nr();
+        // First time the item is rendered is count as newly visible as well.
+        let is_newly_visible = self
+            .last_visible_frame
+            .is_none_or(|last_visible_frame| last_visible_frame.saturating_add(1) < frame_nr);
+
+        self.last_visible_frame = Some(frame_nr);
+        is_newly_visible
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VisibilityTracker;
+
+    #[test]
+    fn returns_true_on_first_visible_frame() {
+        let mut tracker = VisibilityTracker::default();
+        let ctx = egui::Context::default();
+
+        let _ = ctx.run_ui(Default::default(), |ui| {
+            assert!(tracker.is_newly_visible(ui));
+        });
+    }
+
+    #[test]
+    fn returns_false_while_visibility_is_continuous() {
+        let mut tracker = VisibilityTracker::default();
+        let ctx = egui::Context::default();
+
+        let _ = ctx.run_ui(Default::default(), |ui| {
+            assert!(tracker.is_newly_visible(ui));
+        });
+        let _ = ctx.run_ui(Default::default(), |ui| {
+            assert!(!tracker.is_newly_visible(ui));
+        });
+    }
+
+    #[test]
+    fn returns_true_after_visibility_gap() {
+        let mut tracker = VisibilityTracker::default();
+        let ctx = egui::Context::default();
+
+        let _ = ctx.run_ui(Default::default(), |ui| {
+            assert!(tracker.is_newly_visible(ui));
+        });
+        let _ = ctx.run_ui(Default::default(), |_| {});
+        let _ = ctx.run_ui(Default::default(), |ui| {
+            assert!(tracker.is_newly_visible(ui));
+        });
+    }
+}

--- a/application/apps/indexer/gui/application/src/host/common/app_style.rs
+++ b/application/apps/indexer/gui/application/src/host/common/app_style.rs
@@ -7,6 +7,9 @@ pub fn global_styles(style: &mut Style) {
     // We expect the labels to be not selectable by default.
     style.interaction.selectable_labels = false;
 
+    // Do not immediately open the next tooltip after another one was just shown.
+    style.interaction.tooltip_grace_time = 0.0;
+
     // Reduce monospace fonts default size.
     const MONOSPACE_FONT_SIZE_DELTA: f32 = 1.5;
     if let Some(body_font) = style.text_styles.get(&TextStyle::Body) {

--- a/application/apps/indexer/gui/application/src/host/ui/home/recent.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/recent.rs
@@ -8,7 +8,7 @@ use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
 
 use crate::{
-    common::ui::substring_matcher::SubstringMatcher,
+    common::ui::{substring_matcher::SubstringMatcher, visibility_tracker::VisibilityTracker},
     host::{
         command::{HostCommand, OpenRecentSessionParam},
         common::ui_utls::sized_singleline_text_edit,
@@ -27,6 +27,8 @@ pub struct RecentSessionsUi {
     query: String,
     matcher: SubstringMatcher,
     cmd_tx: Sender<HostCommand>,
+    // Used to focus the recent-sessions filter when the home panel becomes visible again.
+    visibility_tracker: VisibilityTracker,
     /// Arbitrary value to avoid persisting scroll state after app restart.
     scroll_salt: Uuid,
 }
@@ -38,6 +40,7 @@ impl RecentSessionsUi {
             query: String::new(),
             matcher: SubstringMatcher::default(),
             cmd_tx,
+            visibility_tracker: VisibilityTracker::default(),
             scroll_salt: Uuid::new_v4(),
         }
     }
@@ -53,11 +56,15 @@ impl RecentSessionsUi {
         ui.heading("Recently opened");
         ui.add_space(4.0);
 
-        let query_changed =
+        let focus_filter = self.visibility_tracker.is_newly_visible(ui);
+        let query_response =
             sized_singleline_text_edit(ui, &mut self.query, vec2(ui.available_width(), 27.0), 7)
                 .hint_text("Filter recent sessions")
-                .ui(ui)
-                .changed();
+                .ui(ui);
+        if focus_filter {
+            query_response.request_focus();
+        }
+        let query_changed = query_response.changed();
         if query_changed {
             self.matcher.build_query(self.query.trim());
         }

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/mod.rs
@@ -3,24 +3,27 @@ use core::slice;
 use egui::{Align, Layout, Margin, ScrollArea, TextEdit, Ui};
 use tokio::sync::mpsc::Sender;
 
-use crate::host::{
-    command::HostCommand,
-    common::{
-        parsers::ParserNames,
-        sources::StreamNames,
-        ui_utls::{general_group_frame, show_validation_message},
-    },
-    ui::{
-        UiActions,
-        session_setup::{
-            RenderOutcome, start_session_on_enter,
-            state::{
-                SessionSetupState,
-                parsers::ParserConfig,
-                sources::{ByteSourceConfig, SourceFileInfo, StreamConfig},
-            },
+use crate::{
+    common::ui::visibility_tracker::VisibilityTracker,
+    host::{
+        command::HostCommand,
+        common::{
+            parsers::ParserNames,
+            sources::StreamNames,
+            ui_utls::{general_group_frame, show_validation_message},
         },
-        storage::RecentSessionsStorage,
+        ui::{
+            UiActions,
+            session_setup::{
+                RenderOutcome, start_session_on_enter,
+                state::{
+                    SessionSetupState,
+                    parsers::ParserConfig,
+                    sources::{ByteSourceConfig, SourceFileInfo, StreamConfig},
+                },
+            },
+            storage::RecentSessionsStorage,
+        },
     },
 };
 
@@ -33,6 +36,7 @@ pub mod udp;
 
 pub fn render_content(
     state: &mut SessionSetupState,
+    input_visibility: &mut VisibilityTracker,
     recent_sessions: &mut RecentSessionsStorage,
     cmd_tx: &Sender<HostCommand>,
     actions: &mut UiActions,
@@ -58,7 +62,7 @@ pub fn render_content(
                 get_frame(ui).show(ui, |ui| {
                     ui.heading("Connection");
                     ui.add_space(10.);
-                    output = render_stream_connection(stream, actions, ui);
+                    output = render_stream_connection(stream, input_visibility, actions, ui);
                 });
 
                 get_frame(ui).show(ui, |ui| {
@@ -102,14 +106,17 @@ fn render_files(
 
 fn render_stream_connection(
     stream: &mut StreamConfig,
+    input_visibility: &mut VisibilityTracker,
     actions: &mut UiActions,
     ui: &mut Ui,
 ) -> RenderOutcome {
     match stream {
-        StreamConfig::Process(config) => process::render_connection(config, actions, ui),
-        StreamConfig::Tcp(config) => tcp::render_connection(config, ui),
-        StreamConfig::Udp(config) => udp::render_connection(config, ui),
-        StreamConfig::Serial(config) => serial::render_connection(config, ui),
+        StreamConfig::Process(config) => {
+            process::render_connection(config, input_visibility, actions, ui)
+        }
+        StreamConfig::Tcp(config) => tcp::render_connection(config, input_visibility, ui),
+        StreamConfig::Udp(config) => udp::render_connection(config, input_visibility, ui),
+        StreamConfig::Serial(config) => serial::render_connection(config, input_visibility, ui),
     }
 }
 
@@ -121,8 +128,16 @@ pub trait ConfigBindAddress {
     fn bind_err_msg(&self) -> Option<&str>;
 }
 
-/// General function to render the binding address for TCP & UDP.
-pub fn render_socket_address<C: ConfigBindAddress>(config: &mut C, ui: &mut Ui) -> RenderOutcome {
+/// Renders the primary socket-address input shared by TCP and UDP setup forms.
+///
+/// - `config` provides the editable address string plus validation hooks.
+/// - `input_visibility` tracks when this form becomes visible so the address field can be focused.
+/// - `ui` is the current egui scope used to render the controls.
+pub fn render_socket_address<C: ConfigBindAddress>(
+    config: &mut C,
+    input_visibility: &mut VisibilityTracker,
+    ui: &mut Ui,
+) -> RenderOutcome {
     let mut outcome = RenderOutcome::None;
 
     ui.vertical(|ui| {
@@ -134,6 +149,10 @@ pub fn render_socket_address<C: ConfigBindAddress>(config: &mut C, ui: &mut Ui) 
             .hint_text("127.0.0.1:8080")
             .show(ui)
             .response;
+
+        if input_visibility.is_newly_visible(ui) {
+            ip_txt_res.request_focus();
+        }
 
         if ip_txt_res.changed() {
             config.validate();

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/process.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/process.rs
@@ -1,5 +1,7 @@
 use egui::{Align, Button, Label, Layout, Popup, RectAlign, RichText, TextStyle, Ui, Widget, vec2};
 
+use crate::common::ui::visibility_tracker::VisibilityTracker;
+
 use super::RenderOutcome;
 use crate::host::{
     common::ui_utls::{sized_singleline_text_edit, truncate_path_to_width},
@@ -14,6 +16,7 @@ const CWD_DIALOG_ID: &str = "cwd_for_shell";
 
 pub fn render_connection(
     config: &mut ProcessConfig,
+    input_visibility: &mut VisibilityTracker,
     actions: &mut UiActions,
     ui: &mut Ui,
 ) -> RenderOutcome {
@@ -22,7 +25,7 @@ pub fn render_connection(
     ui.allocate_ui_with_layout(
         vec2(ui.available_width(), row_height),
         Layout::right_to_left(Align::Center),
-        |ui| command_and_shell(config, &mut outcome, None, ui),
+        |ui| command_and_shell(config, input_visibility, &mut outcome, None, ui),
     );
 
     ui.add_space(10.);
@@ -36,11 +39,16 @@ pub fn render_connection(
     outcome
 }
 
-/// Renders the area to specify the command and the shell to run on it.
+/// Renders the process command input together with the shell picker.
 ///
-/// `shell_max_width` caps the shell picker button width and truncates the inline shell label.
+/// - `config` stores the editable command text, selected shell, and validation state.
+/// - `input_visibility` tracks when this form becomes visible so the command field can be focused.
+/// - `outcome` is updated when pressing Enter should start the session.
+/// - `shell_max_width` optionally caps the shell picker width and truncates its inline label.
+/// - `ui` is the current egui scope used to render the controls.
 pub fn command_and_shell(
     config: &mut ProcessConfig,
+    input_visibility: &mut VisibilityTracker,
     outcome: &mut RenderOutcome,
     shell_max_width: Option<f32>,
     ui: &mut Ui,
@@ -96,6 +104,10 @@ pub fn command_and_shell(
     .hint_text("Terminal command")
     .show(ui)
     .response;
+
+    if input_visibility.is_newly_visible(ui) {
+        text_res.request_focus();
+    }
 
     if text_res.changed() {
         config.validate();

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/process.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/process.rs
@@ -22,7 +22,7 @@ pub fn render_connection(
     ui.allocate_ui_with_layout(
         vec2(ui.available_width(), row_height),
         Layout::right_to_left(Align::Center),
-        |ui| command_and_shell(config, &mut outcome, ui),
+        |ui| command_and_shell(config, &mut outcome, None, ui),
     );
 
     ui.add_space(10.);
@@ -37,21 +37,38 @@ pub fn render_connection(
 }
 
 /// Renders the area to specify the command and the shell to run on it.
-pub fn command_and_shell(config: &mut ProcessConfig, outcome: &mut RenderOutcome, ui: &mut Ui) {
+///
+/// `shell_max_width` caps the shell picker button width and truncates the inline shell label.
+pub fn command_and_shell(
+    config: &mut ProcessConfig,
+    outcome: &mut RenderOutcome,
+    shell_max_width: Option<f32>,
+    ui: &mut Ui,
+) {
     let height = ui.available_height();
+    let shell_name = config
+        .shell
+        .as_ref()
+        .map(|s| s.shell.to_string())
+        .unwrap_or_else(|| String::from("Default Shell"));
 
     let shell_txt = RichText::new(format!(
         "{} {}",
         egui_phosphor::regular::TERMINAL,
-        config
-            .shell
-            .as_ref()
-            .map(|s| s.shell.to_string())
-            .unwrap_or_else(|| String::from("Default Shell"))
+        shell_name
     ))
     .text_style(egui::TextStyle::Button);
+    let button = Button::new(shell_txt).min_size(vec2(0., height)).truncate();
 
-    let button_res = Button::new(shell_txt).min_size(vec2(0., height)).ui(ui);
+    let button_res = if let Some(shell_max_width) = shell_max_width {
+        ui.add_sized(vec2(shell_max_width, height), button)
+            .on_hover_ui(|ui| {
+                ui.set_max_width(ui.spacing().tooltip_width);
+                ui.label(format!("Current shell: {shell_name}"));
+            })
+    } else {
+        button.ui(ui)
+    };
 
     let pop_id = egui::Id::new("shells");
 

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/serial.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/serial.rs
@@ -4,7 +4,7 @@ use egui::{
 };
 
 use crate::{
-    common::ui::buttons,
+    common::ui::{buttons, visibility_tracker::VisibilityTracker},
     host::{
         common::ui_utls::sized_singleline_text_edit,
         ui::session_setup::{
@@ -20,7 +20,11 @@ const CONTROL_GROUP_WIDTH: f32 = 160.0;
 const CONTROL_GROUP_SIDE_MARGIN: i8 = 5;
 const CONTROL_WIDTH: f32 = CONTROL_GROUP_WIDTH - (CONTROL_GROUP_SIDE_MARGIN as f32 * 2.);
 
-pub fn render_connection(config: &mut SerialConfig, ui: &mut Ui) -> RenderOutcome {
+pub fn render_connection(
+    config: &mut SerialConfig,
+    input_visibility: &mut VisibilityTracker,
+    ui: &mut Ui,
+) -> RenderOutcome {
     config.check_update_ports();
 
     let mut outcome = RenderOutcome::None;
@@ -29,7 +33,7 @@ pub fn render_connection(config: &mut SerialConfig, ui: &mut Ui) -> RenderOutcom
     ui.allocate_ui_with_layout(
         vec2(ui.available_width(), row_height),
         Layout::right_to_left(egui::Align::Center),
-        |ui| render_port_path(config, &mut outcome, ui),
+        |ui| render_port_path(config, input_visibility, &mut outcome, ui),
     );
 
     ui.separator();
@@ -155,7 +159,12 @@ pub fn render_connection(config: &mut SerialConfig, ui: &mut Ui) -> RenderOutcom
 }
 
 /// Renders the port selection menu and manual input field, handling validation and session startup triggers.
-fn render_port_path(config: &mut SerialConfig, outcome: &mut RenderOutcome, ui: &mut Ui) {
+fn render_port_path(
+    config: &mut SerialConfig,
+    input_visibility: &mut VisibilityTracker,
+    outcome: &mut RenderOutcome,
+    ui: &mut Ui,
+) {
     let height = ui.available_height();
 
     let ports_txt = format!("Detected ports ({})", config.available_ports.len());
@@ -184,6 +193,10 @@ fn render_port_path(config: &mut SerialConfig, outcome: &mut RenderOutcome, ui: 
             .hint_text("Port path")
             .show(ui)
             .response;
+
+    if input_visibility.is_newly_visible(ui) {
+        path_res.request_focus();
+    }
 
     if path_res.changed() {
         path_changed = true;

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/tcp.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/tcp.rs
@@ -1,6 +1,9 @@
 use egui::Ui;
 
-use crate::host::ui::session_setup::state::sources::TcpConfig;
+use crate::{
+    common::ui::visibility_tracker::VisibilityTracker,
+    host::ui::session_setup::state::sources::TcpConfig,
+};
 
 use super::{ConfigBindAddress, RenderOutcome, render_socket_address};
 
@@ -22,6 +25,10 @@ impl ConfigBindAddress for TcpConfig {
     }
 }
 
-pub fn render_connection(config: &mut TcpConfig, ui: &mut Ui) -> RenderOutcome {
-    render_socket_address(config, ui)
+pub fn render_connection(
+    config: &mut TcpConfig,
+    input_visibility: &mut VisibilityTracker,
+    ui: &mut Ui,
+) -> RenderOutcome {
+    render_socket_address(config, input_visibility, ui)
 }

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/udp.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/udp.rs
@@ -1,7 +1,10 @@
 use egui::{Align, Button, Label, Layout, Response, RichText, Sides, TextEdit, Ui, Widget, vec2};
 
 use crate::{
-    common::{phosphor::icons, ui::buttons},
+    common::{
+        phosphor::icons,
+        ui::{buttons, visibility_tracker::VisibilityTracker},
+    },
     host::ui::session_setup::state::sources::{MulticastItem, UdpConfig},
 };
 
@@ -25,8 +28,12 @@ impl ConfigBindAddress for UdpConfig {
     }
 }
 
-pub fn render_connection(config: &mut UdpConfig, ui: &mut Ui) -> RenderOutcome {
-    let outcome = render_socket_address(config, ui);
+pub fn render_connection(
+    config: &mut UdpConfig,
+    input_visibility: &mut VisibilityTracker,
+    ui: &mut Ui,
+) -> RenderOutcome {
+    let outcome = render_socket_address(config, input_visibility, ui);
 
     if !config.multicasts.is_empty() {
         render_multicasts(config, ui);

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/mod.rs
@@ -8,7 +8,7 @@ use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
 
 use crate::{
-    common::ui::buttons,
+    common::ui::{buttons, visibility_tracker::VisibilityTracker},
     host::{
         command::HostCommand,
         common::{file_utls, parsers::ParserNames, sources::StreamNames},
@@ -25,6 +25,8 @@ pub mod state;
 pub struct SessionSetup {
     pub state: SessionSetupState,
     cmd_tx: Sender<HostCommand>,
+    // Used to focus the active stream input when the selected transport changes.
+    input_visibility: VisibilityTracker,
 }
 
 /// The outcome of render routines in children components of this view.
@@ -37,7 +39,11 @@ pub enum RenderOutcome {
 
 impl SessionSetup {
     pub fn new(state: SessionSetupState, cmd_tx: Sender<HostCommand>) -> Self {
-        Self { state, cmd_tx }
+        Self {
+            state,
+            cmd_tx,
+            input_visibility: VisibilityTracker::default(),
+        }
     }
 
     #[inline]
@@ -84,6 +90,7 @@ impl SessionSetup {
             ui.centered_and_justified(|ui| {
                 let outcome = main_config::render_content(
                     &mut self.state,
+                    &mut self.input_visibility,
                     recent_sessions,
                     &self.cmd_tx,
                     actions,
@@ -185,6 +192,8 @@ impl SessionSetup {
 
                 if original_stream != selected_stream {
                     self.state.update_stream(selected_stream);
+                    // Focus input text on switching stream type.
+                    self.input_visibility = VisibilityTracker::default();
                 }
 
                 ui.label("Stream From:");

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/mod.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use crate::{
     common::{
         phosphor::icons,
-        ui::{buttons, substring_matcher::SubstringMatcher},
+        ui::{buttons, substring_matcher::SubstringMatcher, visibility_tracker::VisibilityTracker},
     },
     host::{
         command::{ExportPresetsParam, HostCommand},
@@ -58,6 +58,8 @@ pub struct PresetsUI {
     cmd_tx: Sender<SessionCommand>,
     host_cmd_tx: Sender<HostCommand>,
     query_state: PresetQueryState,
+    // Used to focus the preset filter when the presets tab becomes visible again.
+    query_visibility: VisibilityTracker,
     edit_state: Option<PresetEditState>,
     export_state: Option<ExportSelectionState>,
 }
@@ -135,6 +137,7 @@ impl PresetsUI {
             cmd_tx,
             host_cmd_tx,
             query_state: PresetQueryState::default(),
+            query_visibility: VisibilityTracker::default(),
             edit_state: None,
             export_state: None,
         }
@@ -211,18 +214,22 @@ impl PresetsUI {
                 }
 
                 ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
-                    let query_changed = sized_singleline_text_edit(
+                    let focus_query = self.query_visibility.is_newly_visible(ui);
+                    let query_response = sized_singleline_text_edit(
                         ui,
                         &mut self.query_state.query,
                         ui.available_size(),
                         7,
                     )
                     .hint_text("Filter presets by name")
-                    .ui(ui)
-                    .changed();
+                    .ui(ui);
+                    if focus_query {
+                        query_response.request_focus();
+                    }
+
                     self.query_state.update_with_revision(
                         registry.presets.definitions_revision(),
-                        query_changed,
+                        query_response.changed(),
                         |matcher| collect_matching_preset_ids(matcher, registry),
                     );
 

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_bar.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_bar.rs
@@ -9,6 +9,7 @@ use processor::search::filter::SearchFilter;
 use crate::{
     common::{
         phosphor::{self, icons},
+        ui::visibility_tracker::VisibilityTracker,
         validation::{ValidationEligibility, validate_filter},
     },
     host::{
@@ -29,6 +30,8 @@ pub struct SearchBar {
     pub is_regex: bool,
     pub match_case: bool,
     pub is_word: bool,
+    // Used to focus the search input when the search bar becomes visible again.
+    visibility_tracker: VisibilityTracker,
 }
 
 impl SearchBar {
@@ -39,6 +42,7 @@ impl SearchBar {
             is_regex: true,
             match_case: false,
             is_word: false,
+            visibility_tracker: VisibilityTracker::default(),
         }
     }
     pub fn render_content(
@@ -93,6 +97,7 @@ impl SearchBar {
 
         // Text id is needed to keep track if the text control is focused.
         let text_id = ui.id().with("search_text");
+        let became_visible = self.visibility_tracker.is_newly_visible(ui);
 
         ui.allocate_ui_with_layout(
             vec2(ui.available_width(), 25.),
@@ -143,8 +148,10 @@ impl SearchBar {
                                     text_output.state.cursor.set_char_range(None);
                                     text_output.state.store(ui.ctx(), text_output.response.id);
                                 }
-                                ////TODO AAZ: Request focus on start session or tab switch only.
-                                //input_res.request_focus();
+
+                                if became_visible {
+                                    text_output.response.request_focus();
+                                }
                             })
                     },
                 );

--- a/application/apps/indexer/gui/application/src/session/ui/side_panel/filters.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/side_panel/filters.rs
@@ -1,6 +1,6 @@
 use egui::{
-    Align, Button, Frame, Key, Layout, Modifiers, RichText, ScrollArea, Sense, Sides, TextEdit, Ui,
-    UiBuilder, vec2,
+    Align, Button, Frame, Grid, Key, Layout, Modifiers, RichText, ScrollArea, Sense, Sides,
+    TextEdit, Ui, UiBuilder, vec2,
 };
 use processor::search::filter::SearchFilter;
 use tokio::sync::mpsc;
@@ -746,10 +746,9 @@ impl FiltersUi {
     }
 
     fn render_color_picker_row(ui: &mut Ui, label: &str, color: &mut egui::Color32) {
-        ui.horizontal(|ui| {
-            ui.label(label);
-            ui.color_edit_button_srgba(color);
-        });
+        ui.label(label);
+        ui.color_edit_button_srgba(color);
+        ui.end_row();
     }
 
     fn render_color_swatch(ui: &mut Ui, color: egui::Color32) {
@@ -813,15 +812,19 @@ impl FiltersUi {
         ui.heading(RichText::new("Filter Details").size(16.0));
         ui.add_space(10.0);
 
-        Self::render_color_picker_row(ui, "Foreground", &mut colors.fg);
-        Self::render_color_picker_row(ui, "Background", &mut colors.bg);
+        Grid::new("filter_editor_colors").show(ui, |ui| {
+            Self::render_color_picker_row(ui, "Foreground", &mut colors.fg);
+            Self::render_color_picker_row(ui, "Background", &mut colors.bg);
+        });
     }
 
     fn render_search_value_editor(ui: &mut Ui, color: &mut egui::Color32) {
         ui.heading(RichText::new("Chart Details").size(16.0));
         ui.add_space(10.0);
 
-        Self::render_color_picker_row(ui, "Color", color);
+        Grid::new("search_value_editor_colors").show(ui, |ui| {
+            Self::render_color_picker_row(ui, "Color", color);
+        });
     }
 
     /// Applies the queued sidebar mutation and dispatches any required pipeline sync commands.

--- a/application/apps/indexer/gui/application/src/session/ui/side_panel/observing/process.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/side_panel/observing/process.rs
@@ -79,7 +79,7 @@ impl ProcessObserveUi {
             ui.allocate_ui_with_layout(
                 vec2(ui.available_width(), row_height),
                 Layout::right_to_left(Align::Center),
-                |ui| host_setup::command_and_shell(config, &mut outcome, ui),
+                |ui| host_setup::command_and_shell(config, &mut outcome, Some(60.0), ui),
             );
 
             ui.add_space(10.);

--- a/application/apps/indexer/gui/application/src/session/ui/side_panel/observing/process.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/side_panel/observing/process.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::{
-    common::phosphor::icons,
+    common::{phosphor::icons, ui::visibility_tracker::VisibilityTracker},
     host::{
         common::ui_utls::truncate_path_to_width,
         ui::{
@@ -28,6 +28,8 @@ pub struct ProcessObserveUi {
     cmd_tx: mpsc::Sender<SessionCommand>,
     /// Process config is being lazy loaded since it has initialization process.
     config: Option<Box<ProcessConfig>>,
+    // Used to focus the command input when the attach-command form is shown again.
+    input_visibility: VisibilityTracker,
 }
 
 impl ProcessObserveUi {
@@ -37,6 +39,7 @@ impl ProcessObserveUi {
             id,
             cmd_tx,
             config: None,
+            input_visibility: VisibilityTracker::default(),
         }
     }
 
@@ -79,7 +82,15 @@ impl ProcessObserveUi {
             ui.allocate_ui_with_layout(
                 vec2(ui.available_width(), row_height),
                 Layout::right_to_left(Align::Center),
-                |ui| host_setup::command_and_shell(config, &mut outcome, Some(60.0), ui),
+                |ui| {
+                    host_setup::command_and_shell(
+                        config,
+                        &mut self.input_visibility,
+                        &mut outcome,
+                        Some(60.0),
+                        ui,
+                    )
+                },
             );
 
             ui.add_space(10.);

--- a/application/apps/indexer/gui/application/src/session/ui/side_panel/observing/tcp.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/side_panel/observing/tcp.rs
@@ -4,7 +4,10 @@ use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::{
-    common::{phosphor::icons, ui::buttons},
+    common::{
+        phosphor::icons,
+        ui::{buttons, visibility_tracker::VisibilityTracker},
+    },
     host::ui::{
         UiActions,
         session_setup::{
@@ -24,6 +27,8 @@ pub struct TcpObserveUi {
     id: Id,
     cmd_tx: mpsc::Sender<SessionCommand>,
     config: TcpConfig,
+    // Used to focus the address input when the attach-TCP form is shown again.
+    input_visibility: VisibilityTracker,
 }
 
 impl TcpObserveUi {
@@ -33,6 +38,7 @@ impl TcpObserveUi {
             id,
             cmd_tx,
             config: TcpConfig::new(),
+            input_visibility: VisibilityTracker::default(),
         }
     }
 
@@ -63,7 +69,11 @@ impl TcpObserveUi {
 
     fn attach_tcp(&mut self, ui: &mut Ui, actions: &mut UiActions) {
         super::render_attach_source(ui, self.id, "New Connection", |ui| {
-            let mut outcome = main_config::render_socket_address(&mut self.config, ui);
+            let mut outcome = main_config::render_socket_address(
+                &mut self.config,
+                &mut self.input_visibility,
+                ui,
+            );
             ui.with_layout(Layout::right_to_left(Align::TOP), |ui| {
                 if ui
                     .add_enabled(

--- a/application/apps/indexer/gui/application/src/session/ui/side_panel/observing/udp.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/side_panel/observing/udp.rs
@@ -4,7 +4,10 @@ use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::{
-    common::{phosphor::icons, ui::buttons},
+    common::{
+        phosphor::icons,
+        ui::{buttons, visibility_tracker::VisibilityTracker},
+    },
     host::ui::{
         UiActions,
         session_setup::{
@@ -24,6 +27,8 @@ pub struct UdpObserveUi {
     id: Id,
     cmd_tx: mpsc::Sender<SessionCommand>,
     config: UdpConfig,
+    // Used to focus the address input when the attach-UDP form is shown again.
+    input_visibility: VisibilityTracker,
 }
 
 impl UdpObserveUi {
@@ -34,6 +39,7 @@ impl UdpObserveUi {
             id,
             cmd_tx,
             config: UdpConfig::new(),
+            input_visibility: VisibilityTracker::default(),
         }
     }
 
@@ -64,7 +70,11 @@ impl UdpObserveUi {
 
     fn attach_udp(&mut self, ui: &mut Ui, actions: &mut UiActions) {
         super::render_attach_source(ui, self.id, "New Connection", |ui| {
-            let mut outcome = main_config::render_socket_address(&mut self.config, ui);
+            let mut outcome = main_config::render_socket_address(
+                &mut self.config,
+                &mut self.input_visibility,
+                ui,
+            );
             if !self.config.multicasts.is_empty() {
                 main_config::udp::render_multicasts(&mut self.config, ui);
             }


### PR DESCRIPTION
This PR includes:

* Implement a mechanism to track if the view is newly visible to highlight input texts on switching tabs and view.
* Set max size for terminal fish picker to fit in side panel.
* Use grid for color pickers in filter side view
* Do not immediately open the next tooltip after another one was just  shown
* Formatting fixes.