### PR TITLE
Native: Support for Drag and Drop Files & Dirs

### DIFF
--- a/application/apps/indexer/gui/application/src/host/ui/dnd_paths.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/dnd_paths.rs
@@ -1,0 +1,87 @@
+//! Host-level OS path drag-and-drop handling for files and directories.
+
+use std::fmt::Write as _;
+
+use egui::{Align2, Id, LayerId, Order, TextStyle, Ui};
+use stypes::FileFormat;
+use tokio::sync::mpsc::Sender;
+
+use crate::host::{command::HostCommand, ui::UiActions};
+
+/// Previews hovered OS paths and opens dropped files or text-file directories through the normal host flow.
+pub fn handle_path_drops(ui: &mut Ui, actions: &mut UiActions, cmd_tx: &Sender<HostCommand>) {
+    preview_files_being_dropped(ui);
+    handle_dropping_files(ui, actions, cmd_tx);
+}
+
+/// Consumes dropped paths and forwards files and directories to matching host open commands.
+fn handle_dropping_files(ui: &mut Ui, actions: &mut UiActions, cmd_tx: &Sender<HostCommand>) {
+    if ui.input(|input| input.raw.dropped_files.is_empty()) {
+        return;
+    }
+
+    let mut files = Vec::new();
+    let mut dirs = Vec::new();
+
+    for path in ui
+        .input_mut(|input| std::mem::take(&mut input.raw.dropped_files))
+        .into_iter()
+        .filter_map(|file| file.path)
+    {
+        if path.is_dir() {
+            dirs.push(path);
+        } else {
+            files.push(path);
+        }
+    }
+
+    if !files.is_empty() {
+        actions.try_send_command(cmd_tx, HostCommand::OpenFiles(files));
+    }
+
+    for dir_path in dirs {
+        // Check for text files when directories are dropped as reasonable default.
+        actions.try_send_command(
+            cmd_tx,
+            HostCommand::OpenFromDirectory {
+                dir_path,
+                target_format: FileFormat::Text,
+            },
+        );
+    }
+}
+
+/// Paints a full-window preview while OS paths hover over the app.
+fn preview_files_being_dropped(ui: &mut Ui) {
+    if ui.input(|input| input.raw.hovered_files.is_empty()) {
+        return;
+    }
+
+    let mut text = "Drop to open:".to_owned();
+    ui.input(|input| {
+        for file in &input.raw.hovered_files {
+            if let Some(path) = &file.path {
+                write!(text, "\n{}", path.display()).ok();
+            } else if !file.mime.is_empty() {
+                write!(text, "\n{}", file.mime).ok();
+            }
+        }
+    });
+
+    let painter = ui.layer_painter(LayerId::new(Order::Foreground, Id::new("file_drop_target")));
+    let screen_rect = ui.content_rect();
+    let style = ui.global_style();
+
+    painter.rect_filled(
+        screen_rect,
+        0.0,
+        style.visuals.extreme_bg_color.gamma_multiply_u8(192),
+    );
+    painter.text(
+        screen_rect.center(),
+        Align2::CENTER_CENTER,
+        text,
+        TextStyle::Body.resolve(&style),
+        style.visuals.strong_text_color(),
+    );
+}

--- a/application/apps/indexer/gui/application/src/host/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/mod.rs
@@ -39,6 +39,7 @@ use state::HostState;
 pub use actions::{HostAction, UiActions};
 
 pub mod actions;
+mod dnd_paths;
 pub mod home;
 mod info;
 mod menu;
@@ -470,6 +471,9 @@ impl eframe::App for Host {
 
     fn ui(&mut self, ui: &mut Ui, frame: &mut eframe::Frame) {
         self.render_ui(ui, frame);
+
+        dnd_paths::handle_path_drops(ui, &mut self.ui_actions, &self.senders.cmd_tx);
+
         self.handle_ui_actions(ui.ctx());
     }
 


### PR DESCRIPTION
This PR add support for drag and drop for files.

It's not working one Wayland because it's still not supported on `winit` crate.

@itsmesamster Could you please test it on mac & windows before merging it