### PR TITLE
Native: Update Notifications & About Page

### DIFF
--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["esrlabs.com"]
 
 [workspace.dependencies]
@@ -54,6 +54,8 @@ serde_json = "1.0"
 thiserror = "2.0"
 lazy_static = "1.5"
 tokio = { version = "1", features = ["full"] }
+reqwest = "0.12"
+semver = "1"
 tokio-stream = "0.1"
 dlt-core = "0.20.2"
 crossbeam-channel = "0.5"

--- a/application/apps/indexer/gui/application/Cargo.toml
+++ b/application/apps/indexer/gui/application/Cargo.toml
@@ -32,6 +32,8 @@ serde.workspace = true
 serde_json.workspace = true
 log.workspace = true
 tokio.workspace = true
+reqwest = { workspace = true, features = ["json"] }
+semver.workspace = true
 rfd.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 itertools.workspace = true

--- a/application/apps/indexer/gui/application/src/common/app_version.rs
+++ b/application/apps/indexer/gui/application/src/common/app_version.rs
@@ -1,0 +1,17 @@
+//! Shared access to the application's embedded version metadata.
+
+use std::sync::LazyLock;
+
+use semver::Version;
+
+/// Current application version embedded in the binary.
+pub const CURRENT_VERSION_STR: &str = env!("CARGO_PKG_VERSION");
+
+/// Returns the parsed current application version.
+pub fn current_version() -> &'static Version {
+    static CURRENT_VERSION: LazyLock<Version> = LazyLock::new(|| {
+        Version::parse(CURRENT_VERSION_STR).unwrap_or_else(|_| Version::new(0, 0, 0))
+    });
+
+    &CURRENT_VERSION
+}

--- a/application/apps/indexer/gui/application/src/common/mod.rs
+++ b/application/apps/indexer/gui/application/src/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod action_throttle;
+pub mod app_version;
 pub mod comm_utls;
 pub mod fixed_queue;
 pub mod fonts;

--- a/application/apps/indexer/gui/application/src/host/message.rs
+++ b/application/apps/indexer/gui/application/src/host/message.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use semver::Version;
 use uuid::Uuid;
 
 use crate::{
@@ -40,6 +41,8 @@ pub enum HostMessage {
     PresetsImported(Box<PresetsImported>),
     /// Presets were exported successfully to the provided file path.
     PresetsExported { path: PathBuf, count: usize },
+    /// A newer application version is available.
+    AppVersionUpdate(Box<AppVersionUpdate>),
     /// Storage-related async events.
     Storage(StorageEvent),
 }
@@ -53,4 +56,17 @@ pub struct PresetsImported {
     pub presets: Vec<Preset>,
     /// True when the file was parsed through the legacy compatibility path.
     pub used_legacy_format: bool,
+}
+
+/// Message payload for a newer application version.
+#[derive(Debug)]
+pub struct AppVersionUpdate {
+    /// Newer version returned by the release source.
+    pub latest_version: Version,
+    /// Release notes associated with the newer version.
+    //TODO AAZ:
+    #[allow(unused)]
+    pub release_notes: Option<String>,
+    /// Release page URL.
+    pub release_url: String,
 }

--- a/application/apps/indexer/gui/application/src/host/service/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/service/mod.rs
@@ -50,6 +50,7 @@ use storage::StorageService;
 
 pub mod file;
 mod presets_io;
+mod release_info;
 mod storage;
 
 #[derive(Debug)]
@@ -94,6 +95,7 @@ impl HostService {
                     storage,
                 };
 
+                release_info::spawn_update_check(host.communication.senders.clone());
                 host.run().await;
             });
         });

