### PR TITLE
Native Attachements: Filtering & Go/Select associated Logs & UI Improvements

### DIFF
--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/chart/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/chart/mod.rs
@@ -343,8 +343,7 @@ impl ChartUI {
 
         match plot_res.inner {
             PlotResponse::JumpToLog(log_nr) => {
-                shared.logs.scroll_main_row = Some(log_nr);
-                shared.logs.replace_selection_with(log_nr);
+                shared.logs.focus_main_row(log_nr);
                 actions.try_send_command(&self.cmd_tx, SessionCommand::GetSelectedLog(log_nr));
             }
             PlotResponse::RequestForRange(bound_x) => {

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_table.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_table.rs
@@ -162,7 +162,7 @@ impl<'a> LogsDelegate<'a> {
             return;
         };
 
-        self.shared.logs.scroll_main_row = Some(selected_row);
+        self.shared.logs.focus_main_row(selected_row);
     }
 
     fn handle_selection_click(&mut self, pos: u64, modifiers: egui::Modifiers) {

--- a/application/apps/indexer/gui/application/src/session/ui/logs_table/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/logs_table/mod.rs
@@ -81,7 +81,7 @@ impl LogsTable {
             table = table.headers(Vec::new());
         }
 
-        if let Some(row) = shared.logs.scroll_main_row.take() {
+        if let Some(row) = shared.logs.take_main_scroll_row() {
             const OFFSET: u64 = 3;
             table = table.scroll_to_rows(row.saturating_sub(OFFSET)..=(row + OFFSET), None);
         }

--- a/application/apps/indexer/gui/application/src/session/ui/shared/attachments.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/shared/attachments.rs
@@ -12,8 +12,21 @@ pub struct AttachmentsState {
     index_by_uuid: FxHashMap<Uuid, usize>,
     /// Index for lookups: log position -> attachments list index
     index_by_position: FxHashMap<usize, usize>,
+    /// Available attachment extensions in first-seen order.
+    extensions: Vec<String>,
     /// Index for lookups: attachment extension -> associated color
     color_by_extension: FxHashMap<String, egui::Color32>,
+    /// Active extension filter and its cached attachment indices.
+    filter: Option<AttachmentFilter>,
+}
+
+/// Cached attachment indices for the active extension filter.
+#[derive(Debug)]
+pub struct AttachmentFilter {
+    /// Extension currently selected in the filter menu.
+    extension: String,
+    /// Attachment indices matching the selected extension.
+    indices: Vec<usize>,
 }
 
 impl AttachmentsState {
@@ -29,20 +42,27 @@ impl AttachmentsState {
             self.index_by_position.insert(position, index);
         }
 
-        // Assumption: index_by_uuid and color_by_extension cannot change when a attachment is updated.
+        // Assumption: attachment metadata tied to a UUID does not change on update.
         if self.index_by_uuid.contains_key(&uuid) {
             return;
         }
 
         self.index_by_uuid.insert(uuid, index);
 
-        if let Some(ext) = attachment.ext.as_deref()
-            && !self.color_by_extension.contains_key(ext)
-        {
-            self.color_by_extension.insert(
-                ext.to_string(),
-                colors::search_value_color(self.color_by_extension.len()),
-            );
+        if let Some(ext) = attachment.ext.as_deref() {
+            if !self.color_by_extension.contains_key(ext) {
+                self.extensions.push(ext.to_string());
+                self.color_by_extension.insert(
+                    ext.to_string(),
+                    colors::search_value_color(self.color_by_extension.len()),
+                );
+            }
+
+            if let Some(filter) = &mut self.filter
+                && filter.extension == ext
+            {
+                filter.indices.push(index);
+            }
         }
 
         self.attachments.push(attachment);
@@ -67,6 +87,39 @@ impl AttachmentsState {
             .and_then(|index| self.attachments.get(*index))
     }
 
+    /// Get available attachment extensions in first-seen order.
+    pub fn extensions(&self) -> &[String] {
+        &self.extensions
+    }
+
+    /// Get the active extension filter, if set.
+    pub fn active_filter(&self) -> Option<&AttachmentFilter> {
+        self.filter.as_ref()
+    }
+
+    /// Set the active extension filter and rebuild its cached indices.
+    pub fn set_extension_filter(&mut self, extension: String) {
+        let indices = self
+            .attachments
+            .iter()
+            .enumerate()
+            .filter_map(|(index, attachment)| {
+                attachment
+                    .ext
+                    .as_deref()
+                    .is_some_and(|ext| ext == extension.as_str())
+                    .then_some(index)
+            })
+            .collect();
+
+        self.filter = Some(AttachmentFilter { extension, indices });
+    }
+
+    /// Clear the active extension filter.
+    pub fn clear_filter(&mut self) {
+        self.filter = None;
+    }
+
     /// Get color for a given file extension.
     pub fn color_by_extension(&self, ext: &str) -> Option<egui::Color32> {
         self.color_by_extension.get(ext).copied()
@@ -78,5 +131,90 @@ impl AttachmentsState {
             .and_then(|attachment| attachment.ext.as_deref())
             .and_then(|ext| self.color_by_extension.get(ext))
             .copied()
+    }
+}
+
+impl AttachmentFilter {
+    /// Get the selected attachment extension.
+    pub fn extension(&self) -> &str {
+        &self.extension
+    }
+
+    /// Get attachment indices matching the selected extension.
+    pub fn indices(&self) -> &[usize] {
+        &self.indices
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn attachment(id: u128, ext: Option<&str>) -> AttachmentInfo {
+        AttachmentInfo {
+            uuid: Uuid::from_u128(id),
+            filepath: PathBuf::from(format!("attachment-{id}")),
+            name: format!("attachment-{id}"),
+            ext: ext.map(str::to_string),
+            size: id as usize,
+            mime: None,
+            messages: vec![id as usize],
+        }
+    }
+
+    #[test]
+    fn tracks_extensions_once_in_first_seen_order() {
+        let mut state = AttachmentsState::default();
+
+        state.add(attachment(1, Some("txt")));
+        state.add(attachment(2, Some("png")));
+        state.add(attachment(3, Some("txt")));
+        state.add(attachment(4, None));
+
+        assert_eq!(state.extensions(), &["txt".to_string(), "png".to_string()]);
+    }
+
+    #[test]
+    fn filters_existing_and_new_matching_attachments() {
+        let mut state = AttachmentsState::default();
+        state.add(attachment(1, Some("txt")));
+        state.add(attachment(2, Some("png")));
+        state.add(attachment(3, Some("txt")));
+
+        state.set_extension_filter("png".to_string());
+        assert_eq!(state.active_filter().unwrap().indices(), &[1]);
+
+        state.add(attachment(4, Some("png")));
+        state.add(attachment(5, Some("txt")));
+        state.add(attachment(6, None));
+
+        let filter = state.active_filter().unwrap();
+        assert_eq!(filter.extension(), "png");
+        assert_eq!(filter.indices(), &[1, 3]);
+    }
+
+    #[test]
+    fn duplicate_attachment_update_does_not_duplicate_filter_indices() {
+        let mut state = AttachmentsState::default();
+        state.add(attachment(1, Some("png")));
+        state.set_extension_filter("png".to_string());
+
+        state.add(attachment(1, Some("png")));
+
+        assert_eq!(state.attachments().len(), 1);
+        assert_eq!(state.active_filter().unwrap().indices(), &[0]);
+    }
+
+    #[test]
+    fn clear_filter_removes_active_filter() {
+        let mut state = AttachmentsState::default();
+        state.add(attachment(1, Some("png")));
+        state.set_extension_filter("png".to_string());
+
+        state.clear_filter();
+
+        assert!(state.active_filter().is_none());
     }
 }

--- a/application/apps/indexer/gui/application/src/session/ui/shared/logs.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/shared/logs.rs
@@ -5,7 +5,7 @@ pub struct LogsState {
     pub logs_count: u64,
     /// The stream position of the log which the main logs table
     /// should scroll into.
-    pub scroll_main_row: Option<u64>,
+    scroll_main_row: Option<u64>,
     /// Selected rows keyed by original stream position.
     selected_rows: FxHashSet<u64>,
     /// Most recent row explicitly selected by the user.
@@ -78,6 +78,31 @@ impl LogsState {
         self.selected_rows.insert(row);
         self.last_selected_row = Some(row);
         self.selection_change(SelectionIntent::Exclusive)
+    }
+
+    /// Replaces the current selection with `rows`.
+    pub fn replace_selection_with_rows(&mut self, rows: &[u64]) -> SelectionChange {
+        self.selected_rows.clear();
+        self.selected_rows.extend(rows.iter().copied());
+        self.last_selected_row = rows.last().copied();
+        self.selection_change(SelectionIntent::Exclusive)
+    }
+
+    /// Selects `row` and requests the main logs table to scroll to it.
+    pub fn focus_main_row(&mut self, row: u64) -> SelectionChange {
+        self.scroll_main_row = Some(row);
+        self.replace_selection_with(row)
+    }
+
+    /// Selects `rows` and requests the main logs table to scroll to the first one.
+    pub fn focus_main_rows(&mut self, rows: &[u64]) -> SelectionChange {
+        self.scroll_main_row = rows.first().copied();
+        self.replace_selection_with_rows(rows)
+    }
+
+    /// Takes the pending main-table scroll request.
+    pub fn take_main_scroll_row(&mut self) -> Option<u64> {
+        self.scroll_main_row.take()
     }
 
     /// Applies a click mode and returns the resulting selection side effects.
@@ -345,5 +370,73 @@ mod tests {
 
         state.select_from_click(14, TOGGLE_ROW);
         assert_eq!(state.single_selected_row(), None);
+    }
+
+    #[test]
+    fn focus_main_row_selects_row_and_requests_scroll() {
+        let mut state = LogsState::default();
+
+        let change = state.focus_main_row(13);
+
+        assert_eq!(state.take_main_scroll_row(), Some(13));
+        assert_eq!(state.take_main_scroll_row(), None);
+        assert_eq!(state.single_selected_row(), Some(13));
+        assert_eq!(change.details_row, Some(13));
+        assert_eq!(change.jump_to_row, Some(13));
+    }
+
+    #[test]
+    fn focus_main_rows_selects_rows_and_requests_scroll_to_first() {
+        let mut state = LogsState::default();
+
+        let change = state.focus_main_rows(&[8, 13, 21]);
+
+        assert_eq!(state.take_main_scroll_row(), Some(8));
+        assert_eq!(state.single_selected_row(), None);
+        assert_eq!(change.details_row, None);
+        assert_eq!(change.jump_to_row, None);
+        assert_eq!(state.selected_rows, [8, 13, 21].into_iter().collect());
+        assert_eq!(state.last_selected_row, Some(21));
+    }
+
+    #[test]
+    fn multi_row_replacement_selects_all_rows() {
+        let mut state = LogsState::default();
+
+        state.replace_selection_with(3);
+        let change = state.replace_selection_with_rows(&[8, 13, 21]);
+
+        assert_eq!(state.single_selected_row(), None);
+        assert_eq!(change.details_row, None);
+        assert_eq!(change.jump_to_row, None);
+        assert_eq!(state.selected_rows, [8, 13, 21].into_iter().collect());
+        assert_eq!(state.last_selected_row, Some(21));
+    }
+
+    #[test]
+    fn multi_row_replacement_with_one_row_keeps_single_selection_effects() {
+        let mut state = LogsState::default();
+
+        let change = state.replace_selection_with_rows(&[8]);
+
+        assert_eq!(state.single_selected_row(), Some(8));
+        assert_eq!(change.details_row, Some(8));
+        assert_eq!(change.jump_to_row, Some(8));
+        assert_eq!(state.selected_rows, [8].into_iter().collect());
+        assert_eq!(state.last_selected_row, Some(8));
+    }
+
+    #[test]
+    fn multi_row_replacement_with_empty_rows_clears_selection() {
+        let mut state = LogsState::default();
+
+        state.replace_selection_with_rows(&[8, 13]);
+        let change = state.replace_selection_with_rows(&[]);
+
+        assert_eq!(state.single_selected_row(), None);
+        assert_eq!(change.details_row, None);
+        assert_eq!(change.jump_to_row, None);
+        assert!(state.selected_rows.is_empty());
+        assert_eq!(state.last_selected_row, None);
     }
 }

--- a/application/apps/indexer/gui/application/src/session/ui/side_panel/attachments.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/side_panel/attachments.rs
@@ -39,8 +39,6 @@ pub struct AttachmentsUi {
     session_cmd_tx: mpsc::Sender<SessionCommand>,
     /// Indices of currently selected rows in the attachments list.
     selected_rows: FxHashSet<usize>,
-    /// Index of the clicked row, used for context menu actions.
-    clicked_row: Option<usize>,
     /// Index of the previously clicked row, used as the anchor for shift-click multi-selection.
     previously_clicked_row: Option<usize>,
     /// Uuids of attachments that are pending to be saved after file dialog completion.
@@ -57,7 +55,6 @@ impl AttachmentsUi {
             session_cmd_tx,
             selected_rows: FxHashSet::default(),
             previously_clicked_row: None,
-            clicked_row: None,
             pending_attachment_save: FxHashSet::default(),
         }
     }
@@ -72,7 +69,7 @@ impl AttachmentsUi {
 
         let attachments = shared.attachments.attachments();
 
-        self.render_attachments_header(ui, attachments.len());
+        self.render_header(ui, attachments.len());
 
         // Details panel located at the bottom but needs to be rendered before the attachments list.
         if self.selected_rows.len() == 1 {
@@ -82,20 +79,18 @@ impl AttachmentsUi {
                 .show_separator_line(false)
                 .exact_size(200.0)
                 .show_inside(ui, |ui| {
-                    show_side_panel_group(ui, |ui| self.render_attachment_preview(ui));
+                    show_side_panel_group(ui, |ui| self.render_preview(ui));
                 });
         }
 
         egui::CentralPanel::default()
             .frame(Frame::NONE)
             .show_inside(ui, |ui| {
-                show_side_panel_group(ui, |ui| {
-                    self.render_attachments_list(&shared.attachments, ui_actions, ui)
-                });
+                show_side_panel_group(ui, |ui| self.render_list(shared, ui_actions, ui));
             });
     }
 
-    fn render_attachments_header(&self, ui: &mut egui::Ui, attachments_count: usize) {
+    fn render_header(&self, ui: &mut egui::Ui, attachments_count: usize) {
         egui::Sides::new().show(
             ui,
             |ui| {
@@ -120,7 +115,7 @@ impl AttachmentsUi {
     }
 
     // TODO [TOOL-741]: Implement attachments preview.
-    fn render_attachment_preview(&self, ui: &mut egui::Ui) {
+    fn render_preview(&self, ui: &mut egui::Ui) {
         Label::new(RichText::new("Preview").heading().size(SUBTITLE_SIZE))
             .truncate()
             .ui(ui);
@@ -129,13 +124,13 @@ impl AttachmentsUi {
         });
     }
 
-    fn render_attachments_list(
+    fn render_list(
         &mut self,
-        attachments_state: &AttachmentsState,
+        shared: &mut SessionShared,
         ui_actions: &mut UiActions,
         ui: &mut egui::Ui,
     ) {
-        let attachments = attachments_state.attachments();
+        let attachments_count = shared.attachments.attachments().len();
         let row_height = 2.0 * ui.text_style_height(&egui::TextStyle::Body) + ROW_VERTICAL_PADDING;
 
         Label::new(
@@ -147,7 +142,7 @@ impl AttachmentsUi {
         .ui(ui);
         ui.add_space(5.0);
 
-        if attachments.is_empty() {
+        if attachments_count == 0 {
             ui.label(RichText::new("No attachments").weak());
             return;
         }
@@ -157,19 +152,22 @@ impl AttachmentsUi {
             egui::ScrollArea::vertical().show_rows(
                 ui,
                 row_height,
-                attachments.len(),
+                attachments_count,
                 |ui, row_range| {
                     for current_row in row_range {
                         let is_selected = self.selected_rows.contains(&current_row);
-                        let attachment = &attachments[current_row];
+                        let Some(attachment) = shared.attachments.attachments().get(current_row)
+                        else {
+                            continue;
+                        };
 
                         let extension_color = attachment
                             .ext
                             .as_deref()
-                            .and_then(|ext| attachments_state.color_by_extension(ext))
+                            .and_then(|ext| shared.attachments.color_by_extension(ext))
                             .unwrap_or(DEFAULT_ATTACHMENT_EXT_COLOR);
 
-                        let response = self.render_attachment_row(
+                        let response = self.render_row(
                             ui,
                             attachment,
                             extension_color,
@@ -178,17 +176,11 @@ impl AttachmentsUi {
                         );
 
                         if response.clicked() {
-                            self.clicked_row = Some(current_row);
                             self.handle_row_click(current_row, ui.input(|i| i.modifiers));
                         }
 
-                        // TODO [TOOL-756]: Reevaluate secondary click logic
-                        if response.secondary_clicked() {
-                            self.clicked_row = Some(current_row);
-                        }
-
                         response.context_menu(|ui| {
-                            self.render_attachments_list_context_menu(ui, ui_actions, attachments);
+                            self.render_context_menu(current_row, shared, ui_actions, ui);
                         });
                     }
                 },
@@ -196,7 +188,7 @@ impl AttachmentsUi {
         });
     }
 
-    fn render_attachment_row(
+    fn render_row(
         &mut self,
         ui: &mut egui::Ui,
         attachment: &AttachmentInfo,
@@ -253,14 +245,20 @@ impl AttachmentsUi {
         response
     }
 
-    fn render_attachments_list_context_menu(
+    fn render_context_menu(
         &mut self,
-        ui: &mut egui::Ui,
+        attachment_idx: usize,
+        shared: &mut SessionShared,
         ui_actions: &mut UiActions,
-        attachments: &[AttachmentInfo],
+        ui: &mut egui::Ui,
     ) {
+        let attachments = shared.attachments.attachments();
+        let Some(attachment) = attachments.get(attachment_idx) else {
+            return;
+        };
         let attachment_count = attachments.len();
 
+        // ** Attachments Selection **
         if ui.button("Select all").clicked() {
             self.selected_rows.clear();
             self.selected_rows.extend(0..attachment_count);
@@ -273,9 +271,34 @@ impl AttachmentsUi {
         }
         ui.separator();
 
-        if ui.button(RichText::new("Save as")).clicked()
-            && let Some(attachment) = self.clicked_row.and_then(|r| attachments.get(r))
-        {
+        // ** Jump & Select matching Logs **
+        if let [first_position, ..] = attachment.messages.as_slice() {
+            let response = ui
+                .button(RichText::new("Jump to related row"))
+                .on_hover_text("Jumps to the first related row");
+            if response.clicked() {
+                shared.logs.focus_main_row(*first_position as u64);
+                ui.close();
+            }
+
+            if ui
+                .button(RichText::new("Select all related rows"))
+                .clicked()
+            {
+                let rows = attachment
+                    .messages
+                    .iter()
+                    .map(|&position| position as u64)
+                    .collect::<Vec<_>>();
+                shared.logs.focus_main_rows(&rows);
+                ui.close();
+            }
+
+            ui.separator();
+        }
+
+        // ** Save Attachments **
+        if ui.button(RichText::new("Save as")).clicked() {
             self.pending_attachment_save.clear();
             self.pending_attachment_save.insert(attachment.uuid);
 

--- a/application/apps/indexer/gui/application/src/session/ui/side_panel/attachments.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/side_panel/attachments.rs
@@ -12,7 +12,11 @@ use uuid::Uuid;
 use crate::{
     host::{
         command::{CopyFileInfo, HostCommand},
-        common::{colors::DEFAULT_ATTACHMENT_EXT_COLOR, file_utls, ui_utls::show_side_panel_group},
+        common::{
+            colors::{self, DEFAULT_ATTACHMENT_EXT_COLOR},
+            file_utls,
+            ui_utls::show_side_panel_group,
+        },
         ui::{UiActions, actions::FileDialogOptions},
     },
     session::{
@@ -45,6 +49,13 @@ pub struct AttachmentsUi {
     pending_attachment_save: FxHashSet<Uuid>,
 }
 
+/// Deferred filter mutation collected while rendering the filter menu.
+#[derive(Debug)]
+enum FilterChange {
+    Clear,
+    Set(String),
+}
+
 impl AttachmentsUi {
     pub fn new(
         host_cmd_tx: mpsc::Sender<HostCommand>,
@@ -67,9 +78,7 @@ impl AttachmentsUi {
     ) {
         self.handle_pending_dialogs(ui_actions, &shared.attachments);
 
-        let attachments = shared.attachments.attachments();
-
-        self.render_header(ui, attachments.len());
+        self.render_header(ui, &mut shared.attachments);
 
         // Details panel located at the bottom but needs to be rendered before the attachments list.
         if self.selected_rows.len() == 1 {
@@ -90,27 +99,88 @@ impl AttachmentsUi {
             });
     }
 
-    fn render_header(&self, ui: &mut egui::Ui, attachments_count: usize) {
+    fn render_header(&mut self, ui: &mut egui::Ui, attachments: &mut AttachmentsState) {
+        let mut filter_change = None;
+        let active_filter = attachments.active_filter();
+        let active_extension = active_filter.map(|filter| filter.extension().to_string());
+        let filtered_count = active_filter.map(|filter| filter.indices().len());
+        let attachments_count = attachments.attachments().len();
+
         egui::Sides::new().show(
             ui,
             |ui| {
-                let title = format!("Attachments ({})", attachments_count);
+                let count = filtered_count.map_or_else(
+                    || attachments_count.to_string(),
+                    |filtered_count| format!("{filtered_count}/{attachments_count}"),
+                );
+                let title = format!("Attachments ({count})");
                 Label::new(RichText::new(title).heading().size(TITLE_SIZE)).ui(ui);
             },
             |ui| {
-                ui.menu_button(
+                let response = ui.menu_button(
                     egui::RichText::new(egui_phosphor::regular::FUNNEL).size(16.0),
                     |ui| {
-                        if ui
-                            .button("Attachment filters not implemented yet")
-                            .clicked()
-                        {
+                        ui.set_min_width(80.0);
+
+                        let all_label = if active_extension.is_none() {
+                            format!("{} All", egui_phosphor::regular::CHECK)
+                        } else {
+                            "  All".to_string()
+                        };
+                        if ui.button(all_label).clicked() {
+                            filter_change = Some(FilterChange::Clear);
                             ui.close();
                         }
+
+                        if !attachments.extensions().is_empty() {
+                            ui.separator();
+                        }
+
+                        for extension in attachments.extensions() {
+                            let is_active = active_extension.as_deref() == Some(extension.as_str());
+                            let label = if is_active {
+                                format!("{} *.{extension}", egui_phosphor::regular::CHECK)
+                            } else {
+                                format!("  *.{extension}")
+                            };
+
+                            if ui.button(label).clicked() {
+                                if !is_active {
+                                    filter_change = Some(FilterChange::Set(extension.clone()));
+                                }
+                                ui.close();
+                            }
+                        }
                     },
-                )
+                );
+
+                if let Some(extension) = active_extension.as_deref() {
+                    let dot_center = response.response.rect.right_top() + egui::vec2(-0.5, 0.5);
+                    ui.painter().circle_filled(
+                        dot_center,
+                        3.5,
+                        colors::main_accent_stroke(ui.visuals().dark_mode),
+                    );
+                    let filtered_count = filtered_count.unwrap_or(attachments_count);
+                    response.response.on_hover_text(format!(
+                        "Filtered by *.{extension}: {filtered_count} of {attachments_count}"
+                    ));
+                }
             },
         );
+
+        match filter_change {
+            Some(FilterChange::Set(extension)) => {
+                attachments.set_extension_filter(extension);
+                // Narrowing/changing the visible set drops hidden selections and the shift anchor.
+                self.selected_rows.clear();
+                self.previously_clicked_row = None;
+            }
+            // Clearing expands the visible set, so existing selections remain valid.
+            Some(FilterChange::Clear) => attachments.clear_filter(),
+            None => {}
+        }
+
         ui.add_space(ui.spacing().item_spacing.y);
     }
 
@@ -131,6 +201,10 @@ impl AttachmentsUi {
         ui: &mut egui::Ui,
     ) {
         let attachments_count = shared.attachments.attachments().len();
+        let visible_count = shared
+            .attachments
+            .active_filter()
+            .map_or(attachments_count, |filter| filter.indices().len());
         let row_height = 2.0 * ui.text_style_height(&egui::TextStyle::Body) + ROW_VERTICAL_PADDING;
 
         Label::new(
@@ -147,16 +221,30 @@ impl AttachmentsUi {
             return;
         }
 
+        if visible_count == 0 {
+            ui.label(RichText::new("No attachments match the active filter").weak());
+            return;
+        }
+
         ui.scope(|ui| {
             ui.spacing_mut().item_spacing.y = 0.0;
             egui::ScrollArea::vertical().show_rows(
                 ui,
                 row_height,
-                attachments_count,
+                visible_count,
                 |ui, row_range| {
-                    for current_row in row_range {
-                        let is_selected = self.selected_rows.contains(&current_row);
-                        let Some(attachment) = shared.attachments.attachments().get(current_row)
+                    for visible_row in row_range {
+                        // show_rows emits visible row numbers. Filtered rows map back to the
+                        // full attachments list because selection and save actions use that index.
+                        let attachment_idx = match shared.attachments.active_filter() {
+                            Some(filter) => match filter.indices().get(visible_row).copied() {
+                                Some(index) => index,
+                                None => continue,
+                            },
+                            None => visible_row,
+                        };
+                        let is_selected = self.selected_rows.contains(&attachment_idx);
+                        let Some(attachment) = shared.attachments.attachments().get(attachment_idx)
                         else {
                             continue;
                         };
@@ -176,11 +264,18 @@ impl AttachmentsUi {
                         );
 
                         if response.clicked() {
-                            self.handle_row_click(current_row, ui.input(|i| i.modifiers));
+                            self.handle_row_click(
+                                attachment_idx,
+                                shared
+                                    .attachments
+                                    .active_filter()
+                                    .map(|filter| filter.indices()),
+                                ui.input(|i| i.modifiers),
+                            );
                         }
 
                         response.context_menu(|ui| {
-                            self.render_context_menu(current_row, shared, ui_actions, ui);
+                            self.render_context_menu(attachment_idx, shared, ui_actions, ui);
                         });
                     }
                 },
@@ -261,11 +356,20 @@ impl AttachmentsUi {
         // ** Attachments Selection **
         if ui.button("Select all").clicked() {
             self.selected_rows.clear();
-            self.selected_rows.extend(0..attachment_count);
+            if let Some(filter) = shared.attachments.active_filter() {
+                self.selected_rows.extend(filter.indices().iter().copied());
+            } else {
+                self.selected_rows.extend(0..attachment_count);
+            }
             ui.close();
         }
         if ui.button("Invert selection").clicked() {
-            let all_rows: FxHashSet<usize> = (0..attachment_count).collect();
+            let all_rows: FxHashSet<usize> =
+                if let Some(filter) = shared.attachments.active_filter() {
+                    filter.indices().iter().copied().collect()
+                } else {
+                    (0..attachment_count).collect()
+                };
             self.selected_rows = all_rows.difference(&self.selected_rows).copied().collect();
             ui.close();
         }
@@ -414,37 +518,82 @@ impl AttachmentsUi {
         }
     }
 
-    fn handle_row_click(&mut self, clicked_row: usize, modifiers: egui::Modifiers) {
+    fn handle_row_click(
+        &mut self,
+        clicked_attachment_idx: usize,
+        filtered_indices: Option<&[usize]>,
+        modifiers: egui::Modifiers,
+    ) {
         if modifiers.matches_exact(Modifiers::CTRL) {
-            if self.selected_rows.contains(&clicked_row) {
-                self.selected_rows.remove(&clicked_row);
+            if self.selected_rows.contains(&clicked_attachment_idx) {
+                self.selected_rows.remove(&clicked_attachment_idx);
             } else {
-                self.selected_rows.insert(clicked_row);
+                self.selected_rows.insert(clicked_attachment_idx);
             }
         }
 
         if modifiers.matches_exact(Modifiers::SHIFT)
             && let Some(previously_clicked_row) = self.previously_clicked_row
         {
-            let shift_range = match previously_clicked_row.cmp(&clicked_row) {
-                Ordering::Less => previously_clicked_row..=clicked_row,
-                Ordering::Greater => clicked_row..=previously_clicked_row,
-                Ordering::Equal => clicked_row..=clicked_row,
-            };
-
-            for row in shift_range {
-                self.selected_rows.insert(row);
-            }
+            self.select_shift_range(
+                previously_clicked_row,
+                clicked_attachment_idx,
+                filtered_indices,
+            );
         }
 
         if modifiers.matches_exact(Modifiers::NONE) {
-            if self.selected_rows.len() == 1 && self.selected_rows.contains(&clicked_row) {
+            if self.selected_rows.len() == 1 && self.selected_rows.contains(&clicked_attachment_idx)
+            {
                 self.selected_rows.clear();
             } else {
                 self.selected_rows.clear();
-                self.selected_rows.insert(clicked_row);
+                self.selected_rows.insert(clicked_attachment_idx);
             }
         }
-        self.previously_clicked_row = Some(clicked_row);
+        self.previously_clicked_row = Some(clicked_attachment_idx);
+    }
+
+    fn select_shift_range(
+        &mut self,
+        previous_attachment_idx: usize,
+        clicked_attachment_idx: usize,
+        filtered_indices: Option<&[usize]>,
+    ) {
+        // Without a filter, visible row indices and attachment indices are identical.
+        let Some(filtered_indices) = filtered_indices else {
+            let shift_range = match previous_attachment_idx.cmp(&clicked_attachment_idx) {
+                Ordering::Less => previous_attachment_idx..=clicked_attachment_idx,
+                Ordering::Greater => clicked_attachment_idx..=previous_attachment_idx,
+                Ordering::Equal => clicked_attachment_idx..=clicked_attachment_idx,
+            };
+
+            self.selected_rows.extend(shift_range);
+            return;
+        };
+
+        // With a filter, shift selection must use visible positions to avoid selecting hidden rows.
+        let Some(previous_visible_idx) = filtered_indices
+            .iter()
+            .position(|&index| index == previous_attachment_idx)
+        else {
+            return;
+        };
+        let Some(clicked_visible_idx) = filtered_indices
+            .iter()
+            .position(|&index| index == clicked_attachment_idx)
+        else {
+            return;
+        };
+
+        let visible_range = match previous_visible_idx.cmp(&clicked_visible_idx) {
+            Ordering::Less => previous_visible_idx..=clicked_visible_idx,
+            Ordering::Greater => clicked_visible_idx..=previous_visible_idx,
+            Ordering::Equal => clicked_visible_idx..=clicked_visible_idx,
+        };
+
+        // Store selected rows as attachment indices so save/context actions stay filter-agnostic.
+        self.selected_rows
+            .extend(visible_range.map(|visible_idx| filtered_indices[visible_idx]));
     }
 }

--- a/application/apps/indexer/gui/application/src/session/ui/side_panel/attachments.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/side_panel/attachments.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use log::error;
 use rustc_hash::FxHashSet;
 
-use egui::{Modifiers, RichText, Ui};
+use egui::{Frame, Label, Layout, Modifiers, RichText, Ui, UiBuilder, Widget, vec2};
 use stypes::AttachmentInfo;
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -12,22 +12,25 @@ use uuid::Uuid;
 use crate::{
     host::{
         command::{CopyFileInfo, HostCommand},
-        common::{colors::DEFAULT_ATTACHMENT_EXT_COLOR, file_utls},
+        common::{colors::DEFAULT_ATTACHMENT_EXT_COLOR, file_utls, ui_utls::show_side_panel_group},
         ui::{UiActions, actions::FileDialogOptions},
     },
     session::{
         command::SessionCommand,
-        ui::shared::{AttachmentsState, SessionShared},
+        ui::{
+            shared::{AttachmentsState, SessionShared},
+            side_panel::TITLE_SIZE,
+        },
     },
 };
 const ATTACHMENTS_DIALOG_ID_SAVE_SELECTED: &str = "save_selected_attachments";
 const ATTACHMENTS_DIALOG_ID_SAVE_AS: &str = "save_attachment_as";
 
-const ATTACHMENTS_LIST_MINIMUM_HEIGHT: f32 = 200.0;
-const ATTACHMENTS_PREVIEW_MINIMUM_HEIGHT: f32 = 100.0;
 const EXT_COLUMN_WIDTH: f32 = 40.0;
 const ROW_VERTICAL_PADDING: f32 = 8.0;
 const ROW_HORIZONTAL_PADDING: f32 = 12.0;
+
+const SUBTITLE_SIZE: f32 = TITLE_SIZE - 1.0;
 
 #[derive(Debug)]
 pub struct AttachmentsUi {
@@ -69,40 +72,36 @@ impl AttachmentsUi {
 
         let attachments = shared.attachments.attachments();
 
-        egui::Panel::top("attachments_header")
-            .resizable(false)
-            .show_inside(ui, |ui| {
-                self.render_attachments_header(ui, attachments.len());
-            });
+        self.render_attachments_header(ui, attachments.len());
 
         // Details panel located at the bottom but needs to be rendered before the attachments list.
         if self.selected_rows.len() == 1 {
             egui::Panel::bottom("attachments_details")
-                .resizable(true)
-                .default_size(200.0)
-                .size_range(
-                    ATTACHMENTS_PREVIEW_MINIMUM_HEIGHT
-                        ..=(ui.available_height() - ATTACHMENTS_LIST_MINIMUM_HEIGHT),
-                )
+                .frame(Frame::NONE)
+                .resizable(false)
+                .show_separator_line(false)
+                .exact_size(200.0)
                 .show_inside(ui, |ui| {
-                    egui::ScrollArea::vertical()
-                        .auto_shrink(false)
-                        .show(ui, |ui| {
-                            self.render_attachment_preview(ui);
-                        });
+                    show_side_panel_group(ui, |ui| self.render_attachment_preview(ui));
                 });
         }
 
-        // NOTE: CentralPanel should be added last as per egui documentation.
-        egui::CentralPanel::default().show_inside(ui, |ui| {
-            self.render_attachments_list(&shared.attachments, ui_actions, ui);
-        });
+        egui::CentralPanel::default()
+            .frame(Frame::NONE)
+            .show_inside(ui, |ui| {
+                show_side_panel_group(ui, |ui| {
+                    self.render_attachments_list(&shared.attachments, ui_actions, ui)
+                });
+            });
     }
 
     fn render_attachments_header(&self, ui: &mut egui::Ui, attachments_count: usize) {
         egui::Sides::new().show(
             ui,
-            |ui| ui.label(format!("Attachments ({})", attachments_count)),
+            |ui| {
+                let title = format!("Attachments ({})", attachments_count);
+                Label::new(RichText::new(title).heading().size(TITLE_SIZE)).ui(ui);
+            },
             |ui| {
                 ui.menu_button(
                     egui::RichText::new(egui_phosphor::regular::FUNNEL).size(16.0),
@@ -122,12 +121,11 @@ impl AttachmentsUi {
 
     // TODO [TOOL-741]: Implement attachments preview.
     fn render_attachment_preview(&self, ui: &mut egui::Ui) {
-        egui::ScrollArea::vertical().show(ui, |ui| {
-            ui.add_space(ui.spacing().item_spacing.y);
-            ui.label("Preview");
-            ui.centered_and_justified(|ui| {
-                ui.label(RichText::new("Attachment preview not implemented yet."));
-            });
+        Label::new(RichText::new("Preview").heading().size(SUBTITLE_SIZE))
+            .truncate()
+            .ui(ui);
+        ui.centered_and_justified(|ui| {
+            ui.label(RichText::new("Attachment preview not implemented yet."));
         });
     }
 
@@ -138,71 +136,64 @@ impl AttachmentsUi {
         ui: &mut egui::Ui,
     ) {
         let attachments = attachments_state.attachments();
-        ui.spacing_mut().item_spacing.y = 0.0;
-        let row_height = 2.0 * ui.text_style_height(&egui::TextStyle::Body)
-            + ui.spacing().item_spacing.y
-            + ROW_VERTICAL_PADDING;
+        let row_height = 2.0 * ui.text_style_height(&egui::TextStyle::Body) + ROW_VERTICAL_PADDING;
 
-        egui::Frame::default()
-            .fill(ui.visuals().widgets.inactive.bg_fill)
-            .corner_radius(6.0)
-            .show(ui, |ui| {
-                ui.add_space(row_height / 2.0);
-                ui.horizontal(|ui| {
-                    ui.add_space(ROW_HORIZONTAL_PADDING);
-                    ui.label(
-                        egui::RichText::new("Received attachments")
-                            .size(12.0)
-                            .strong(),
-                    );
-                });
-                ui.add_space(row_height / 2.0);
+        Label::new(
+            RichText::new("Received Attachments")
+                .heading()
+                .size(SUBTITLE_SIZE),
+        )
+        .truncate()
+        .ui(ui);
+        ui.add_space(5.0);
 
-                egui::ScrollArea::vertical().show_rows(
-                    ui,
-                    row_height,
-                    attachments.len(),
-                    |ui, row_range| {
-                        for current_row in row_range {
-                            let is_selected = self.selected_rows.contains(&current_row);
-                            let attachment = &attachments[current_row];
+        if attachments.is_empty() {
+            ui.label(RichText::new("No attachments").weak());
+            return;
+        }
 
-                            let extension_color = attachment
-                                .ext
-                                .as_deref()
-                                .and_then(|ext| attachments_state.color_by_extension(ext))
-                                .unwrap_or(DEFAULT_ATTACHMENT_EXT_COLOR);
+        ui.scope(|ui| {
+            ui.spacing_mut().item_spacing.y = 0.0;
+            egui::ScrollArea::vertical().show_rows(
+                ui,
+                row_height,
+                attachments.len(),
+                |ui, row_range| {
+                    for current_row in row_range {
+                        let is_selected = self.selected_rows.contains(&current_row);
+                        let attachment = &attachments[current_row];
 
-                            let response = self.render_attachment_row(
-                                ui,
-                                attachment,
-                                extension_color,
-                                row_height,
-                                is_selected,
-                            );
+                        let extension_color = attachment
+                            .ext
+                            .as_deref()
+                            .and_then(|ext| attachments_state.color_by_extension(ext))
+                            .unwrap_or(DEFAULT_ATTACHMENT_EXT_COLOR);
 
-                            if response.clicked() {
-                                self.clicked_row = Some(current_row);
-                                self.handle_row_click(current_row, ui.input(|i| i.modifiers));
-                            }
+                        let response = self.render_attachment_row(
+                            ui,
+                            attachment,
+                            extension_color,
+                            row_height,
+                            is_selected,
+                        );
 
-                            // TODO [TOOL-756]: Reevaluate secondary click logic
-                            if response.secondary_clicked() {
-                                self.clicked_row = Some(current_row);
-                            }
-
-                            response.context_menu(|ui| {
-                                self.render_attachments_list_context_menu(
-                                    ui,
-                                    ui_actions,
-                                    attachments,
-                                );
-                            });
+                        if response.clicked() {
+                            self.clicked_row = Some(current_row);
+                            self.handle_row_click(current_row, ui.input(|i| i.modifiers));
                         }
-                        ui.add_space(row_height / 2.0);
-                    },
-                );
-            });
+
+                        // TODO [TOOL-756]: Reevaluate secondary click logic
+                        if response.secondary_clicked() {
+                            self.clicked_row = Some(current_row);
+                        }
+
+                        response.context_menu(|ui| {
+                            self.render_attachments_list_context_menu(ui, ui_actions, attachments);
+                        });
+                    }
+                },
+            );
+        });
     }
 
     fn render_attachment_row(
@@ -219,55 +210,42 @@ impl AttachmentsUi {
         );
 
         let row_background_color = match (is_selected, response.hovered()) {
-            (true, true) => ui.visuals().selection.bg_fill.gamma_multiply(0.6),
+            (true, true) => ui.visuals().selection.bg_fill.gamma_multiply(0.85),
             (true, false) => ui.visuals().selection.bg_fill,
             (false, true) => ui.visuals().widgets.hovered.bg_fill,
-            (false, false) => ui.visuals().widgets.inactive.bg_fill,
+            (false, false) => egui::Color32::TRANSPARENT,
         };
-        ui.painter()
-            .rect_filled(row_rectangle, 0, row_background_color);
-
-        if is_selected {
-            ui.painter().rect_filled(
-                egui::Rect::from_min_size(
-                    row_rectangle.min,
-                    egui::vec2(4.0, row_rectangle.height()),
-                ),
-                egui::CornerRadius::same(0),
-                ui.visuals().selection.stroke.color,
-            );
+        if row_background_color != egui::Color32::TRANSPARENT {
+            ui.painter()
+                .rect_filled(row_rectangle, 4.0, row_background_color);
         }
 
+        ui.painter().rect_filled(
+            egui::Rect::from_min_size(row_rectangle.min, egui::vec2(4.0, row_rectangle.height())),
+            0.0,
+            extension_color,
+        );
+
+        let formatted_size = file_utls::format_file_size(attachment.size as u64);
         ui.scope_builder(
-            egui::UiBuilder::new()
+            UiBuilder::new()
                 .max_rect(row_rectangle)
-                .layout(egui::Layout::left_to_right(egui::Align::LEFT)),
+                .layout(Layout::left_to_right(egui::Align::LEFT)),
             |ui| {
-                // Extra padding from the left
                 ui.add_space(ROW_HORIZONTAL_PADDING);
 
                 ui.add_sized(
-                    egui::vec2(EXT_COLUMN_WIDTH, row_height),
-                    egui::Label::new(
-                        egui::RichText::new(
-                            attachment.ext.as_deref().unwrap_or("—").to_uppercase(),
-                        )
-                        .strong()
-                        .color(extension_color),
+                    vec2(EXT_COLUMN_WIDTH, row_height),
+                    Label::new(
+                        RichText::new(attachment.ext.as_deref().unwrap_or("—").to_uppercase())
+                            .strong()
+                            .color(extension_color),
                     ),
                 );
                 ui.vertical(|ui| {
                     ui.add_space(ROW_VERTICAL_PADDING / 2.0);
-                    ui.add(egui::Label::new(&attachment.name).truncate());
-                    ui.add(
-                        egui::Label::new(
-                            egui::RichText::new(file_utls::format_file_size(
-                                attachment.size as u64,
-                            ))
-                            .weak(),
-                        )
-                        .truncate(),
-                    );
+                    ui.add(Label::new(RichText::new(&attachment.name)).truncate());
+                    ui.add(Label::new(RichText::new(formatted_size).weak()).truncate());
                 });
             },
         );

--- a/application/apps/indexer/gui/application/src/session/ui/side_panel/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/side_panel/mod.rs
@@ -25,6 +25,8 @@ use observing::ObservingUi;
 
 pub use types::*;
 
+const TITLE_SIZE: f32 = 16.0;
+
 #[derive(Debug)]
 pub struct SidePanelUi {
     observing: ObservingUi,

--- a/application/apps/indexer/gui/application/src/session/ui/side_panel/observing/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/side_panel/observing/mod.rs
@@ -11,7 +11,10 @@ use crate::{
     session::{
         command::SessionCommand,
         types::ObserveOperation,
-        ui::shared::{ObserveState, SessionShared},
+        ui::{
+            shared::{ObserveState, SessionShared},
+            side_panel::TITLE_SIZE,
+        },
     },
 };
 
@@ -27,7 +30,6 @@ mod serial;
 mod tcp;
 mod udp;
 
-const TITLE_SIZE: f32 = 16.0;
 const SPACE_BETWEEN_GROUPS: f32 = 5.0;
 
 #[derive(Debug)]


### PR DESCRIPTION
This PR includes:

- Added attachment filtering by file extension.
- Added support to jump to and select logs related to an attachment.
- Polished the attachments view UI to align with the styling of other side tabs.
- Refactored attachment and log selection handling for simpler state management.
