### PR TITLE
Native: Render ANSI colors in log tables + Details View

### DIFF
--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -53,6 +53,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 thiserror = "2.0"
 lazy_static = "1.5"
+memchr = "2.7"
 tokio = { version = "1", features = ["full"] }
 reqwest = "0.12"
 semver = "1"
@@ -82,6 +83,7 @@ serialport = "4.8"
 rustc-hash = "2.1"
 enum-iterator = "2"
 nucleo-matcher = "0.3"
+anstyle-parse = "1.0"
 
 clap = { version = "4", features = ["derive"] }
 

--- a/application/apps/indexer/gui/application/Cargo.toml
+++ b/application/apps/indexer/gui/application/Cargo.toml
@@ -31,6 +31,7 @@ clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 log.workspace = true
+memchr.workspace = true
 tokio.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 semver.workspace = true
@@ -48,6 +49,7 @@ regex-syntax.workspace = true
 enum-iterator.workspace = true
 blake3.workspace = true
 nucleo-matcher.workspace = true
+anstyle-parse.workspace = true
 
 #TODO: Replace env logger with log4rs
 env_logger.workspace = true

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/details/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/details/mod.rs
@@ -1,18 +1,41 @@
 use egui::{Frame, Label, Margin, RichText, Ui, Widget};
-
+use memchr::memchr;
 use stypes::GrabbedElement;
 
-use crate::session::ui::shared::SessionShared;
+use crate::session::ui::{
+    common::{
+        ansi_text::{AnsiText, parse_ansi_text},
+        log_table::text::ansi_layout_job,
+    },
+    shared::SessionShared,
+};
 
 #[derive(Debug, Default)]
 pub struct DetailsUI {
-    loaded_log: Option<GrabbedElement>,
+    loaded_log: Option<LoadedDetailsLog>,
+}
+
+#[derive(Debug)]
+struct LoadedDetailsLog {
+    element: GrabbedElement,
+    /// ANSI parse cache for grabbed element content.
+    ansi_text: Option<AnsiText>,
+}
+
+impl LoadedDetailsLog {
+    fn new(element: GrabbedElement) -> Self {
+        let ansi_text = memchr(0x1b, element.content.as_bytes())
+            .is_some()
+            .then(|| parse_ansi_text(&element.content));
+
+        Self { element, ansi_text }
+    }
 }
 
 impl DetailsUI {
     pub fn handle_selected_log(&mut self, selected_row: Option<u64>, log: GrabbedElement) {
         if selected_row.is_some_and(|row| row == log.pos as u64) {
-            self.loaded_log = Some(log);
+            self.loaded_log = Some(LoadedDetailsLog::new(log));
         }
     }
 
@@ -29,7 +52,7 @@ impl DetailsUI {
             let Some(log) = self
                 .loaded_log
                 .as_ref()
-                .filter(|log| log.pos == selected_row as usize)
+                .filter(|log| log.element.pos == selected_row as usize)
             else {
                 ui.add_space(10.);
                 Label::new("Loading...").selectable(true).ui(ui);
@@ -38,14 +61,22 @@ impl DetailsUI {
 
             ui.add_space(10.);
 
-            Label::new(format!("Row #: {}", log.pos))
+            Label::new(format!("Row #: {}", log.element.pos))
                 .selectable(true)
                 .ui(ui);
 
             ui.add_space(10.);
 
-            let content = RichText::new(&log.content).monospace().strong();
-            Label::new(content).selectable(true).ui(ui);
+            match &log.ansi_text {
+                Some(ansi_text) => {
+                    let content = ansi_layout_job(ui, ansi_text, ui.visuals().strong_text_color());
+                    Label::new(content).selectable(true).ui(ui);
+                }
+                None => {
+                    let content = RichText::new(&log.element.content).monospace().strong();
+                    Label::new(content).selectable(true).ui(ui);
+                }
+            }
         });
     }
 }
@@ -71,7 +102,10 @@ mod tests {
 
         details.handle_selected_log(Some(4), log(4));
 
-        assert_eq!(details.loaded_log.as_ref().map(|log| log.pos), Some(4));
+        assert_eq!(
+            details.loaded_log.as_ref().map(|log| log.element.pos),
+            Some(4)
+        );
     }
 
     #[test]