--- a/application/apps/indexer/gui/application/src/host/service/release_info.rs
+++ b/application/apps/indexer/gui/application/src/host/service/release_info.rs
@@ -1,0 +1,173 @@
+use anyhow::Result;
+use log::{info, warn};
+use semver::Version;
+use serde::Deserialize;
+
+use crate::{
+    common::app_version,
+    host::{
+        communication::ServiceSenders,
+        message::{AppVersionUpdate, HostMessage},
+    },
+};
+
+const OWNER: &str = "esrlabs";
+const REPO: &str = "chipmunk";
+const RELEASES_LIMIT: usize = 10;
+const USER_AGENT: &str = "chipmunk";
+
+#[derive(Debug, Deserialize)]
+struct ReleaseInfo {
+    tag_name: String,
+    body: Option<String>,
+    html_url: String,
+    draft: bool,
+}
+
+/// Spawns a background check for a newer GitHub release in the current major series.
+pub fn spawn_update_check(senders: ServiceSenders) {
+    tokio::spawn(check_for_updates(senders));
+}
+
+async fn check_for_updates(senders: ServiceSenders) {
+    let releases = match fetch_release_info().await {
+        Ok(releases) => releases,
+        Err(err) => {
+            warn!("Failed to fetch GitHub releases: {err:#}");
+            return;
+        }
+    };
+
+    let current_version = app_version::current_version().clone();
+
+    let Some((latest_version, release)) =
+        latest_current_major_release(releases, current_version.major)
+    else {
+        info!(
+            "No release found for the current major version in the latest \
+            {RELEASES_LIMIT} GitHub releases."
+        );
+        return;
+    };
+
+    if latest_version <= current_version {
+        info!(
+            "Application is up to date for the current major version. \
+            current_version={current_version}, latest_version={latest_version}"
+        );
+        return;
+    }
+
+    let update = AppVersionUpdate {
+        latest_version,
+        release_notes: release.body,
+        release_url: release.html_url,
+    };
+
+    senders
+        .send_message(HostMessage::AppVersionUpdate(Box::new(update)))
+        .await;
+}
+
+fn parse_version(version: &str) -> Result<Version, semver::Error> {
+    Version::parse(version.trim_start_matches('v'))
+}
+
+/// Returns the newest non-draft release that parses as the current major version.
+fn latest_current_major_release(
+    releases: Vec<ReleaseInfo>,
+    current_major: u64,
+) -> Option<(Version, ReleaseInfo)> {
+    let mut matching_releases = releases
+        .into_iter()
+        .filter_map(|release| {
+            if release.draft {
+                return None;
+            }
+
+            let version = parse_version(&release.tag_name)
+                .inspect_err(|err| {
+                    warn!(
+                        "Failed to parse GitHub release version '{}': {err}",
+                        release.tag_name
+                    );
+                })
+                .ok()?;
+
+            (version.major == current_major).then_some((version, release))
+        })
+        .collect::<Vec<_>>();
+
+    matching_releases.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+    matching_releases.pop()
+}
+
+/// Fetches the latest published releases from GitHub.
+async fn fetch_release_info() -> Result<Vec<ReleaseInfo>> {
+    let client = reqwest::Client::new();
+    let url = format!(
+        "https://api.github.com/repos/{OWNER}/{REPO}/releases?per_page={RELEASES_LIMIT}&page=1"
+    );
+
+    let response = client
+        .get(url)
+        .header(reqwest::header::USER_AGENT, USER_AGENT)
+        .send()
+        .await?
+        .error_for_status()?;
+
+    Ok(response.json().await?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn release(tag_name: &str) -> ReleaseInfo {
+        ReleaseInfo {
+            tag_name: tag_name.into(),
+            body: None,
+            html_url: String::from("https://example.com/release"),
+            draft: false,
+        }
+    }
+
+    #[test]
+    fn prerelease_versions_follow_semver_order() {
+        let alpha_1 = parse_version("4.0.0-alpha.1").expect("alpha.1 should parse");
+        let alpha_2 = parse_version("4.0.0-alpha.2").expect("alpha.2 should parse");
+        let beta_1 = parse_version("4.0.0-beta.1").expect("beta.1 should parse");
+        let beta_2 = parse_version("4.0.0-beta.2").expect("beta.2 should parse");
+        let stable = parse_version("4.0.0").expect("stable should parse");
+
+        assert!(alpha_1 < alpha_2);
+        assert!(alpha_2 < beta_1);
+        assert!(beta_1 < beta_2);
+        assert!(beta_2 < stable);
+    }
+
+    #[test]
+    fn dotted_prerelease_format_is_rejected() {
+        assert!(parse_version("4.0.0.alpha-1").is_err());
+        assert!(parse_version("4.0.0.alpha-2").is_err());
+        assert!(parse_version("4.0.0.beta-1").is_err());
+        assert!(parse_version("4.0.0.beta-2").is_err());
+    }
+
+    #[test]
+    fn latest_current_major_release_sorts_versions() {
+        let latest = latest_current_major_release(
+            vec![
+                release("4.0.0-alpha.1"),
+                release("5.0.0-alpha.1"),
+                release("4.0.0-beta.1"),
+                release("4.0.0-beta.2"),
+            ],
+            4,
+        )
+        .expect("current major release should be found");
+
+        assert_eq!(latest.0, parse_version("4.0.0-beta.2").unwrap());
+        assert_eq!(latest.1.tag_name, "4.0.0-beta.2");
+    }
+}

--- a/application/apps/indexer/gui/application/src/host/ui/info.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/info.rs
@@ -1,0 +1,180 @@
+use egui::{
+    Align, Area, Button, Context, Frame, Grid, Id, Layout, OpenUrl, Order, Stroke, Ui, Widget, vec2,
+};
+
+use crate::{
+    common::{app_version, modal::show_modal},
+    host::{common::colors, ui::state::info::AppInfoState},
+};
+
+const UPDATE_CARD_MARGIN: f32 = 16.0;
+const UPDATE_CARD_MAX_WIDTH: f32 = 250.0;
+const ABOUT_GITHUB_URL: &str = "https://github.com/esrlabs/chipmunk";
+const ABOUT_REPORT_ISSUE_URL: &str = "https://github.com/esrlabs/chipmunk/issues/new/choose";
+const ACTION_BUTTON_SIZE: egui::Vec2 = vec2(100.0, 25.0);
+
+pub fn render_update_banner(app_info: &mut AppInfoState, ui: &mut Ui) {
+    let Some(update) = app_info.update_info() else {
+        return;
+    };
+
+    let mut dismiss = false;
+    let mut open_release = false;
+
+    let card_width = (ui.max_rect().width() - UPDATE_CARD_MARGIN * 2.0).min(UPDATE_CARD_MAX_WIDTH);
+
+    let card_response = Area::new(Id::new("app_version_update_card"))
+        .order(Order::Foreground)
+        .anchor(
+            egui::Align2::RIGHT_BOTTOM,
+            vec2(-UPDATE_CARD_MARGIN, -UPDATE_CARD_MARGIN),
+        )
+        .show(ui.ctx(), |ui| {
+            ui.set_width(card_width);
+
+            let accent_stroke = colors::main_accent_stroke(ui.visuals().dark_mode);
+            Frame::window(ui.style())
+                .stroke(Stroke::new(1.0, accent_stroke))
+                .show(ui, |ui| {
+                    ui.set_width(card_width);
+
+                    ui.vertical_centered(|ui| ui.heading("Update available"));
+
+                    ui.add_space(4.0);
+                    ui.label("A newer Chipmunk version is available.");
+                    ui.add_space(8.0);
+
+                    Grid::new("app_version_update_versions")
+                        .num_columns(2)
+                        .show(ui, |ui| {
+                            ui.strong("Current:");
+                            ui.label(app_version::current_version().to_string());
+                            ui.end_row();
+
+                            ui.strong("Latest:");
+                            ui.label(update.latest_version.to_string());
+                            ui.end_row();
+                        });
+
+                    ui.add_space(8.0);
+                    ui.vertical_centered(|ui| {
+                        ui.allocate_ui_with_layout(
+                            vec2(205.0, 25.0),
+                            Layout::left_to_right(Align::Center),
+                            |ui| {
+                                let button_size = vec2(100.0, 25.0);
+                                if Button::new("Open release")
+                                    .min_size(button_size)
+                                    .ui(ui)
+                                    .clicked()
+                                {
+                                    open_release = true;
+                                }
+
+                                if Button::new("Dismiss")
+                                    .min_size(button_size)
+                                    .ui(ui)
+                                    .clicked()
+                                {
+                                    dismiss = true;
+                                }
+                            },
+                        );
+                    });
+                });
+        });
+
+    if card_response.response.clicked_elsewhere() {
+        dismiss = true;
+    }
+
+    if open_release {
+        ui.ctx()
+            .open_url(OpenUrl::new_tab(update.release_url.clone()));
+        dismiss = true;
+    }
+
+    if dismiss {
+        app_info.show_update_banner = false;
+    }
+}
+
+pub fn render_about_modal(app_info: &mut AppInfoState, ctx: &Context) {
+    let current_version = app_version::current_version().to_string();
+
+    let mut open_github = false;
+    let mut open_report_issue = false;
+    let mut open_release_url = None;
+
+    let modal = show_modal(ctx, "about", 360.0, |ui| {
+        ui.vertical_centered(|ui| {
+            ui.heading("Chipmunk");
+            ui.add_space(8.0);
+            ui.label("Built for fast, scalable log and trace analysis.");
+            ui.add_space(8.0);
+            ui.label(format!("Version: {current_version}"));
+
+            if let Some(update_info) = app_info.update_info() {
+                ui.add_space(4.0);
+                if ui
+                    .hyperlink_to(
+                        format!("Update available: {}", update_info.latest_version),
+                        &update_info.release_url,
+                    )
+                    .clicked()
+                {
+                    open_release_url = Some(update_info.release_url.clone());
+                }
+            }
+
+            ui.add_space(12.0);
+            ui.vertical_centered(|ui| {
+                ui.allocate_ui_with_layout(
+                    vec2(310.0, 25.0),
+                    Layout::left_to_right(Align::Center),
+                    |ui| {
+                        if Button::new("GitHub Repo")
+                            .min_size(ACTION_BUTTON_SIZE)
+                            .ui(ui)
+                            .clicked()
+                        {
+                            open_github = true;
+                        }
+
+                        if Button::new("Report issue")
+                            .min_size(ACTION_BUTTON_SIZE)
+                            .ui(ui)
+                            .clicked()
+                        {
+                            open_report_issue = true;
+                        }
+
+                        if Button::new("Close")
+                            .min_size(ACTION_BUTTON_SIZE)
+                            .ui(ui)
+                            .clicked()
+                        {
+                            ui.close();
+                        }
+                    },
+                );
+            });
+        });
+    });
+
+    if let Some(open_release_url) = open_release_url {
+        ctx.open_url(OpenUrl::new_tab(open_release_url));
+    }
+
+    if open_github {
+        ctx.open_url(OpenUrl::new_tab(ABOUT_GITHUB_URL));
+    }
+
+    if open_report_issue {
+        ctx.open_url(OpenUrl::new_tab(ABOUT_REPORT_ISSUE_URL));
+    }
+
+    if modal.should_close() {
+        app_info.about_open = false;
+    }
+}

--- a/application/apps/indexer/gui/application/src/host/ui/menu.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/menu.rs
@@ -5,7 +5,10 @@ use tokio::sync::mpsc::Sender;
 use crate::host::{
     command::HostCommand,
     common::{app_style, parsers::ParserNames, sources::StreamNames},
-    ui::actions::{FileDialogOptions, UiActions},
+    ui::{
+        actions::{FileDialogOptions, UiActions},
+        state::info::AppInfoState,
+    },
 };
 
 #[derive(Debug)]
@@ -24,7 +27,7 @@ impl MainMenuBar {
         Self { cmd_tx }
     }
 
-    pub fn render(&mut self, ui: &mut Ui, actions: &mut UiActions) {
+    pub fn render(&mut self, ui: &mut Ui, actions: &mut UiActions, app_info: &mut AppInfoState) {
         self.handle_file_dialog(actions);
 
         MenuBar::new().ui(ui, |ui| {
@@ -39,6 +42,13 @@ impl MainMenuBar {
 
                     ui.separator();
                 }
+
+                if ui.button("About").clicked() {
+                    app_info.about_open = true;
+                    ui.close();
+                }
+
+                ui.separator();
 
                 if ui.button("Close").clicked() {
                     ui.send_viewport_cmd(egui::ViewportCommand::Close);

--- a/application/apps/indexer/gui/application/src/host/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/mod.rs
@@ -40,6 +40,7 @@ pub use actions::{HostAction, UiActions};
 
 pub mod actions;
 pub mod home;
+mod info;
 mod menu;
 pub mod multi_setup;
 mod notification;
@@ -202,6 +203,9 @@ impl Host {
                 self.state
                     .handle_presets_exported(path, count, &mut self.ui_actions)
             }
+            HostMessage::AppVersionUpdate(update) => {
+                self.state.app_info.set_update_info(*update);
+            }
             HostMessage::Storage(event) => self.storage.handle_event(event, &mut self.ui_actions),
         }
     }
@@ -232,14 +236,25 @@ impl Host {
             .frame(Frame::central_panel(ui.style()).inner_margin(0))
             .show_inside(ui, |ui| {
                 self.render_main(ui);
+
+                if self.state.app_info.show_update_banner {
+                    info::render_update_banner(&mut self.state.app_info, ui);
+                }
             });
+
+        if self.state.app_info.about_open {
+            info::render_about_modal(&mut self.state.app_info, ui.ctx());
+        }
     }
 
     fn render_menu(&mut self, ui: &mut Ui) {
         let Self {
-            menu, ui_actions, ..
+            menu,
+            ui_actions,
+            state,
+            ..
         } = self;
-        menu.render(ui, ui_actions);
+        menu.render(ui, ui_actions, &mut state.app_info);
     }
 
     fn render_tabs(&mut self, ui: &mut Ui) {
@@ -349,11 +364,6 @@ impl Host {
         }
     }
 
-    /// Renders a blocking modal to inform the user that a system file dialog
-    /// is currently active.
-    ///
-    /// This overlay prevents interaction with the main app and provides hints to
-    /// locate the external dialog window.
     fn file_dialog_overlay(&mut self, ctx: &Context) {
         show_modal(ctx, "file dialog overlay", 350.0, |ui| {
             ui.vertical_centered(|ui| {

--- a/application/apps/indexer/gui/application/src/host/ui/state/info.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/state/info.rs
@@ -1,0 +1,24 @@
+//! UI state for application metadata and update presentation.
+
+use crate::host::message::AppVersionUpdate;
+
+/// UI state for application information.
+#[derive(Debug, Default)]
+pub struct AppInfoState {
+    update_info: Option<AppVersionUpdate>,
+    pub show_update_banner: bool,
+    pub about_open: bool,
+}
+
+impl AppInfoState {
+    /// Returns the latest known update information, if any.
+    pub fn update_info(&self) -> Option<&AppVersionUpdate> {
+        self.update_info.as_ref()
+    }
+
+    /// Stores new update information and shows the update banner.
+    pub fn set_update_info(&mut self, update_info: AppVersionUpdate) {
+        self.update_info = Some(update_info);
+        self.show_update_banner = true;
+    }
+}

--- a/application/apps/indexer/gui/application/src/host/ui/state/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/state/mod.rs
@@ -3,6 +3,7 @@ use rustc_hash::FxHashMap;
 use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
 
+pub mod info;
 mod presets;
 
 use crate::{
@@ -19,6 +20,8 @@ use crate::{
     session::{SessionUiInit, ui::Session},
 };
 
+use self::info::AppInfoState;
+
 pub const HOME_TAB_IDX: usize = 0;
 
 #[derive(Debug)]
@@ -32,6 +35,7 @@ pub struct HostState {
     /// Shared visibility for the host right panel and session auxiliary panels.
     pub panels_visibility: PanelsVisibility,
     pub registry: HostRegistry,
+    pub app_info: AppInfoState,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -54,6 +58,7 @@ impl HostState {
             multi_setups: FxHashMap::default(),
             panels_visibility: PanelsVisibility::default(),
             registry: HostRegistry::default(),
+            app_info: AppInfoState::default(),
         }
     }
 

--- a/application/apps/indexer/gui/application/src/host/ui/state/version.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/state/version.rs
@@ -1,0 +1,8 @@
+use crate::host::message::AppVersionUpdate;
+
+/// UI state for application version information.
+#[derive(Debug, Default)]
+pub struct AppVersionState {
+    /// Newer release information shown to the user when available.
+    pub update: Option<AppVersionUpdate>,
+}


### PR DESCRIPTION
This PR includes:

* Fetch release infos from GitHub.
* UI simple banner on new versions.
* App about page
* Set first version to match 4.0.0-alpha.1