### PR TITLE
Preparation for Chipmunk 4 Alpha release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 `chipmunk` is one of the fastest desktop applications for viewing log files, with no limitations on file size. 1 GB, 2 GB, 10 GB? `chipmunk` is limited only by your disk space - nothing more. With no caching and no unnecessary copying, files of any size open with the same speed. But `chipmunk` goes beyond just working with files: it also allows you to create network connections to collect logs via TCP, UDP, Serial, or from the output of a running command.
 
+## Chipmunk 4 Alpha
+
+Chipmunk 4 Alpha is now available as a preview of the next generation of Chipmunk: a native Rust application built for high-volume logs, traces, and live streams.
+
+During the alpha phase, Chipmunk 4 lives on the `native-ui` branch and will continue to evolve there. Alpha builds are published as pre-releases.
+
+- [Read the Chipmunk 4 Alpha README](https://github.com/esrlabs/chipmunk/blob/native-ui/application/apps/indexer/gui/application/README.md)
+- [Download Chipmunk 4 Alpha builds](https://github.com/esrlabs/chipmunk/releases)
+
+Look for release versions such as `4.0.0-alpha.*` on the releases page. The current stable Chipmunk documentation continues below.
+
 ## Automotive and Network Traces
 
 Out of the box, `chipmunk` supports several formats critical for the automotive industry, including DLT and SomeIp. Unlike many alternatives, `chipmunk` offers full trace inspection capabilities for DLT, including support for embedded attachments. Media files (images, video, audio) and text can be viewed directly within `chipmunk` or exported to disk.

--- a/application/client/src/app/service/bridge.ts
+++ b/application/client/src/app/service/bridge.ts
@@ -626,6 +626,7 @@ export class Service extends Implementation {
 
     public app(): {
         version(): Promise<string>;
+        alphaRelease(): Promise<{ version: string; url: string } | undefined>;
         changelogs(version?: string): Promise<{ markdown: string; version: string }>;
     } {
         return {
@@ -640,6 +641,27 @@ export class Service extends Implementation {
                                 return reject(new Error(response.error));
                             }
                             resolve(response.version);
+                        })
+                        .catch(reject);
+                });
+            },
+            alphaRelease: (): Promise<{ version: string; url: string } | undefined> => {
+                return new Promise((resolve, reject) => {
+                    Requests.IpcRequest.send(
+                        Requests.App.AlphaRelease.Response,
+                        new Requests.App.AlphaRelease.Request(),
+                    )
+                        .then((response) => {
+                            if (response.error !== undefined) {
+                                return reject(new Error(response.error));
+                            }
+                            if (response.version === undefined || response.url === undefined) {
+                                return resolve(undefined);
+                            }
+                            resolve({
+                                version: response.version,
+                                url: response.url,
+                            });
                         })
                         .catch(reject);
                 });

--- a/application/client/src/app/ui/views/dialogs/about/component.ts
+++ b/application/client/src/app/ui/views/dialogs/about/component.ts
@@ -13,21 +13,24 @@ import { Initial } from '@env/decorators/initial';
 @Ilc()
 export class About extends ChangesDetector implements AfterViewInit {
     @Input() public version: string = '';
+    @Input() public alphaRelease: { version: string; url: string } | undefined;
 
     constructor(cdRef: ChangeDetectorRef) {
         super(cdRef);
     }
 
     ngAfterViewInit(): void {
-        this.ilc()
-            .services.system.bridge.app()
-            .version()
-            .then((version: string) => {
+        Promise.all([
+            this.ilc().services.system.bridge.app().version(),
+            this.ilc().services.system.bridge.app().alphaRelease(),
+        ])
+            .then(([version, alphaRelease]) => {
                 this.version = version;
+                this.alphaRelease = alphaRelease;
                 this.detectChanges();
             })
             .catch((err: Error) => {
-                this.log().error(`Fail to get application version: ${err.message}`);
+                this.log().error(`Fail to get about dialog data: ${err.message}`);
             });
     }
 

--- a/application/client/src/app/ui/views/dialogs/about/styles.less
+++ b/application/client/src/app/ui/views/dialogs/about/styles.less
@@ -38,10 +38,20 @@
             text-align: center;
         }
         & p.name {
-            margin-top: 72px;
+            margin-top: 56px;
+        }
+        & p.alpha {
+            margin-top: 8px;
+        }
+        & button.alpha-link {
+            padding: 0;
+            border: none;
+            background: transparent;
+            text-decoration: underline;
+            cursor: pointer;
         }
         & div.controlls {
-            margin-top: 25px;
+            margin-top: 20px;
             text-align: center;
             & button {
                 color: var(--scheme-color-1);

--- a/application/client/src/app/ui/views/dialogs/about/template.html
+++ b/application/client/src/app/ui/views/dialogs/about/template.html
@@ -2,6 +2,10 @@
 <div class="content">
     <p class="name t-large color-scheme-0">CHIPMUNK</p>
     <p class="t-medium color-scheme-2">version: <b class="color-scheme-0">{{version}}</b></p>
+    <p *ngIf="alphaRelease !== undefined" class="alpha t-medium color-scheme-2">
+        Chipmunk 4 alpha:
+        <button class="alpha-link color-scheme-0" (click)="open(alphaRelease.url)">{{alphaRelease.version}}</button>
+    </p>
     <div class="controlls" >
         <button mat-stroked-button (click)="open('https://github.com/esrlabs/chipmunk')">GitHub</button>
         <button mat-stroked-button (click)="open('https://github.com/esrlabs/chipmunk')">Star</button>

--- a/application/holder/src/modules/github.ts
+++ b/application/holder/src/modules/github.ts
@@ -42,6 +42,12 @@ export interface IReleaseData {
     id: number;
     tag_name: string;
     body: string;
+    // Required by updater alpha-awareness. `tag_name` stays the source of truth,
+    // while `html_url` is used for the notification action target.
+    html_url: string;
+    prerelease: boolean;
+    draft: boolean;
+    published_at?: string;
 }
 
 export class GitHubAsset {
@@ -136,13 +142,15 @@ export class GitHubClient {
 
     public getReleases(opt: IGitHubOptions, filter?: { tag?: string }): Promise<IReleaseData[]> {
         return new Promise((resolve, reject) => {
-            let uri = `${CSettings.uri}${opt.user !== undefined ? opt.repo : CSettings.user}/${
+            let uri = `${CSettings.uri}${opt.user !== undefined ? opt.user : CSettings.user}/${
                 opt.repo
             }/releases`;
-            if (filter !== undefined) {
-                if (filter.tag !== undefined) {
-                    uri += `/tags/${filter.tag}`;
-                }
+            if (filter !== undefined && filter.tag !== undefined) {
+                uri += `/tags/${encodeURIComponent(filter.tag)}`;
+            } else {
+                // The updater scans the release list for alpha announcements, so use a wider
+                // page here instead of relying on GitHub's smaller default response.
+                uri += `?per_page=100`;
             }
             net.getRaw(uri, {
                 Accept: 'application/vnd.github.v3+json',

--- a/application/holder/src/service/bridge.ts
+++ b/application/holder/src/service/bridge.ts
@@ -42,6 +42,15 @@ export class Service extends Implementation {
                 .ipc()
                 .respondent(
                     this.getName(),
+                    Requests.App.AlphaRelease.Request,
+                    RequestHandlers.App.AlphaRelease.handler,
+                ),
+        );
+        this.register(
+            electron
+                .ipc()
+                .respondent(
+                    this.getName(),
                     Requests.App.Changelogs.Request,
                     RequestHandlers.App.Changelogs.handler,
                 ),

--- a/application/holder/src/service/bridge/app/alpha_release.ts
+++ b/application/holder/src/service/bridge/app/alpha_release.ts
@@ -1,0 +1,48 @@
+import { CancelablePromise } from 'platform/env/promise';
+import { Logger } from 'platform/log';
+import { GitHubClient } from '@module/github';
+import { REPO } from '@service/updater';
+import { getLatestAlphaRelease, getReleaseLabel } from '@service/updater/alpha';
+
+import * as Requests from 'platform/ipc/request';
+
+export const handler = Requests.InjectLogger<
+    Requests.App.AlphaRelease.Request,
+    CancelablePromise<Requests.App.AlphaRelease.Response>
+>(
+    (
+        _log: Logger,
+        _request: Requests.App.AlphaRelease.Request,
+    ): CancelablePromise<Requests.App.AlphaRelease.Response> => {
+        return new CancelablePromise((resolve, _reject) => {
+            const github = new GitHubClient();
+            github
+                .getReleases({ repo: REPO })
+                .then((releases) => {
+                    const alphaRelease = getLatestAlphaRelease(releases);
+                    resolve(
+                        new Requests.App.AlphaRelease.Response({
+                            version:
+                                alphaRelease === undefined
+                                    ? undefined
+                                    : getReleaseLabel(alphaRelease.release),
+                            url:
+                                alphaRelease === undefined
+                                    ? undefined
+                                    : alphaRelease.release.html_url,
+                            error: undefined,
+                        }),
+                    );
+                })
+                .catch((err: Error) => {
+                    resolve(
+                        new Requests.App.AlphaRelease.Response({
+                            version: undefined,
+                            url: undefined,
+                            error: err.message,
+                        }),
+                    );
+                });
+        });
+    },
+);

--- a/application/holder/src/service/bridge/app/index.ts
+++ b/application/holder/src/service/bridge/app/index.ts
@@ -1,2 +1,3 @@
 export * as Version from './version';
 export * as Changelogs from './changelogs';
+export * as AlphaRelease from './alpha_release';

--- a/application/holder/src/service/updater.ts
+++ b/application/holder/src/service/updater.ts
@@ -10,6 +10,7 @@ import { paths } from '@service/paths';
 import { settings } from '@service/settings';
 import { production } from '@service/production';
 import { notifications } from '@service/notifications';
+import { storage } from '@service/storage';
 import { GitHubClient, IReleaseData, IReleaseAsset } from '@module/github';
 import { Version } from './updater/version';
 import { ReleaseFile } from './updater/releasefile';
@@ -23,9 +24,11 @@ import { Update } from '@loader/exitcases/update';
 import { electron } from '@service/electron';
 import { CancelablePromise } from 'platform/env/promise';
 import { getCustomPlatform } from './updater/metadata';
+import { getAlphaRelease, getLatestAlphaRelease } from './updater/alpha';
 
 import * as path from 'path';
 import * as fs from 'fs';
+import { shell } from 'electron';
 import * as Events from 'platform/ipc/event';
 import * as Requests from 'platform/ipc/request';
 
@@ -34,6 +37,9 @@ declare const global: ChipmunkGlobal;
 const UPDATER = 'updater';
 const AUTO = { key: 'autoUpdateCheck', path: 'general' };
 const PRERELEASE = { key: 'allowUpdateFromPrerelease', path: 'general' };
+// Internal storage for the last alpha tag we already announced in the UI.
+const ALPHA_RELEASE_NOTIFICATION_STATE_KEY = 'updater_alpha';
+const ALPHA_RELEASE_NOTIFICATION_ENTRY = 'last_announced_alpha_tag';
 
 export const REPO = 'chipmunk';
 
@@ -54,14 +60,35 @@ enum LatestReleaseNotFound {
     Skipped,
 }
 
+// Keep updater decision-making explicit. The old string-only result was fine for the
+// manual dialog, but too ambiguous once the automatic flow also needed alpha fallback.
+enum CandidateResultState {
+    Candidate,
+    NoUpdates,
+    Skipped,
+    Unavailable,
+    Alpha,
+}
+
 interface ICandidate {
     release: IReleaseData;
     version: Version;
 }
 
+interface IDownloadCandidate extends ICandidate {
+    compressed: string;
+}
+
+interface ICandidateResult {
+    state: CandidateResultState;
+    candidate?: IDownloadCandidate;
+    report: string;
+}
+
 @DependOn(paths)
 @DependOn(settings)
 @DependOn(notifications)
+@DependOn(storage)
 @DependOn(electron)
 @SetupService(services['updater'])
 export class Service extends Implementation {
@@ -92,8 +119,8 @@ export class Service extends Implementation {
                         _request: Requests.System.CheckUpdates.Request,
                     ): CancelablePromise<Requests.System.CheckUpdates.Request> => {
                         return new CancelablePromise((resolve) => {
-                            this.find(false)
-                                .candidate()
+                            this.find(true)
+                                .candidate(true)
                                 .then((candidate) => {
                                     resolve(
                                         new Requests.System.CheckUpdates.Response({
@@ -125,10 +152,11 @@ export class Service extends Implementation {
         skiping(): boolean;
         night(): Promise<ICandidate | undefined>;
         latest(): Promise<ICandidate | LatestReleaseNotFound>;
-        candidate(): Promise<
-            { release: IReleaseData; version: Version; compressed: string } | string
-        >;
+        result(reportAlphaInsteadOfDownload?: boolean): Promise<ICandidateResult>;
+        candidate(reportAlphaInsteadOfDownload?: boolean): Promise<IDownloadCandidate | string>;
     } {
+        // `result()` is the internal API used by the automatic flow.
+        // `candidate()` keeps the older manual-check contract unchanged.
         return {
             skiping: (): boolean => {
                 const auto = settings.get().value<boolean>(AUTO.path, AUTO.key);
@@ -151,6 +179,13 @@ export class Service extends Implementation {
                 const current: Version = new Version(version.getVersion());
                 let candidate: ICandidate | undefined;
                 releases.forEach((release: IReleaseData) => {
+                    // Chipmunk 4 alpha releases are announced only, never installed by this updater.
+                    if (getAlphaRelease(release) !== undefined) {
+                        this.log().debug(
+                            `Release "${release.name} (tag: ${release.tag_name})" ignored because alpha releases are announcement-only`,
+                        );
+                        return;
+                    }
                     try {
                         const version = new Version(getCleanVersion(release.name));
                         if (current.isGivenGrander(version)) {
@@ -215,16 +250,13 @@ export class Service extends Implementation {
                 }
                 return candidate === undefined ? LatestReleaseNotFound.NoUpdates : candidate;
             },
-            candidate: async (): Promise<
-                { release: IReleaseData; version: Version; compressed: string } | string
-            > => {
+            result: async (reportAlphaInsteadOfDownload = false): Promise<ICandidateResult> => {
                 let candidate: ICandidate | undefined;
                 const latest = await this.find(force).latest();
                 if (latest === LatestReleaseNotFound.NoUpdates) {
                     const night = settings.get().value<boolean>(PRERELEASE.path, PRERELEASE.key);
                     if (!night) {
                         this.log().debug(`No updates has been found in latest release.`);
-                        return Promise.resolve(`No updates has been found.`);
                     } else {
                         this.log().debug(
                             `No updates has been found in latest release. Checking pre-releases`,
@@ -232,12 +264,37 @@ export class Service extends Implementation {
                         candidate = await this.find(force).night();
                     }
                 } else if (latest === LatestReleaseNotFound.Skipped) {
-                    return Promise.resolve(this.log().debug(`Checking of updates is skipped`));
+                    return {
+                        state: CandidateResultState.Skipped,
+                        report: `Checking of updates is skipped`,
+                    };
                 } else {
                     candidate = latest;
                 }
                 if (candidate === undefined) {
-                    return Promise.resolve(this.log().debug(`No updates has been found.`));
+                    const alphaReport = reportAlphaInsteadOfDownload
+                        ? await this._getManualAlphaReleaseReport()
+                        : undefined;
+                    if (alphaReport !== undefined) {
+                        return {
+                            state: CandidateResultState.Alpha,
+                            report: alphaReport,
+                        };
+                    }
+                    this.log().debug(`No updates has been found.`);
+                    return {
+                        state: CandidateResultState.NoUpdates,
+                        report: `No updates has been found.`,
+                    };
+                }
+                if (reportAlphaInsteadOfDownload) {
+                    const alphaRelease = getAlphaRelease(candidate.release);
+                    if (alphaRelease !== undefined) {
+                        return {
+                            state: CandidateResultState.Alpha,
+                            report: this._getManualAlphaReleaseReportText(),
+                        };
+                    }
                 }
                 const customPlatform = await getCustomPlatform();
 
@@ -254,29 +311,45 @@ export class Service extends Implementation {
                     }
                 });
                 if (compressed === undefined) {
-                    this.log().warn(
-                        `Fail to find archive-file with release for current platform. `,
-                    );
-                    return Promise.resolve(
-                        `Fail to find archive-file with release for current platform. `,
-                    );
+                    this.log().warn(`Fail to find archive-file with release for current platform. `);
+                    return {
+                        state: CandidateResultState.Unavailable,
+                        report: `Fail to find archive-file with release for current platform. `,
+                    };
                 }
                 return {
-                    release: candidate.release,
-                    version: candidate.version,
-                    compressed,
+                    state: CandidateResultState.Candidate,
+                    report: `Found release ${candidate.release.name}. Downloading is started`,
+                    candidate: {
+                        release: candidate.release,
+                        version: candidate.version,
+                        compressed,
+                    },
                 };
+            },
+            candidate: async (
+                reportAlphaInsteadOfDownload = false,
+            ): Promise<IDownloadCandidate | string> => {
+                const result = await this.find(force).result(reportAlphaInsteadOfDownload);
+                return result.state === CandidateResultState.Candidate && result.candidate !== undefined
+                    ? result.candidate
+                    : result.report;
             },
         };
     }
 
     public async check(force: boolean): Promise<void> {
-        const candidate = await this.find(force).candidate();
-        if (typeof candidate === 'string') {
-            this.log().debug(`No updates has been found.`);
+        const result = await this.find(force).result();
+        if (result.state !== CandidateResultState.Candidate || result.candidate === undefined) {
+            // Alpha announcements are automatic-check only and must never compete with a real
+            // updater candidate, including the testing prerelease path.
+            if (!force && result.state === CandidateResultState.NoUpdates) {
+                await this._checkForAlphaReleaseAnnouncement();
+            }
             return Promise.resolve();
         }
 
+        const candidate = result.candidate;
         const customPlatform = await getCustomPlatform();
         const release: ReleaseFile = new ReleaseFile(
             getCleanVersion(candidate.release.name),
@@ -329,11 +402,12 @@ export class Service extends Implementation {
                         description: !hasAccess
                             ? `Unable to update`
                             : `Update to ${this.candidate.release.name}`,
-                        disabled: !hasAccess, // Disable the button if access is not available
+                        disabled: !hasAccess,
                     },
                     handler: () => {
-                        if (!hasAccess)
+                        if (!hasAccess) {
                             return Promise.reject(new Error('No access to the current folder'));
+                        }
                         return this._delivery().then((updater: string) => {
                             global.application
                                 .shutdown('Updating')
@@ -357,6 +431,84 @@ export class Service extends Implementation {
                 },
             ],
         );
+    }
+
+    private async _checkForAlphaReleaseAnnouncement(): Promise<void> {
+        const github = new GitHubClient();
+        const releases = await github.getReleases({ repo: REPO });
+        const latestAlpha = getLatestAlphaRelease(releases);
+        // This branch never downloads assets. It only advertises the separate 4.0.0 alpha track.
+        if (latestAlpha === undefined) {
+            return;
+        }
+        const lastAnnouncedTag = await this._getLastAnnouncedAlphaTag();
+        if (lastAnnouncedTag === latestAlpha.tag) {
+            return;
+        }
+        const releasePageUrl = latestAlpha.release.html_url;
+        notifications.send(
+            `Chipmunk's next major release is now in alpha.`,
+            [
+                {
+                    action: {
+                        uuid: unique(),
+                        name: 'Open Release Page',
+                        description: releasePageUrl,
+                        disabled: false,
+                    },
+                    handler: () => {
+                        return shell.openExternal(releasePageUrl);
+                    },
+                },
+                {
+                    action: {
+                        uuid: unique(),
+                        name: 'Dismiss',
+                        description: '',
+                        disabled: false,
+                    },
+                    handler: () => Promise.resolve(),
+                },
+            ],
+        );
+        await this._setLastAnnouncedAlphaTag(latestAlpha.tag);
+    }
+
+    private async _getManualAlphaReleaseReport(): Promise<string | undefined> {
+        const github = new GitHubClient();
+        const releases = await github.getReleases({ repo: REPO });
+        const latestAlpha = getLatestAlphaRelease(releases);
+        if (latestAlpha === undefined) {
+            return undefined;
+        }
+        return this._getManualAlphaReleaseReportText();
+    }
+
+    private _getManualAlphaReleaseReportText(): string {
+        return 'The next major release of Chipmunk is available as an alpha release.\nPlease download it manually from the Chipmunk GitHub releases page.';
+    }
+
+    private async _getLastAnnouncedAlphaTag(): Promise<string | undefined> {
+        try {
+            const entries = await storage.entries.get(ALPHA_RELEASE_NOTIFICATION_STATE_KEY);
+            return entries.get(ALPHA_RELEASE_NOTIFICATION_ENTRY)?.content;
+        } catch (_err) {
+            // Missing state just means nothing has been announced yet.
+            return undefined;
+        }
+    }
+
+    private async _setLastAnnouncedAlphaTag(tag: string): Promise<void> {
+        try {
+            await storage.entries.overwrite(ALPHA_RELEASE_NOTIFICATION_STATE_KEY, [
+                {
+                    uuid: ALPHA_RELEASE_NOTIFICATION_ENTRY,
+                    content: tag,
+                },
+            ]);
+        } catch (err) {
+            this.log().warn(`Fail to save alpha release notification state: ${error(err)}`);
+        }
     }
 
     // Function to check access to the current folder

--- a/application/holder/src/service/updater/alpha.ts
+++ b/application/holder/src/service/updater/alpha.ts
@@ -1,0 +1,80 @@
+import { IReleaseData } from '@module/github';
+
+// Alpha announcements are intentionally separate from the main updater flow.
+// The current app never installs `4.0.0-alpha.x`; it only points users to GitHub.
+const ALPHA_TAG_REGEXP = /^v?4\.0\.0-alpha\.(\d+)$/i;
+
+export interface IAlphaRelease {
+    release: IReleaseData;
+    tag: string;
+    number: number;
+}
+
+/**
+ * Picks the newest GitHub prerelease matching `4.0.0-alpha.{n}`.
+ *
+ * The match is based on `tag_name`, not `name`, because release titles are editable.
+ */
+export function getLatestAlphaRelease(releases: IReleaseData[]): IAlphaRelease | undefined {
+    return releases
+        .map((release) => getAlphaRelease(release))
+        .filter((release): release is IAlphaRelease => release !== undefined)
+        .sort((a, b) => {
+            if (a.number !== b.number) {
+                return b.number - a.number;
+            }
+            const publishedDiff = getPublishedAtTime(b.release) - getPublishedAtTime(a.release);
+            if (publishedDiff !== 0) {
+                return publishedDiff;
+            }
+            return b.release.id - a.release.id;
+        })[0];
+}
+
+export function getAlphaRelease(release: IReleaseData): IAlphaRelease | undefined {
+    if (release.prerelease !== true || release.draft === true) {
+        return undefined;
+    }
+    if (typeof release.html_url !== 'string' || release.html_url.trim() === '') {
+        return undefined;
+    }
+    const parsed = parseAlphaTag(release.tag_name);
+    if (parsed === undefined) {
+        return undefined;
+    }
+    return {
+        release,
+        tag: parsed.tag,
+        number: parsed.number,
+    };
+}
+
+// Notifications prefer the release title when present, but parsing never depends on it.
+export function getReleaseLabel(release: IReleaseData): string {
+    return release.name.trim() !== '' ? release.name : release.tag_name;
+}
+
+function parseAlphaTag(tag: string): { tag: string; number: number } | undefined {
+    // Normalize tags so `v4.0.0-alpha.7` and `4.0.0-alpha.7` dedupe to the same key.
+    const match = tag.trim().toLowerCase().match(ALPHA_TAG_REGEXP);
+    if (match === null) {
+        return undefined;
+    }
+    const number = Number.parseInt(match[1], 10);
+    if (!Number.isSafeInteger(number)) {
+        return undefined;
+    }
+    return {
+        tag: `4.0.0-alpha.${number}`,
+        number,
+    };
+}
+
+function getPublishedAtTime(release: IReleaseData): number {
+    // GitHub ordering is not treated as authoritative for alpha announcements.
+    if (typeof release.published_at !== 'string' || release.published_at.trim() === '') {
+        return 0;
+    }
+    const publishedAt = Date.parse(release.published_at);
+    return Number.isNaN(publishedAt) ? 0 : publishedAt;
+}

--- a/application/platform/ipc/request/app/alpha_release.ts
+++ b/application/platform/ipc/request/app/alpha_release.ts
@@ -1,0 +1,23 @@
+import { Define, Interface, SignatureRequirement } from '../declarations';
+import * as validator from '../../../env/obj';
+
+@Define({ name: 'GetAppAlphaReleaseRequest' })
+export class Request extends SignatureRequirement {}
+export interface Request extends Interface {}
+
+@Define({ name: 'GetAppAlphaReleaseResponse' })
+export class Response extends SignatureRequirement {
+    public version: string | undefined;
+    public url: string | undefined;
+    public error: string | undefined;
+
+    constructor(input: { version: string | undefined; url: string | undefined; error: string | undefined }) {
+        super();
+        validator.isObject(input);
+        this.error = validator.getAsNotEmptyStringOrAsUndefined(input, 'error');
+        this.version = validator.getAsNotEmptyStringOrAsUndefined(input, 'version');
+        this.url = validator.getAsNotEmptyStringOrAsUndefined(input, 'url');
+    }
+}
+
+export interface Response extends Interface {}

--- a/application/platform/ipc/request/app/index.ts
+++ b/application/platform/ipc/request/app/index.ts
@@ -1,2 +1,3 @@
 export * as Version from './version';
 export * as Changelogs from './changelogs';
+export * as AlphaRelease from './alpha_release';


### PR DESCRIPTION
This PR stills a draft until we release Chipmunk 4 Alpha!

This PR includes:

* Prepare Chipmunk to avoid installing release artifacts for the upcoming Chipmunk 4 alpha release since it will replace electron-based frontend
* Show announcement banner for each alpha release
* Show a hint for the alpha release when user click on `check for updates`
* Show a hint for the alpha release in the about page.
* Code is expecting the new version to follow the format `4.0.0-alpha.1` and it will compare the tags not the release name.