@@ -82,6 +116,9 @@ mod tests {
         details.handle_selected_log(Some(7), log(4));
         details.handle_selected_log(None, log(9));
 
-        assert_eq!(details.loaded_log.as_ref().map(|log| log.pos), Some(4));
+        assert_eq!(
+            details.loaded_log.as_ref().map(|log| log.element.pos),
+            Some(4)
+        );
     }
 }

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_table.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_table.rs
@@ -13,10 +13,10 @@ use crate::{
         ui::{
             common::{
                 self,
-                logs_mapped::LogsMapped,
-                logs_tables::{
+                log_table::table::{
                     apply_columns_to_table_state, grab_cmd_consts, should_stick_to_bottom,
                 },
+                logs_mapped::LogsMapped,
             },
             definitions::{LogTableItem, schema::LogSchema},
             logs_table::LogAttachmentInfo,
@@ -152,7 +152,7 @@ impl<'a> LogsDelegate<'a> {
     }
 
     fn select_row(&mut self, pos: u64, modifiers: egui::Modifiers) {
-        let Some(selected_row) = common::logs_tables::apply_selection_click(
+        let Some(selected_row) = common::log_table::table::apply_selection_click(
             self.shared,
             self.actions,
             &self.table.cmd_tx,
@@ -214,7 +214,7 @@ impl<'a> LogsDelegate<'a> {
                 }
             });
 
-        let response = common::logs_tables::render_row_header(
+        let response = common::log_table::table::render_row_header(
             ui,
             text,
             color_idx,
@@ -237,7 +237,7 @@ impl<'a> LogsDelegate<'a> {
     fn render_log_cell(&mut self, ui: &mut Ui, cell: &CellInfo) {
         let mut source_changed = false;
 
-        common::logs_tables::get_cell_frame().show(ui, |ui| {
+        common::log_table::table::get_cell_frame().show(ui, |ui| {
             let log_item = match self.get_log_item(cell) {
                 Some(log) => log,
                 None => {
@@ -264,7 +264,7 @@ impl<'a> LogsDelegate<'a> {
                 .and_then(|rng| log_item.element.content.get(rng.to_owned()))
                 .unwrap_or_default();
 
-            let response = match common::logs_tables::highlighted_cell_layout_job(
+            let response = match common::log_table::text::log_cell_layout_job(
                 ui,
                 content,
                 log_item.element.pos as u64,
@@ -281,7 +281,7 @@ impl<'a> LogsDelegate<'a> {
         });
 
         if source_changed {
-            common::logs_tables::render_upper_bound(ui);
+            common::log_table::table::render_upper_bound(ui);
         }
     }
 }
@@ -345,7 +345,7 @@ impl TableDelegate for LogsDelegate<'_> {
                         .append(combined, self.has_multi_sources);
                 }
                 Err(error) => {
-                    common::logs_tables::handle_grab_errors(
+                    common::log_table::table::handle_grab_errors(
                         error,
                         self.shared.get_id(),
                         self.actions,
@@ -370,7 +370,7 @@ impl TableDelegate for LogsDelegate<'_> {
 
         let is_selected = self.is_row_selected(log_item);
         let main_log_pos = log_item.map(|item| item.element.pos as u64);
-        common::logs_tables::apply_log_row_colors(ui, self.shared, main_log_pos, is_selected);
+        common::log_table::table::apply_log_row_colors(ui, self.shared, main_log_pos, is_selected);
 
         if ui.response().interact(Sense::click()).clicked()
             && let Some(log_item) = log_item

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_table.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_table.rs
@@ -13,8 +13,11 @@ use crate::{
         ui::{
             common::{
                 self,
-                log_table::table::{
-                    apply_columns_to_table_state, grab_cmd_consts, should_stick_to_bottom,
+                log_table::{
+                    table::{
+                        apply_columns_to_table_state, grab_cmd_consts, should_stick_to_bottom,
+                    },
+                    text::render_log_cell_text,
                 },
                 logs_mapped::LogsMapped,
             },
@@ -258,22 +261,8 @@ impl<'a> LogsDelegate<'a> {
                     .source_change_positions()
                     .contains(&log_item.element.pos);
 
-            let content = log_item
-                .column_ranges
-                .get(cell.col_nr.saturating_sub(1))
-                .and_then(|rng| log_item.element.content.get(rng.to_owned()))
-                .unwrap_or_default();
-
-            let response = match common::log_table::text::log_cell_layout_job(
-                ui,
-                content,
-                log_item.element.pos as u64,
-                self.shared,
-                self.shared.search.compiled_filters(),
-            ) {
-                Some(job) => ui.label(job),
-                None => ui.monospace(content),
-            };
+            let col_idx = cell.col_nr.saturating_sub(1);
+            let response = render_log_cell_text(ui, log_item, col_idx, self.shared);
 
             if response.clicked() {
                 self.handle_selection_click(log_item.element.pos as u64, ui.input(|i| i.modifiers));

--- a/application/apps/indexer/gui/application/src/session/ui/common/ansi_text.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/common/ansi_text.rs
@@ -1,0 +1,435 @@
+//! ANSI SGR parsing for log-cell rendering.
+//!
+//! This module strips ANSI escape/control sequences from log text and records
+//! the visible byte ranges where foreground or background colors should apply.
+//! It intentionally implements only color-oriented SGR codes, not full terminal
+//! emulation such as cursor movement, screen clearing, or alternate buffers.
+//! In common notation `ESC[` starts a CSI sequence, and `m` ends an SGR
+//! sequence such as `ESC[31m` for red foreground.
+
+use std::ops::Range;
+
+use anstyle_parse::{DefaultCharAccumulator, Params, Parser, Perform};
+use egui::Color32;
+
+/// Text with ANSI escapes removed and color spans resolved over the visible text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnsiText {
+    /// Visible text after ANSI escape/control sequences are removed.
+    pub text: String,
+    /// Styled byte ranges into `text`.
+    pub spans: Vec<AnsiSpan>,
+}
+
+/// One colored range in [`AnsiText::text`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnsiSpan {
+    /// Byte range in the stripped visible text.
+    pub range: Range<usize>,
+    /// Colors active for the range.
+    pub style: AnsiStyle,
+}
+
+/// ANSI foreground/background colors active for a span.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AnsiStyle {
+    /// ANSI foreground color, if one is active.
+    pub fg: Option<Color32>,
+    /// ANSI background color, if one is active.
+    pub bg: Option<Color32>,
+}
+
+impl AnsiStyle {
+    /// Returns whether this style would affect rendering.
+    fn has_style(&self) -> bool {
+        self.fg.is_some() || self.bg.is_some()
+    }
+}
+
+/// Parses `content` into visible text and ANSI color spans.
+///
+/// Unsupported SGR codes are ignored and malformed escape sequences are stripped
+/// without producing a style. Returned ranges always refer to the stripped text.
+pub fn parse_ansi_text(content: &str) -> AnsiText {
+    // The parser is stateful, so keep it scoped to one cell to avoid leaking an
+    // unfinished escape sequence into the next log cell.
+    let mut parser = Parser::<DefaultCharAccumulator>::new();
+    let mut performer = AnsiPerformer::new(content.len());
+
+    // ANSI parsing is byte-oriented; UTF-8 text is reconstructed by anstyle-parse.
+    for byte in content.bytes() {
+        parser.advance(&mut performer, byte);
+    }
+
+    performer.finish()
+}
+
+/// Receives parser events and translates SGR state into visible text spans.
+struct AnsiPerformer {
+    /// Output accumulated from parser print/execute events.
+    text: String,
+    /// Completed styled ranges in `text`.
+    spans: Vec<AnsiSpan>,
+    /// Current SGR color state.
+    style: AnsiStyle,
+    /// Start of the currently open styled range in `text`, if any.
+    span_start: Option<usize>,
+}
+
+impl AnsiPerformer {
+    /// Creates a performer with enough initial text capacity for common stripped output.
+    fn new(capacity: usize) -> Self {
+        Self {
+            text: String::with_capacity(capacity),
+            spans: Vec::new(),
+            style: AnsiStyle::default(),
+            span_start: None,
+        }
+    }
+
+    /// Closes any active span and returns the parser output.
+    fn finish(mut self) -> AnsiText {
+        self.close_span();
+
+        AnsiText {
+            text: self.text,
+            spans: self.spans,
+        }
+    }
+
+    /// Appends one visible character and opens a span if a style is active.
+    fn push_char(&mut self, c: char) {
+        // Style spans are tracked in visible-text byte offsets, not raw input bytes.
+        if self.style.has_style() && self.span_start.is_none() {
+            self.span_start = Some(self.text.len());
+        }
+
+        self.text.push(c);
+    }
+
+    /// Changes the active style, closing the previous visible range first.
+    fn set_style(&mut self, style: AnsiStyle) {
+        if self.style == style {
+            return;
+        }
+
+        self.close_span();
+        self.style = style;
+        if self.style.has_style() {
+            self.span_start = Some(self.text.len());
+        }
+    }
+
+    /// Finalizes the current styled range, if it contains visible text.
+    fn close_span(&mut self) {
+        let Some(start) = self.span_start.take() else {
+            return;
+        };
+        let end = self.text.len();
+        if start == end {
+            return;
+        }
+
+        let span = AnsiSpan {
+            range: start..end,
+            style: self.style.clone(),
+        };
+
+        // Consecutive SGR sequences can reopen the same style; keep output spans compact.
+        if let Some(last) = self.spans.last_mut()
+            && last.range.end == span.range.start
+            && last.style == span.style
+        {
+            last.range.end = span.range.end;
+            return;
+        }
+
+        self.spans.push(span);
+    }
+
+    /// Applies one SGR parameter list to the current color state.
+    fn apply_sgr(&mut self, params: &Params) {
+        if params.into_iter().any(|param| param.len() != 1) {
+            // Colon-separated SGR forms are intentionally unsupported for now.
+            return;
+        }
+
+        // Empty SGR (`ESC[m`) is equivalent to reset (`ESC[0m`).
+        if params.is_empty() {
+            self.set_style(AnsiStyle::default());
+            return;
+        }
+
+        let mut next_style = self.style.clone();
+        let mut codes = params.into_iter().map(|param| param[0]);
+        while let Some(code) = codes.next() {
+            match code {
+                0 => next_style = AnsiStyle::default(),
+                // 30..37/40..47 are the standard 8 foreground/background colors.
+                30..=37 => next_style.fg = standard_color((code - 30) as u8),
+                40..=47 => next_style.bg = standard_color((code - 40) as u8),
+                // 90..97/100..107 are the bright foreground/background variants.
+                90..=97 => next_style.fg = standard_color((code - 90 + 8) as u8),
+                100..=107 => next_style.bg = standard_color((code - 100 + 8) as u8),
+                39 => next_style.fg = None,
+                49 => next_style.bg = None,
+                38 | 48 => {
+                    let Some(color) = extended_color(&mut codes) else {
+                        break;
+                    };
+                    if code == 38 {
+                        next_style.fg = Some(color);
+                    } else {
+                        next_style.bg = Some(color);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        self.set_style(next_style);
+    }
+}
+
+impl Perform for AnsiPerformer {
+    fn print(&mut self, c: char) {
+        self.push_char(c);
+    }
+
+    fn execute(&mut self, byte: u8) {
+        // Preserve simple whitespace controls that can appear in log text.
+        match byte {
+            b'\t' => self.push_char('\t'),
+            b'\n' => self.push_char('\n'),
+            b'\r' => self.push_char('\r'),
+            _ => {}
+        }
+    }
+
+    fn csi_dispatch(&mut self, params: &Params, intermediates: &[u8], ignore: bool, action: u8) {
+        // CSI ... m is SGR: Select Graphic Rendition. Other CSI actions are
+        // terminal controls, so logs strip them without styling.
+        if ignore || action != b'm' || !intermediates.is_empty() {
+            return;
+        }
+
+        self.apply_sgr(params);
+    }
+}
+
+/// Parses the payload after SGR `38` or `48` into a concrete color.
+fn extended_color(codes: &mut impl Iterator<Item = u16>) -> Option<Color32> {
+    // Extended color forms are `38;5;n`/`48;5;n` for xterm indexes and
+    // `38;2;r;g;b`/`48;2;r;g;b` for truecolor RGB.
+    match codes.next()? {
+        5 => {
+            let color = u8::try_from(codes.next()?).ok()?;
+            Some(indexed_color(color))
+        }
+        2 => {
+            let r = u8::try_from(codes.next()?).ok()?;
+            let g = u8::try_from(codes.next()?).ok()?;
+            let b = u8::try_from(codes.next()?).ok()?;
+            Some(Color32::from_rgb(r, g, b))
+        }
+        _ => None,
+    }
+}
+
+/// Resolves an ANSI 16-color palette index.
+fn standard_color(index: u8) -> Option<Color32> {
+    // Standard terminal 16-color palette: first 8 normal, next 8 bright.
+    const COLORS: [(u8, u8, u8); 16] = [
+        (0x00, 0x00, 0x00),
+        (0x80, 0x00, 0x00),
+        (0x00, 0x80, 0x00),
+        (0x80, 0x80, 0x00),
+        (0x00, 0x00, 0x80),
+        (0x80, 0x00, 0x80),
+        (0x00, 0x80, 0x80),
+        (0xc0, 0xc0, 0xc0),
+        (0x80, 0x80, 0x80),
+        (0xff, 0x00, 0x00),
+        (0x00, 0xff, 0x00),
+        (0xff, 0xff, 0x00),
+        (0x00, 0x00, 0xff),
+        (0xff, 0x00, 0xff),
+        (0x00, 0xff, 0xff),
+        (0xff, 0xff, 0xff),
+    ];
+
+    COLORS
+        .get(index as usize)
+        .map(|&(r, g, b)| Color32::from_rgb(r, g, b))
+}
+
+/// Resolves an xterm 256-color palette index.
+fn indexed_color(index: u8) -> Color32 {
+    if let Some(color) = standard_color(index) {
+        return color;
+    }
+
+    // xterm 256-color indexes 16..231 form a 6x6x6 RGB color cube.
+    if index <= 231 {
+        const LEVELS: [u8; 6] = [0, 95, 135, 175, 215, 255];
+        let cube_index = index - 16;
+        let r = LEVELS[(cube_index / 36) as usize];
+        let g = LEVELS[((cube_index % 36) / 6) as usize];
+        let b = LEVELS[(cube_index % 6) as usize];
+        return Color32::from_rgb(r, g, b);
+    }
+
+    // The remaining indexes are grayscale values from near-black to near-white.
+    let level = 8 + (index - 232) * 10;
+    Color32::from_rgb(level, level, level)
+}
+
+#[cfg(test)]
+mod tests {
+    use egui::Color32;
+
+    use super::{AnsiSpan, AnsiStyle, parse_ansi_text};
+
+    fn style(fg: Option<Color32>, bg: Option<Color32>) -> AnsiStyle {
+        AnsiStyle { fg, bg }
+    }
+
+    #[test]
+    fn plain_text_has_no_spans() {
+        let parsed = parse_ansi_text("plain text");
+
+        assert_eq!(parsed.text, "plain text");
+        assert!(parsed.spans.is_empty());
+    }
+
+    #[test]
+    fn basic_foreground_is_stripped_and_mapped() {
+        let parsed = parse_ansi_text("\x1b[31mred");
+
+        assert_eq!(parsed.text, "red");
+        assert_eq!(
+            parsed.spans,
+            vec![AnsiSpan {
+                range: 0..3,
+                style: style(Some(Color32::from_rgb(0x80, 0x00, 0x00)), None),
+            }]
+        );
+    }
+
+    #[test]
+    fn bright_foreground_is_mapped() {
+        let parsed = parse_ansi_text("\x1b[91mred");
+
+        assert_eq!(parsed.text, "red");
+        assert_eq!(
+            parsed.spans[0].style.fg,
+            Some(Color32::from_rgb(0xff, 0x00, 0x00))
+        );
+    }
+
+    #[test]
+    fn background_is_mapped() {
+        let parsed = parse_ansi_text("\x1b[44mblue bg");
+
+        assert_eq!(parsed.text, "blue bg");
+        assert_eq!(
+            parsed.spans[0].style.bg,
+            Some(Color32::from_rgb(0x00, 0x00, 0x80))
+        );
+    }
+
+    #[test]
+    fn reset_all_closes_current_span() {
+        let parsed = parse_ansi_text("\x1b[31mred\x1b[0m plain");
+
+        assert_eq!(parsed.text, "red plain");
+        assert_eq!(parsed.spans[0].range, 0..3);
+        assert_eq!(parsed.spans.len(), 1);
+    }
+
+    #[test]
+    fn foreground_and_background_reset_independently() {
+        let parsed = parse_ansi_text("\x1b[31;44mred\x1b[39mblue\x1b[49mplain");
+
+        assert_eq!(parsed.text, "redblueplain");
+        assert_eq!(
+            parsed.spans,
+            vec![
+                AnsiSpan {
+                    range: 0..3,
+                    style: style(
+                        Some(Color32::from_rgb(0x80, 0x00, 0x00)),
+                        Some(Color32::from_rgb(0x00, 0x00, 0x80))
+                    ),
+                },
+                AnsiSpan {
+                    range: 3..7,
+                    style: style(None, Some(Color32::from_rgb(0x00, 0x00, 0x80))),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn indexed_foreground_and_background_are_mapped() {
+        let parsed = parse_ansi_text("\x1b[38;5;196mfg\x1b[48;5;21mbg");
+
+        assert_eq!(parsed.text, "fgbg");
+        assert_eq!(parsed.spans[0].style.fg, Some(Color32::from_rgb(255, 0, 0)));
+        assert_eq!(
+            parsed.spans[1].style,
+            style(
+                Some(Color32::from_rgb(255, 0, 0)),
+                Some(Color32::from_rgb(0, 0, 255))
+            )
+        );
+    }
+
+    #[test]
+    fn truecolor_foreground_and_background_are_mapped() {
+        let parsed = parse_ansi_text("\x1b[38;2;1;2;3mfg\x1b[48;2;4;5;6mbg");
+
+        assert_eq!(parsed.text, "fgbg");
+        assert_eq!(parsed.spans[0].style.fg, Some(Color32::from_rgb(1, 2, 3)));
+        assert_eq!(
+            parsed.spans[1].style,
+            style(
+                Some(Color32::from_rgb(1, 2, 3)),
+                Some(Color32::from_rgb(4, 5, 6))
+            )
+        );
+    }
+
+    #[test]
+    fn malformed_extended_color_is_stripped_without_style() {
+        let parsed = parse_ansi_text("\x1b[38;3;43mtext");
+
+        assert_eq!(parsed.text, "text");
+        assert!(parsed.spans.is_empty());
+    }
+
+    #[test]
+    fn unsupported_sgr_is_ignored() {
+        let parsed = parse_ansi_text("\x1b[5mblink");
+
+        assert_eq!(parsed.text, "blink");
+        assert!(parsed.spans.is_empty());
+    }
+
+    #[test]
+    fn adjacent_equal_spans_are_merged() {
+        let parsed = parse_ansi_text("\x1b[31mred\x1b[31mblue");
+
+        assert_eq!(parsed.text, "redblue");
+        assert_eq!(parsed.spans.len(), 1);
+        assert_eq!(parsed.spans[0].range, 0..7);
+    }
+
+    #[test]
+    fn colon_sgr_form_is_stripped_without_style() {
+        let parsed = parse_ansi_text("\x1b[38:2:1:2:3mtext");
+
+        assert_eq!(parsed.text, "text");
+        assert!(parsed.spans.is_empty());
+    }
+}

--- a/application/apps/indexer/gui/application/src/session/ui/common/log_table/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/common/log_table/mod.rs
@@ -1,0 +1,9 @@
+//! Shared log-table infrastructure.
+//!
+//! Main logs and search results render through separate table delegates, but
+//! they share row mechanics, column persistence, selection behavior, and log
+//! cell text layout. This module groups those shared pieces without making the
+//! search table depend on the main log table module.
+
+pub mod table;
+pub mod text;

--- a/application/apps/indexer/gui/application/src/session/ui/common/log_table/table.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/common/log_table/table.rs
@@ -1,14 +1,13 @@
-//! Provides shared helper functions and utilities to be used
-//! with logs tables (both logs and search tables).
-
-use std::ops::{Not, Range};
+//! Shared table and row helpers for log-like tables.
+//!
+//! This module owns table columns, row headers, selection clicks, row coloring,
+//! and shared backend-grab constants used by both the main log table and the
+//! search-result table.
 
 use egui::{
-    Align, Color32, CursorIcon, Frame, Layout, Margin, Response, Sense, Shape, Stroke, TextStyle,
-    Ui, vec2,
+    Align, Color32, CursorIcon, Frame, Layout, Margin, Response, Sense, Shape, Stroke, Ui, vec2,
 };
 use egui_table::{Column, TableState};
-use regex::Regex;
 use stypes::ObserveOrigin;
 use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
@@ -25,10 +24,7 @@ use crate::{
         ui::{
             definitions::schema::LogSchema,
             logs_table::LogAttachmentInfo,
-            shared::{
-                ObserveState, SelectionIntent, SessionShared,
-                searching::{FilterIndex, LogMainIndex},
-            },
+            shared::{ObserveState, SelectionIntent, SessionShared, searching::LogMainIndex},
         },
     },
 };
@@ -42,14 +38,8 @@ pub mod grab_cmd_consts {
     pub const SEND_RETRY_MAX_COUNT: u8 = 10;
 }
 
-pub const ROW_HEADER_SOURCE_COLOR_WIDTH: f32 = 5.0;
-pub const ROW_HEADER_BOOKMARK_WIDTH: f32 = 8.0;
-pub const LOG_TEXT_STYLE: TextStyle = TextStyle::Monospace;
-
-// This overlay is only painted for rows the backend already marked as matched,
-// so it sits on top of the row-level match tint instead of the plain table background.
-// A single translucent white highlight stays visible in both themes on that base.
-const FILTER_MATCH_HIGHLIGHT_BG: Color32 = Color32::from_rgba_unmultiplied_const(255, 255, 255, 60);
+const ROW_HEADER_SOURCE_COLOR_WIDTH: f32 = 5.0;
+const ROW_HEADER_BOOKMARK_WIDTH: f32 = 8.0;
 const COLUMN_WIDTH_EPSILON: f32 = 0.25;
 
 /// Creates the columns for logs table based on the provided `schema`,
@@ -277,66 +267,6 @@ pub fn get_cell_frame() -> Frame {
     Frame::NONE.inner_margin(Margin::symmetric(4, 0))
 }
 
-/// Returns the backend-reported filter indices for one main-log position, if that row matched.
-fn matched_filter_indices(shared: &SessionShared, main_log_pos: u64) -> Option<&[FilterIndex]> {
-    shared
-        .search
-        .current_matches_map()
-        .and_then(|map| map.get(&LogMainIndex(main_log_pos)))
-        .map(Vec::as_slice)
-}
-
-/// Finds all cell-local matches for the row's matched filters and merges overlap into one pass.
-fn cell_match_spans(
-    content: &str,
-    matched_filters: &[FilterIndex],
-    compiled_filters: &[Regex],
-) -> Vec<Range<usize>> {
-    let spans: Vec<Range<usize>> = matched_filters
-        .iter()
-        .filter_map(|idx| compiled_filters.get(idx.0 as usize))
-        .flat_map(|filter| filter.find_iter(content))
-        .filter_map(|mat| (mat.start() < mat.end()).then_some(mat.range()))
-        .collect();
-
-    merge_match_spans(spans)
-}
-
-/// Resolves the merged highlight spans for one visible cell using the original main-log position.
-fn matched_cell_spans(
-    content: &str,
-    main_log_pos: u64,
-    shared: &SessionShared,
-    compiled_filters: &[Regex],
-) -> Vec<Range<usize>> {
-    matched_filter_indices(shared, main_log_pos)
-        .map(|matched_filters| cell_match_spans(content, matched_filters, compiled_filters))
-        .unwrap_or_default()
-}
-
-/// Coalesces overlapping or adjacent spans so the final paint pass uses minimal segments.
-fn merge_match_spans(mut spans: Vec<Range<usize>>) -> Vec<Range<usize>> {
-    if spans.len() <= 1 {
-        return spans;
-    }
-
-    spans.sort_unstable_by_key(|range| (range.start, range.end));
-
-    let mut merged: Vec<Range<usize>> = Vec::with_capacity(spans.len());
-
-    for span in spans {
-        if let Some(last) = merged.last_mut()
-            && span.start <= last.end
-        {
-            last.end = last.end.max(span.end);
-        } else {
-            merged.push(span);
-        }
-    }
-
-    merged
-}
-
 pub fn apply_selection_click(
     shared: &mut SessionShared,
     actions: &mut UiActions,
@@ -363,63 +293,6 @@ fn selection_intent(modifiers: egui::Modifiers) -> SelectionIntent {
     } else {
         SelectionIntent::Exclusive
     }
-}
-
-/// Builds highlighted text only when this cell's main-log position has concrete matches to paint.
-pub fn highlighted_cell_layout_job(
-    ui: &Ui,
-    content: &str,
-    main_log_pos: u64,
-    shared: &SessionShared,
-    compiled_filters: &[Regex],
-) -> Option<egui::text::LayoutJob> {
-    let spans = matched_cell_spans(content, main_log_pos, shared, compiled_filters);
-
-    spans
-        .is_empty()
-        .not()
-        .then(|| build_highlighted_layout_job(ui, content, &spans))
-}
-
-/// Preserves the row-selected text color and adds only background highlight on matched spans.
-fn build_highlighted_layout_job(
-    ui: &Ui,
-    content: &str,
-    spans: &[Range<usize>],
-) -> egui::text::LayoutJob {
-    let mut job = egui::text::LayoutJob::default();
-    let base_format = egui::text::TextFormat {
-        font_id: LOG_TEXT_STYLE.resolve(ui.style()),
-        color: ui
-            .style()
-            .visuals
-            .override_text_color
-            .unwrap_or_else(|| ui.visuals().text_color()),
-        ..Default::default()
-    };
-    let highlight_format = egui::text::TextFormat {
-        background: FILTER_MATCH_HIGHLIGHT_BG,
-        ..base_format.clone()
-    };
-
-    let mut cursor = 0;
-    for span in spans {
-        if cursor < span.start {
-            job.append(&content[cursor..span.start], 0.0, base_format.clone());
-        }
-        job.append(
-            &content[span.start..span.end],
-            0.0,
-            highlight_format.clone(),
-        );
-        cursor = span.end;
-    }
-
-    if cursor < content.len() {
-        job.append(&content[cursor..], 0.0, base_format);
-    }
-
-    job
 }
 
 /// Apply row background and foreground colors for logs/search tables.
@@ -497,186 +370,10 @@ pub fn should_stick_to_bottom(shared: &SessionShared) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use egui::Modifiers;
-    use processor::search::filter::{self, SearchFilter};
-    use regex::Regex;
-    use stypes::{FileFormat, FilterMatch, ObserveOrigin};
-    use uuid::Uuid;
 
-    use crate::{
-        host::{
-            common::parsers::ParserNames,
-            ui::registry::filters::{FilterDefinition, FilterRegistry},
-        },
-        session::{
-            types::ObserveOperation,
-            ui::shared::{SessionInfo, SessionShared},
-        },
-    };
-
-    use super::{
-        FilterIndex, cell_match_spans, matched_cell_spans, matched_filter_indices, selection_intent,
-    };
+    use super::selection_intent;
     use crate::session::ui::shared::SelectionIntent;
-
-    fn new_shared() -> SessionShared {
-        let session_id = Uuid::new_v4();
-        let origin = ObserveOrigin::File(
-            "source".to_owned(),
-            FileFormat::Text,
-            PathBuf::from("source.log"),
-        );
-        let observe_op = ObserveOperation::new(Uuid::new_v4(), origin);
-        let session_info = SessionInfo {
-            id: session_id,
-            title: "test".to_owned(),
-            parser: ParserNames::Text,
-        };
-
-        SessionShared::new(session_info, observe_op)
-    }
-
-    fn apply_filter(
-        shared: &mut SessionShared,
-        registry: &mut FilterRegistry,
-        filter: SearchFilter,
-    ) -> Uuid {
-        let filter_def = FilterDefinition::new(filter);
-        let filter_id = filter_def.id;
-        registry.add_filter(filter_def);
-        shared.filters.apply_filter(registry, filter_id);
-        filter_id
-    }
-
-    fn append_row_match(shared: &mut SessionShared, row_nr: u64, filters: Vec<u8>) {
-        shared.search.set_search_operation(Uuid::new_v4());
-        shared.search.append_matches(vec![FilterMatch {
-            index: row_nr,
-            filters,
-        }]);
-    }
-
-    fn compile_regexes(filters: impl IntoIterator<Item = SearchFilter>) -> Vec<Regex> {
-        filters
-            .into_iter()
-            .map(|filter| Regex::new(&filter::as_regex(&filter)).unwrap())
-            .collect()
-    }
-
-    #[test]
-    fn plain_text_filter_highlights_literal() {
-        let compiled = compile_regexes([SearchFilter::plain("cpu=(1.0)")]);
-
-        let spans = cell_match_spans("cpu=(1.0) status", &[FilterIndex(0)], &compiled);
-
-        assert_eq!(spans, vec![0..9]);
-    }
-
-    #[test]
-    fn regex_filter_highlights_match() {
-        let compiled = compile_regexes([SearchFilter::plain("cpu=\\d+").regex(true)]);
-
-        let spans = cell_match_spans("cpu=42 status", &[FilterIndex(0)], &compiled);
-
-        assert_eq!(spans, vec![0..6]);
-    }
-
-    #[test]
-    fn ignore_case_matches_mixed_case() {
-        let compiled = compile_regexes([SearchFilter::plain("warning").ignore_case(true)]);
-
-        let spans = cell_match_spans("pre WARNING post", &[FilterIndex(0)], &compiled);
-
-        assert_eq!(spans, vec![4..11]);
-    }
-
-    #[test]
-    fn word_boundary_skips_embedded_text() {
-        let compiled = compile_regexes([SearchFilter::plain("warn").word(true)]);
-
-        let spans = cell_match_spans("prewarn warn warned", &[FilterIndex(0)], &compiled);
-
-        assert_eq!(spans, vec![8..12]);
-    }
-
-    #[test]
-    fn all_matches_in_cell() {
-        let compiled = compile_regexes([SearchFilter::plain("err")]);
-
-        let spans = cell_match_spans("err and err", &[FilterIndex(0)], &compiled);
-
-        assert_eq!(spans, vec![0..3, 8..11]);
-    }
-
-    #[test]
-    fn overlapping_matches_are_merged() {
-        let compiled = compile_regexes([SearchFilter::plain("foo"), SearchFilter::plain("oob")]);
-
-        let spans = cell_match_spans("foobar", &[FilterIndex(0), FilterIndex(1)], &compiled);
-
-        assert_eq!(spans, vec![0..4]);
-    }
-
-    #[test]
-    fn stale_filter_index_is_ignored() {
-        let compiled = compile_regexes([SearchFilter::plain("warn")]);
-
-        let spans = cell_match_spans("warn", &[FilterIndex(1)], &compiled);
-
-        assert!(spans.is_empty());
-    }
-
-    #[test]
-    fn bookmarked_row_has_no_cell_highlight() {
-        let mut shared = new_shared();
-        shared.logs.bookmarked_rows.insert(7);
-        let compiled = compile_regexes([SearchFilter::plain("warn")]);
-
-        assert!(matched_filter_indices(&shared, 7).is_none());
-        assert!(matched_cell_spans("warn", 7, &shared, &compiled).is_empty());
-    }
-
-    #[test]
-    fn indexed_row_uses_main_log_pos() {
-        let mut shared = new_shared();
-        let compiled = compile_regexes([SearchFilter::plain("warn")]);
-
-        append_row_match(&mut shared, 42, vec![0]);
-
-        let spans = matched_cell_spans("warn row", 42, &shared, &compiled);
-
-        assert_eq!(spans, vec![0..4]);
-        assert!(matched_cell_spans("warn row", 3, &shared, &compiled).is_empty());
-    }
-
-    #[test]
-    fn active_filters_follow_backend_order() {
-        let mut shared = new_shared();
-        let mut registry = FilterRegistry::default();
-
-        let first_id = apply_filter(&mut shared, &mut registry, SearchFilter::plain("first"));
-        let second_id = apply_filter(&mut shared, &mut registry, SearchFilter::plain("second"));
-        shared
-            .filters
-            .set_temp_search(SearchFilter::plain("temp").ignore_case(true));
-        let filters = shared.search.get_active_filters(&shared.filters, &registry);
-        shared.search.refresh_compiled_filters(&filters);
-
-        append_row_match(&mut shared, 12, vec![0, 2]);
-
-        let spans = matched_cell_spans(
-            "first temp second",
-            12,
-            &shared,
-            shared.search.compiled_filters(),
-        );
-
-        assert_eq!(shared.filters.filter_entries[0].id, first_id);
-        assert_eq!(shared.filters.filter_entries[1].id, second_id);
-        assert_eq!(spans, vec![0..5, 6..10]);
-    }
 
     #[test]
     fn plain_modifiers_map_to_exclusive_selection() {

--- a/application/apps/indexer/gui/application/src/session/ui/common/log_table/text.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/common/log_table/text.rs
@@ -6,12 +6,12 @@
 
 use std::ops::Range;
 
-use egui::{Color32, TextStyle, Ui};
-use memchr::memchr;
+use egui::{Color32, Response, TextStyle, Ui};
 use regex::Regex;
 
 use crate::session::ui::{
-    common::ansi_text::{AnsiSpan, parse_ansi_text},
+    common::ansi_text::{AnsiSpan, AnsiText},
+    definitions::{LogTableCell, LogTableItem},
     shared::{
         SessionShared,
         searching::{FilterIndex, LogMainIndex},
@@ -25,41 +25,73 @@ const LOG_TEXT_STYLE: TextStyle = TextStyle::Monospace;
 // A single translucent white highlight stays visible in both themes on that base.
 const FILTER_MATCH_HIGHLIGHT_BG: Color32 = Color32::from_rgba_unmultiplied_const(255, 255, 255, 60);
 
-/// Builds a monospace layout job for a log cell when plain rendering is not enough.
-///
-/// Returns `None` for the common plain case so callers can keep using
-/// `ui.monospace(content)` without constructing a custom layout job. ANSI escape
-/// sequences are stripped before filter matches are calculated, because match
-/// ranges must refer to the text visible to the user.
-pub fn log_cell_layout_job(
-    ui: &Ui,
+/// Renders a monospace log-table cell with cached ANSI spans and match highlights.
+pub fn render_log_cell_text(
+    ui: &mut Ui,
+    item: &LogTableItem,
+    col_idx: usize,
+    shared: &SessionShared,
+) -> Response {
+    let Some(cell) = item.cells.get(col_idx) else {
+        return ui.monospace("");
+    };
+
+    let main_log_pos = item.element.pos as u64;
+    match cell {
+        LogTableCell::Plain(range) => {
+            let content = item.element.content.get(range.clone()).unwrap_or_default();
+            render_plain_cell(ui, content, main_log_pos, shared)
+        }
+        LogTableCell::Ansi(ansi_text) => render_ansi_cell(ui, ansi_text, main_log_pos, shared),
+    }
+}
+
+fn render_plain_cell(
+    ui: &mut Ui,
     content: &str,
     main_log_pos: u64,
     shared: &SessionShared,
-    compiled_filters: &[Regex],
-) -> Option<egui::text::LayoutJob> {
-    if memchr(0x1b, content.as_bytes()).is_none() {
-        // Most cells are plain text. Keep this path close to the old search-only behavior.
-        let match_spans = matched_cell_spans(content, main_log_pos, shared, compiled_filters);
-        if match_spans.is_empty() {
-            return None;
-        }
+) -> Response {
+    let match_spans = matched_cell_spans(
+        content,
+        main_log_pos,
+        shared,
+        shared.search.compiled_filters(),
+    );
+    if match_spans.is_empty() {
+        ui.monospace(content)
+    } else {
+        let content_job = build_match_layout_job(ui, content, &match_spans);
 
-        let job = build_match_layout_job(ui, content, &match_spans);
-
-        return Some(job);
+        ui.label(content_job)
     }
+}
 
-    // ANSI parsing returns visible text plus style ranges in that visible text.
-    let ansi_text = parse_ansi_text(content);
-    let match_spans = matched_cell_spans(&ansi_text.text, main_log_pos, shared, compiled_filters);
-
-    Some(build_log_layout_job(
-        ui,
+fn render_ansi_cell(
+    ui: &mut Ui,
+    ansi_text: &AnsiText,
+    main_log_pos: u64,
+    shared: &SessionShared,
+) -> Response {
+    let match_spans = matched_cell_spans(
         &ansi_text.text,
-        &ansi_text.spans,
-        &match_spans,
-    ))
+        main_log_pos,
+        shared,
+        shared.search.compiled_filters(),
+    );
+    if ansi_text.spans.is_empty() {
+        if match_spans.is_empty() {
+            ui.monospace(&ansi_text.text)
+        } else {
+            let job = build_match_layout_job(ui, &ansi_text.text, &match_spans);
+
+            ui.label(job)
+        }
+    } else {
+        let job = build_log_layout_job(ui, &ansi_text.text, &ansi_text.spans, &match_spans);
+
+        ui.label(job)
+    }
 }
 
 /// Returns the backend-reported filter indices for one main-log position, if that row matched.

--- a/application/apps/indexer/gui/application/src/session/ui/common/log_table/text.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/common/log_table/text.rs
@@ -183,6 +183,20 @@ fn build_match_layout_job(ui: &Ui, content: &str, spans: &[Range<usize>]) -> egu
     job
 }
 
+/// Builds a layout for ANSI-styled text without search highlighting.
+pub fn ansi_layout_job(
+    ui: &Ui,
+    ansi_text: &AnsiText,
+    base_color: Color32,
+) -> egui::text::LayoutJob {
+    build_styled_layout_job(
+        &ansi_text.text,
+        &ansi_text.spans,
+        &[],
+        text_format(ui, base_color),
+    )
+}
+
 /// Builds a layout where ANSI spans and search-highlight spans can overlap.
 ///
 /// The input spans must use byte ranges in `content`. Search highlighting wins
@@ -193,8 +207,16 @@ fn build_log_layout_job(
     ansi_spans: &[AnsiSpan],
     match_spans: &[Range<usize>],
 ) -> egui::text::LayoutJob {
+    build_styled_layout_job(content, ansi_spans, match_spans, base_log_format(ui))
+}
+
+fn build_styled_layout_job(
+    content: &str,
+    ansi_spans: &[AnsiSpan],
+    match_spans: &[Range<usize>],
+    base_format: egui::text::TextFormat,
+) -> egui::text::LayoutJob {
     let mut job = egui::text::LayoutJob::default();
-    let base_format = base_log_format(ui);
 
     // A LayoutJob segment can have only one final TextFormat. ANSI styling and
     // search highlighting are represented as independent ranges, so first split
@@ -279,13 +301,19 @@ fn build_log_layout_job(
 
 /// Returns the base text format shared by ANSI and search-highlight jobs.
 fn base_log_format(ui: &Ui) -> egui::text::TextFormat {
-    egui::text::TextFormat {
-        font_id: LOG_TEXT_STYLE.resolve(ui.style()),
-        color: ui
-            .style()
+    text_format(
+        ui,
+        ui.style()
             .visuals
             .override_text_color
             .unwrap_or_else(|| ui.visuals().text_color()),
+    )
+}
+
+fn text_format(ui: &Ui, color: Color32) -> egui::text::TextFormat {
+    egui::text::TextFormat {
+        font_id: LOG_TEXT_STYLE.resolve(ui.style()),
+        color,
         ..Default::default()
     }
 }

--- a/application/apps/indexer/gui/application/src/session/ui/common/log_table/text.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/common/log_table/text.rs
@@ -1,0 +1,530 @@
+//! Shared text layout for log table cells.
+//!
+//! This module combines ANSI SGR color spans with backend-reported filter match
+//! spans into one egui `LayoutJob`. ANSI parsing itself stays in `ansi_text`;
+//! this module owns the log-table rendering policy and precedence rules.
+
+use std::ops::Range;
+
+use egui::{Color32, TextStyle, Ui};
+use memchr::memchr;
+use regex::Regex;
+
+use crate::session::ui::{
+    common::ansi_text::{AnsiSpan, parse_ansi_text},
+    shared::{
+        SessionShared,
+        searching::{FilterIndex, LogMainIndex},
+    },
+};
+
+const LOG_TEXT_STYLE: TextStyle = TextStyle::Monospace;
+
+// This overlay is only painted for rows the backend already marked as matched,
+// so it sits on top of the row-level match tint instead of the plain table background.
+// A single translucent white highlight stays visible in both themes on that base.
+const FILTER_MATCH_HIGHLIGHT_BG: Color32 = Color32::from_rgba_unmultiplied_const(255, 255, 255, 60);
+
+/// Builds a monospace layout job for a log cell when plain rendering is not enough.
+///
+/// Returns `None` for the common plain case so callers can keep using
+/// `ui.monospace(content)` without constructing a custom layout job. ANSI escape
+/// sequences are stripped before filter matches are calculated, because match
+/// ranges must refer to the text visible to the user.
+pub fn log_cell_layout_job(
+    ui: &Ui,
+    content: &str,
+    main_log_pos: u64,
+    shared: &SessionShared,
+    compiled_filters: &[Regex],
+) -> Option<egui::text::LayoutJob> {
+    if memchr(0x1b, content.as_bytes()).is_none() {
+        // Most cells are plain text. Keep this path close to the old search-only behavior.
+        let match_spans = matched_cell_spans(content, main_log_pos, shared, compiled_filters);
+        if match_spans.is_empty() {
+            return None;
+        }
+
+        let job = build_match_layout_job(ui, content, &match_spans);
+
+        return Some(job);
+    }
+
+    // ANSI parsing returns visible text plus style ranges in that visible text.
+    let ansi_text = parse_ansi_text(content);
+    let match_spans = matched_cell_spans(&ansi_text.text, main_log_pos, shared, compiled_filters);
+
+    Some(build_log_layout_job(
+        ui,
+        &ansi_text.text,
+        &ansi_text.spans,
+        &match_spans,
+    ))
+}
+
+/// Returns the backend-reported filter indices for one main-log position, if that row matched.
+fn matched_filter_indices(shared: &SessionShared, main_log_pos: u64) -> Option<&[FilterIndex]> {
+    shared
+        .search
+        .current_matches_map()
+        .and_then(|map| map.get(&LogMainIndex(main_log_pos)))
+        .map(Vec::as_slice)
+}
+
+/// Finds all cell-local matches for the row's matched filters and merges overlap into one pass.
+fn cell_match_spans(
+    content: &str,
+    matched_filters: &[FilterIndex],
+    compiled_filters: &[Regex],
+) -> Vec<Range<usize>> {
+    let spans: Vec<Range<usize>> = matched_filters
+        .iter()
+        .filter_map(|idx| compiled_filters.get(idx.0 as usize))
+        .flat_map(|filter| filter.find_iter(content))
+        .filter_map(|mat| (mat.start() < mat.end()).then_some(mat.range()))
+        .collect();
+
+    merge_match_spans(spans)
+}
+
+/// Resolves the merged highlight spans for one visible cell using the original main-log position.
+fn matched_cell_spans(
+    content: &str,
+    main_log_pos: u64,
+    shared: &SessionShared,
+    compiled_filters: &[Regex],
+) -> Vec<Range<usize>> {
+    matched_filter_indices(shared, main_log_pos)
+        .map(|matched_filters| cell_match_spans(content, matched_filters, compiled_filters))
+        .unwrap_or_default()
+}
+
+/// Coalesces overlapping or adjacent spans so the final paint pass uses minimal segments.
+fn merge_match_spans(mut spans: Vec<Range<usize>>) -> Vec<Range<usize>> {
+    if spans.len() <= 1 {
+        return spans;
+    }
+
+    spans.sort_unstable_by_key(|range| (range.start, range.end));
+
+    let mut merged: Vec<Range<usize>> = Vec::with_capacity(spans.len());
+
+    for span in spans {
+        if let Some(last) = merged.last_mut()
+            && span.start <= last.end
+        {
+            last.end = last.end.max(span.end);
+        } else {
+            merged.push(span);
+        }
+    }
+
+    merged
+}
+
+/// Builds the cheaper search-only layout used when no ANSI escape exists.
+fn build_match_layout_job(ui: &Ui, content: &str, spans: &[Range<usize>]) -> egui::text::LayoutJob {
+    let mut job = egui::text::LayoutJob::default();
+    let base_format = base_log_format(ui);
+    let highlight_format = egui::text::TextFormat {
+        background: FILTER_MATCH_HIGHLIGHT_BG,
+        ..base_format.clone()
+    };
+
+    let mut cursor = 0;
+    for span in spans {
+        if cursor < span.start {
+            job.append(&content[cursor..span.start], 0.0, base_format.clone());
+        }
+        job.append(
+            &content[span.start..span.end],
+            0.0,
+            highlight_format.clone(),
+        );
+        cursor = span.end;
+    }
+
+    if cursor < content.len() {
+        job.append(&content[cursor..], 0.0, base_format);
+    }
+
+    job
+}
+
+/// Builds a layout where ANSI spans and search-highlight spans can overlap.
+///
+/// The input spans must use byte ranges in `content`. Search highlighting wins
+/// over ANSI background, while ANSI foreground stays active.
+fn build_log_layout_job(
+    ui: &Ui,
+    content: &str,
+    ansi_spans: &[AnsiSpan],
+    match_spans: &[Range<usize>],
+) -> egui::text::LayoutJob {
+    let mut job = egui::text::LayoutJob::default();
+    let base_format = base_log_format(ui);
+
+    // A LayoutJob segment can have only one final TextFormat. ANSI styling and
+    // search highlighting are represented as independent ranges, so first split
+    // the text at every range edge. Each pair of adjacent boundaries then covers
+    // a segment where the active ANSI style and match state cannot change.
+
+    // Include text start/end plus start/end for every style and match range.
+    let boundary_count = 2 + 2 * (ansi_spans.len() + match_spans.len());
+    let mut boundaries = Vec::with_capacity(boundary_count);
+    boundaries.push(0);
+    boundaries.push(content.len());
+    for span in ansi_spans {
+        boundaries.push(span.range.start);
+        boundaries.push(span.range.end);
+    }
+    for span in match_spans {
+        boundaries.push(span.start);
+        boundaries.push(span.end);
+    }
+    // Multiple ranges can start/end at the same byte, so remove duplicates after sorting.
+    boundaries.sort_unstable();
+    boundaries.dedup();
+
+    let mut ansi_idx = 0;
+    let mut match_idx = 0;
+    // Walk each segment between two adjacent boundaries, resolve the active ANSI
+    // style and match state for that segment, then append it with one TextFormat.
+    for window in boundaries.windows(2) {
+        let start = window[0];
+        let end = window[1];
+        if start == end {
+            continue;
+        }
+
+        // Spans are sorted and non-overlapping within their own list, so indexes
+        // only move forward as segment starts increase.
+        while ansi_spans
+            .get(ansi_idx)
+            .is_some_and(|span| span.range.end <= start)
+        {
+            ansi_idx += 1;
+        }
+        while match_spans
+            .get(match_idx)
+            .is_some_and(|span| span.end <= start)
+        {
+            match_idx += 1;
+        }
+
+        // Resolve whether the current segment is inside the active match span.
+        let is_match = match_spans
+            .get(match_idx)
+            .is_some_and(|span| span.start <= start && start < span.end);
+
+        // Start from row-aware defaults, then layer ANSI colors and match overlay.
+        let mut format = base_format.clone();
+        if let Some(span) = ansi_spans
+            .get(ansi_idx)
+            .filter(|span| span.range.start <= start && start < span.range.end)
+        {
+            if let Some(fg) = span.style.fg {
+                format.color = fg;
+            }
+            if let Some(bg) = span.style.bg {
+                format.background = bg;
+                if span.style.fg.is_none() && !is_match {
+                    format.color = readable_text_color(bg, format.color);
+                }
+            }
+        }
+        if is_match {
+            // The match overlay is translucent, so do not derive contrast from it here.
+            format.background = FILTER_MATCH_HIGHLIGHT_BG;
+        }
+
+        // The segment boundaries were collected from UTF-8-safe regex and parser ranges.
+        job.append(&content[start..end], 0.0, format);
+    }
+
+    job
+}
+
+/// Returns the base text format shared by ANSI and search-highlight jobs.
+fn base_log_format(ui: &Ui) -> egui::text::TextFormat {
+    egui::text::TextFormat {
+        font_id: LOG_TEXT_STYLE.resolve(ui.style()),
+        color: ui
+            .style()
+            .visuals
+            .override_text_color
+            .unwrap_or_else(|| ui.visuals().text_color()),
+        ..Default::default()
+    }
+}
+
+/// Keeps `base` when readable, otherwise chooses black or white for the background.
+fn readable_text_color(background: Color32, base: Color32) -> Color32 {
+    const MIN_TEXT_BACKGROUND_CONTRAST: f32 = 4.5;
+
+    if contrast_ratio(base, background) >= MIN_TEXT_BACKGROUND_CONTRAST {
+        return base;
+    }
+
+    let black_contrast = contrast_ratio(Color32::BLACK, background);
+    let white_contrast = contrast_ratio(Color32::WHITE, background);
+    if black_contrast >= white_contrast {
+        Color32::BLACK
+    } else {
+        Color32::WHITE
+    }
+}
+
+/// WCAG contrast ratio between two opaque sRGB colors.
+fn contrast_ratio(first: Color32, second: Color32) -> f32 {
+    let first = relative_luminance(first);
+    let second = relative_luminance(second);
+    let lighter = first.max(second);
+    let darker = first.min(second);
+
+    // WCAG adds 0.05 so pure black still has a finite contrast ratio.
+    (lighter + 0.05) / (darker + 0.05)
+}
+
+/// Relative luminance for an opaque sRGB color.
+fn relative_luminance(color: Color32) -> f32 {
+    // WCAG weights linear RGB by human-perceived brightness: green contributes
+    // most, then red, then blue.
+    0.2126 * linear_channel(color.r())
+        + 0.7152 * linear_channel(color.g())
+        + 0.0722 * linear_channel(color.b())
+}
+
+/// Converts one sRGB channel to linear light.
+fn linear_channel(value: u8) -> f32 {
+    // Color32 stores channels as 0..=255 sRGB bytes; normalize to 0.0..=1.0 first.
+    let channel = f32::from(value) / 255.0;
+    if channel <= 0.03928 {
+        // Low sRGB values use the linear part of the transfer function.
+        channel / 12.92
+    } else {
+        // Higher sRGB values use the gamma curve defined by WCAG/sRGB.
+        ((channel + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use egui::Color32;
+    use processor::search::filter::{self, SearchFilter};
+    use regex::Regex;
+    use stypes::{FileFormat, FilterMatch, ObserveOrigin};
+    use uuid::Uuid;
+
+    use crate::{
+        host::{
+            common::parsers::ParserNames,
+            ui::registry::filters::{FilterDefinition, FilterRegistry},
+        },
+        session::{
+            types::ObserveOperation,
+            ui::shared::{SessionInfo, SessionShared},
+        },
+    };
+
+    use super::{
+        FilterIndex, cell_match_spans, matched_cell_spans, matched_filter_indices,
+        readable_text_color,
+    };
+    use crate::session::ui::common::ansi_text::parse_ansi_text;
+
+    fn new_shared() -> SessionShared {
+        let session_id = Uuid::new_v4();
+        let origin = ObserveOrigin::File(
+            "source".to_owned(),
+            FileFormat::Text,
+            PathBuf::from("source.log"),
+        );
+        let observe_op = ObserveOperation::new(Uuid::new_v4(), origin);
+        let session_info = SessionInfo {
+            id: session_id,
+            title: "test".to_owned(),
+            parser: ParserNames::Text,
+        };
+
+        SessionShared::new(session_info, observe_op)
+    }
+
+    fn apply_filter(
+        shared: &mut SessionShared,
+        registry: &mut FilterRegistry,
+        filter: SearchFilter,
+    ) -> Uuid {
+        let filter_def = FilterDefinition::new(filter);
+        let filter_id = filter_def.id;
+        registry.add_filter(filter_def);
+        shared.filters.apply_filter(registry, filter_id);
+        filter_id
+    }
+
+    fn append_row_match(shared: &mut SessionShared, row_nr: u64, filters: Vec<u8>) {
+        shared.search.set_search_operation(Uuid::new_v4());
+        shared.search.append_matches(vec![FilterMatch {
+            index: row_nr,
+            filters,
+        }]);
+    }
+
+    fn compile_regexes(filters: impl IntoIterator<Item = SearchFilter>) -> Vec<Regex> {
+        filters
+            .into_iter()
+            .map(|filter| Regex::new(&filter::as_regex(&filter)).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn plain_text_filter_highlights_literal() {
+        let compiled = compile_regexes([SearchFilter::plain("cpu=(1.0)")]);
+
+        let spans = cell_match_spans("cpu=(1.0) status", &[FilterIndex(0)], &compiled);
+
+        assert_eq!(spans, vec![0..9]);
+    }
+
+    #[test]
+    fn regex_filter_highlights_match() {
+        let compiled = compile_regexes([SearchFilter::plain("cpu=\\d+").regex(true)]);
+
+        let spans = cell_match_spans("cpu=42 status", &[FilterIndex(0)], &compiled);
+
+        assert_eq!(spans, vec![0..6]);
+    }
+
+    #[test]
+    fn ignore_case_matches_mixed_case() {
+        let compiled = compile_regexes([SearchFilter::plain("warning").ignore_case(true)]);
+
+        let spans = cell_match_spans("pre WARNING post", &[FilterIndex(0)], &compiled);
+
+        assert_eq!(spans, vec![4..11]);
+    }
+
+    #[test]
+    fn word_boundary_skips_embedded_text() {
+        let compiled = compile_regexes([SearchFilter::plain("warn").word(true)]);
+
+        let spans = cell_match_spans("prewarn warn warned", &[FilterIndex(0)], &compiled);
+
+        assert_eq!(spans, vec![8..12]);
+    }
+
+    #[test]
+    fn all_matches_in_cell() {
+        let compiled = compile_regexes([SearchFilter::plain("err")]);
+
+        let spans = cell_match_spans("err and err", &[FilterIndex(0)], &compiled);
+
+        assert_eq!(spans, vec![0..3, 8..11]);
+    }
+
+    #[test]
+    fn overlapping_matches_are_merged() {
+        let compiled = compile_regexes([SearchFilter::plain("foo"), SearchFilter::plain("oob")]);
+
+        let spans = cell_match_spans("foobar", &[FilterIndex(0), FilterIndex(1)], &compiled);
+
+        assert_eq!(spans, vec![0..4]);
+    }
+
+    #[test]
+    fn stale_filter_index_is_ignored() {
+        let compiled = compile_regexes([SearchFilter::plain("warn")]);
+
+        let spans = cell_match_spans("warn", &[FilterIndex(1)], &compiled);
+
+        assert!(spans.is_empty());
+    }
+
+    #[test]
+    fn bookmarked_row_has_no_cell_highlight() {
+        let mut shared = new_shared();
+        shared.logs.bookmarked_rows.insert(7);
+        let compiled = compile_regexes([SearchFilter::plain("warn")]);
+
+        assert!(matched_filter_indices(&shared, 7).is_none());
+        assert!(matched_cell_spans("warn", 7, &shared, &compiled).is_empty());
+    }
+
+    #[test]
+    fn indexed_row_uses_main_log_pos() {
+        let mut shared = new_shared();
+        let compiled = compile_regexes([SearchFilter::plain("warn")]);
+
+        append_row_match(&mut shared, 42, vec![0]);
+
+        let spans = matched_cell_spans("warn row", 42, &shared, &compiled);
+
+        assert_eq!(spans, vec![0..4]);
+        assert!(matched_cell_spans("warn row", 3, &shared, &compiled).is_empty());
+    }
+
+    #[test]
+    fn filter_matches_visible_ansi_text() {
+        let mut shared = new_shared();
+        let compiled = compile_regexes([SearchFilter::plain("warn")]);
+        append_row_match(&mut shared, 42, vec![0]);
+
+        let visible = parse_ansi_text("w\x1b[31marn").text;
+        let spans = matched_cell_spans(&visible, 42, &shared, &compiled);
+
+        assert_eq!(visible, "warn");
+        assert_eq!(spans, vec![0..4]);
+    }
+
+    #[test]
+    fn readable_text_color_keeps_sufficient_contrast() {
+        let base = Color32::WHITE;
+
+        assert_eq!(readable_text_color(Color32::BLACK, base), base);
+    }
+
+    #[test]
+    fn readable_text_color_picks_black_for_light_background() {
+        assert_eq!(
+            readable_text_color(Color32::from_rgb(255, 255, 0), Color32::WHITE),
+            Color32::BLACK
+        );
+    }
+
+    #[test]
+    fn readable_text_color_picks_white_for_dark_background() {
+        assert_eq!(
+            readable_text_color(Color32::from_rgb(0, 0, 128), Color32::BLACK),
+            Color32::WHITE
+        );
+    }
+
+    #[test]
+    fn active_filters_follow_backend_order() {
+        let mut shared = new_shared();
+        let mut registry = FilterRegistry::default();
+
+        let first_id = apply_filter(&mut shared, &mut registry, SearchFilter::plain("first"));
+        let second_id = apply_filter(&mut shared, &mut registry, SearchFilter::plain("second"));
+        shared
+            .filters
+            .set_temp_search(SearchFilter::plain("temp").ignore_case(true));
+        let filters = shared.search.get_active_filters(&shared.filters, &registry);
+        shared.search.refresh_compiled_filters(&filters);
+
+        append_row_match(&mut shared, 12, vec![0, 2]);
+
+        let spans = matched_cell_spans(
+            "first temp second",
+            12,
+            &shared,
+            shared.search.compiled_filters(),
+        );
+
+        assert_eq!(shared.filters.filter_entries[0].id, first_id);
+        assert_eq!(shared.filters.filter_entries[1].id, second_id);
+        assert_eq!(spans, vec![0..5, 6..10]);
+    }
+}

--- a/application/apps/indexer/gui/application/src/session/ui/common/logs_mapped.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/common/logs_mapped.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use rustc_hash::{FxHashMap, FxHashSet};
 use stypes::GrabbedElement;
 
-use crate::session::ui::definitions::{LogTableItem, schema::LogSchema};
+use crate::session::ui::definitions::{LogTableCell, LogTableItem, schema::LogSchema};
 
 /// Simple implementation for displaying a window of the logs to be used
 /// inside the log viewers (e.g., Main Table, Search Table).
@@ -67,11 +67,12 @@ impl LogsMapped {
                 }
             }
 
-            let column_ranges = self.schema.prepare_log(&mut element);
-            let item = LogTableItem {
-                element,
-                column_ranges,
-            };
+            let ranges = self.schema.prepare_log(&mut element);
+            let cells = ranges
+                .into_iter()
+                .map(|range| LogTableCell::from_range(&element.content, range))
+                .collect();
+            let item = LogTableItem { element, cells };
             self.logs.insert(idx, item);
         });
     }
@@ -103,5 +104,89 @@ impl LogsMapped {
     /// logs from different sources.
     pub fn source_change_positions(&self) -> &FxHashSet<usize> {
         &self.source_change_positions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ops::Range, rc::Rc};
+
+    use egui::Color32;
+    use egui_table::Column;
+    use stypes::GrabbedElement;
+
+    use crate::session::ui::definitions::{
+        LogTableCell,
+        schema::{ColumnInfo, LogSchema, map_columns_with_separator},
+    };
+
+    use super::LogsMapped;
+
+    #[derive(Debug)]
+    struct PipeSchema {
+        columns: [ColumnInfo; 2],
+    }
+
+    impl Default for PipeSchema {
+        fn default() -> Self {
+            Self {
+                columns: [
+                    ColumnInfo::new("first", "first", Column::default()),
+                    ColumnInfo::new("second", "second", Column::default()),
+                ],
+            }
+        }
+    }
+
+    impl LogSchema for PipeSchema {
+        fn has_headers(&self) -> bool {
+            true
+        }
+
+        fn columns(&self) -> &[ColumnInfo] {
+            &self.columns
+        }
+
+        fn prepare_log(&self, element: &mut GrabbedElement) -> Vec<Range<usize>> {
+            let mut ranges = Vec::with_capacity(self.columns.len());
+            map_columns_with_separator(&element.content, &mut ranges, '|');
+            ranges
+        }
+    }
+
+    fn element(content: &str) -> GrabbedElement {
+        GrabbedElement {
+            source_id: 0,
+            content: content.to_owned(),
+            pos: 0,
+            nature: 0,
+        }
+    }
+
+    #[test]
+    fn append_prepares_ansi_cells_per_column() {
+        let mut logs = LogsMapped::new(Rc::new(PipeSchema::default()));
+
+        logs.append([(7, element("plain|\x1b[31mred"))].into_iter(), false);
+
+        let item = logs.get_log_item(&7).unwrap();
+        assert_eq!(item.cells.len(), 2);
+
+        let LogTableCell::Plain(range) = &item.cells[0] else {
+            panic!("expected plain cell");
+        };
+        assert_eq!(item.element.content.get(range.clone()), Some("plain"));
+
+        let LogTableCell::Ansi(ansi_text) = &item.cells[1] else {
+            panic!("expected ANSI cell");
+        };
+        assert_eq!(ansi_text.text, "red");
+        assert_eq!(ansi_text.spans.len(), 1);
+        assert_eq!(ansi_text.spans[0].range, 0..3);
+        assert_eq!(
+            ansi_text.spans[0].style.fg,
+            Some(Color32::from_rgb(0x80, 0x00, 0x00))
+        );
+        assert_eq!(ansi_text.spans[0].style.bg, None);
     }
 }

--- a/application/apps/indexer/gui/application/src/session/ui/common/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/common/mod.rs
@@ -1,2 +1,3 @@
+pub mod ansi_text;
+pub mod log_table;
 pub mod logs_mapped;
-pub mod logs_tables;

--- a/application/apps/indexer/gui/application/src/session/ui/definitions/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/definitions/mod.rs
@@ -1,15 +1,39 @@
 use std::ops::Range;
 
+use memchr::memchr;
+
 use stypes::GrabbedElement;
+
+use crate::session::ui::common::ansi_text::{AnsiText, parse_ansi_text};
 
 pub mod schema;
 
-/// Represent a log item to be represented in logs tables including
-/// the grabbed element and its columns' ranges.
+/// Represent a log item to be represented in logs tables.
 #[derive(Debug, Clone)]
 pub struct LogTableItem {
     pub element: GrabbedElement,
-    pub column_ranges: Vec<Range<usize>>,
+    pub cells: Vec<LogTableCell>,
+}
+
+/// Prepared text for one log-table column.
+#[derive(Debug, Clone)]
+pub enum LogTableCell {
+    /// Plain cell text borrowed from the prepared log content.
+    Plain(Range<usize>),
+    /// ANSI-styled cell text with escapes stripped from the visible content.
+    Ansi(AnsiText),
+}
+
+impl LogTableCell {
+    /// Builds a display cell from a byte range in prepared log content.
+    pub fn from_range(content: &str, range: Range<usize>) -> Self {
+        let cell_text = content.get(range.clone()).unwrap_or_default();
+        if memchr(0x1b, cell_text.as_bytes()).is_some() {
+            Self::Ansi(parse_ansi_text(cell_text))
+        } else {
+            Self::Plain(range)
+        }
+    }
 }
 
 /// Represents the outcome of updating the operation by a state component.

--- a/application/apps/indexer/gui/application/src/session/ui/logs_table/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/logs_table/mod.rs
@@ -16,11 +16,11 @@ use crate::{
             bottom_panel::BottomTabType,
             common::{
                 self,
-                logs_mapped::LogsMapped,
-                logs_tables::{
+                log_table::table::{
                     columns_filling_last, grab_cmd_consts, should_stick_to_bottom,
                     sync_column_widths,
                 },
+                logs_mapped::LogsMapped,
             },
             definitions::schema::LogSchema,
             shared::SessionShared,
@@ -129,7 +129,7 @@ impl<'a> LogsDelegate<'a> {
     }
 
     fn select_row(&mut self, row_nr: u64, modifiers: egui::Modifiers) {
-        let Some(selected_row) = common::logs_tables::apply_selection_click(
+        let Some(selected_row) = common::log_table::table::apply_selection_click(
             self.shared,
             self.actions,
             &self.table.cmd_tx,
@@ -187,7 +187,7 @@ impl<'a> LogsDelegate<'a> {
                 }
             });
 
-        let response = common::logs_tables::render_row_header(
+        let response = common::log_table::table::render_row_header(
             ui,
             cell.row_nr.to_string(),
             color_idx,
@@ -206,7 +206,7 @@ impl<'a> LogsDelegate<'a> {
 
         let &CellInfo { col_nr, row_nr, .. } = cell;
 
-        common::logs_tables::get_cell_frame().show(ui, |ui| {
+        common::log_table::table::get_cell_frame().show(ui, |ui| {
             let content = match self.table.logs.get_log_item(&row_nr) {
                 Some(item) => {
                     source_changed = self.has_multi_sources
@@ -231,7 +231,7 @@ impl<'a> LogsDelegate<'a> {
                 }
             };
 
-            let response = match common::logs_tables::highlighted_cell_layout_job(
+            let response = match common::log_table::text::log_cell_layout_job(
                 ui,
                 content,
                 row_nr,
@@ -248,7 +248,7 @@ impl<'a> LogsDelegate<'a> {
         });
 
         if source_changed {
-            common::logs_tables::render_upper_bound(ui);
+            common::log_table::table::render_upper_bound(ui);
         }
     }
 }
@@ -304,7 +304,7 @@ impl TableDelegate for LogsDelegate<'_> {
                     self.has_multi_sources,
                 ),
                 Err(error) => {
-                    common::logs_tables::handle_grab_errors(
+                    common::log_table::table::handle_grab_errors(
                         error,
                         self.shared.get_id(),
                         self.actions,
@@ -319,7 +319,7 @@ impl TableDelegate for LogsDelegate<'_> {
     }
 
     fn header_cell_ui(&mut self, ui: &mut Ui, cell: &HeaderCellInfo) {
-        common::logs_tables::get_cell_frame().show(ui, |ui| {
+        common::log_table::table::get_cell_frame().show(ui, |ui| {
             let (header, tooltip) = match cell.group_index {
                 0 => ("Nr.", "Log Position"),
                 idx => self
@@ -337,7 +337,7 @@ impl TableDelegate for LogsDelegate<'_> {
 
     fn row_ui(&mut self, ui: &mut Ui, row_nr: u64) {
         let is_selected = self.shared.logs.is_selected(row_nr);
-        common::logs_tables::apply_log_row_colors(ui, self.shared, Some(row_nr), is_selected);
+        common::log_table::table::apply_log_row_colors(ui, self.shared, Some(row_nr), is_selected);
 
         if ui.response().interact(Sense::click()).clicked() {
             self.handle_selection_click(row_nr, ui.input(|i| i.modifiers));

--- a/application/apps/indexer/gui/application/src/session/ui/logs_table/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/logs_table/mod.rs
@@ -16,9 +16,12 @@ use crate::{
             bottom_panel::BottomTabType,
             common::{
                 self,
-                log_table::table::{
-                    columns_filling_last, grab_cmd_consts, should_stick_to_bottom,
-                    sync_column_widths,
+                log_table::{
+                    table::{
+                        self, columns_filling_last, grab_cmd_consts, should_stick_to_bottom,
+                        sync_column_widths,
+                    },
+                    text::render_log_cell_text,
                 },
                 logs_mapped::LogsMapped,
             },
@@ -207,40 +210,28 @@ impl<'a> LogsDelegate<'a> {
         let &CellInfo { col_nr, row_nr, .. } = cell;
 
         common::log_table::table::get_cell_frame().show(ui, |ui| {
-            let content = match self.table.logs.get_log_item(&row_nr) {
-                Some(item) => {
-                    source_changed = self.has_multi_sources
-                        && self
-                            .table
-                            .logs
-                            .source_change_positions()
-                            .contains(&item.element.pos);
-                    let col_idx = col_nr.saturating_sub(1);
-                    item.column_ranges
-                        .get(col_idx)
-                        .and_then(|rng| item.element.content.get(rng.clone()))
-                        .unwrap_or_default()
+            let Some(item) = self.table.logs.get_log_item(&row_nr) else {
+                // Ensure data will be requested on next frame.
+                if self.table.pending_logs_rx.is_none() {
+                    self.table.last_visible_rows = None;
                 }
-                None => {
-                    // Ensure data will be requested on next frame.
-                    if self.table.pending_logs_rx.is_none() {
-                        self.table.last_visible_rows = None;
-                    }
 
-                    "Loading..."
+                let response = ui.monospace("Loading...");
+                if response.clicked() {
+                    self.handle_selection_click(row_nr, ui.input(|i| i.modifiers));
                 }
+                return;
             };
 
-            let response = match common::log_table::text::log_cell_layout_job(
-                ui,
-                content,
-                row_nr,
-                self.shared,
-                self.shared.search.compiled_filters(),
-            ) {
-                Some(job) => ui.label(job),
-                None => ui.monospace(content),
-            };
+            source_changed = self.has_multi_sources
+                && self
+                    .table
+                    .logs
+                    .source_change_positions()
+                    .contains(&item.element.pos);
+
+            let col_idx = col_nr.saturating_sub(1);
+            let response = render_log_cell_text(ui, item, col_idx, self.shared);
 
             if response.clicked() {
                 self.handle_selection_click(row_nr, ui.input(|i| i.modifiers));
@@ -248,7 +239,7 @@ impl<'a> LogsDelegate<'a> {
         });
 
         if source_changed {
-            common::log_table::table::render_upper_bound(ui);
+            table::render_upper_bound(ui);
         }
     }
 }

--- a/application/apps/indexer/gui/application/src/session/ui/shared/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/shared/mod.rs
@@ -6,7 +6,7 @@ use crate::{
         command::SessionCommand,
         types::{ObserveOperation, OperationPhase},
         ui::{
-            common::logs_tables,
+            common::log_table,
             definitions::{
                 UpdateOperationOutcome,
                 schema::{self, LogSchema},
@@ -90,7 +90,7 @@ impl SessionShared {
             search_values: SearchValuesState::default(),
             logs: LogsState::default(),
             layout: UiLayoutState {
-                log_columns: logs_tables::create_table_columns(schema.as_ref()),
+                log_columns: log_table::table::create_table_columns(schema.as_ref()),
             },
             observe: ObserveState::new(observe_op),
             attachments: AttachmentsState::default(),

--- a/application/apps/indexer/parsers/Cargo.toml
+++ b/application/apps/indexer/parsers/Cargo.toml
@@ -14,7 +14,7 @@ dlt-core = { workspace = true, features = ["serialization", "fibex"] }
 lazy_static.workspace = true
 log.workspace = true
 regex.workspace = true
-memchr = "2.7"
+memchr.workspace = true
 serde = { workspace = true , features = ["derive"] }
 thiserror.workspace = true
 rand.workspace = true


### PR DESCRIPTION
* Add ANSI SGR parsing for native log cell rendering for both logs and search tables and Details view.
* Keep search match highlight precedence over ANSI background
* Improve text contrast when ANSI background has no foreground color
* Split shared log table helpers into tow sub-modules