### PR TITLE
Native File Dialog: All-Files Filter & Improve Filter Naming

### DIFF
--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/side_config/shared.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/side_config/shared.rs
@@ -45,9 +45,10 @@ pub fn fibex_file_selector(
     {
         actions.file_dialog.pick_files(
             file_dialog_id,
-            FileDialogOptions::new()
-                .title(dialog_title)
-                .filter(FileDialogFilter::new("FIBEX", vec![String::from("xml")])),
+            FileDialogOptions::new().title(dialog_title).filters(vec![
+                FileDialogFilter::new("FIBEX (*.xml)", vec![String::from("xml")]),
+                FileDialogFilter::new("All files (*)", vec![String::from("*")]),
+            ]),
         );
     }
 

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/mod.rs
@@ -208,7 +208,11 @@ impl PresetsUI {
                             IMPORT_PRESETS_DIALOG_ID,
                             FileDialogOptions::new()
                                 .title("Import Presets")
-                                .filters(preset_file_filters()),
+                                .filters(vec![
+                                    FileDialogFilter::new("JSON (*.json)", vec!["json".to_owned()]),
+                                    FileDialogFilter::new("Text (*.txt)", vec!["txt".to_owned()]),
+                                    FileDialogFilter::new("All files (*)", vec!["*".to_owned()]),
+                                ]),
                         );
                     }
                 }
@@ -330,7 +334,10 @@ impl PresetsUI {
                             FileDialogOptions::new()
                                 .title("Export Presets")
                                 .file_name(PRESETS_EXPORT_FILE_NAME)
-                                .filters(preset_file_filters()),
+                                .filters(vec![FileDialogFilter::new(
+                                    "JSON (*.json)",
+                                    vec!["json".to_owned()],
+                                )]),
                         );
                     }
 
@@ -782,10 +789,6 @@ fn move_item<T>(items: &mut Vec<T>, from: usize, to: usize) -> bool {
 fn can_create_preset_from_session(shared: &SessionShared) -> bool {
     // Capture snapshots the full session items, not just enabled ones.
     !shared.filters.filter_entries.is_empty() || !shared.filters.search_value_entries.is_empty()
-}
-
-fn preset_file_filters() -> Vec<FileDialogFilter> {
-    vec![FileDialogFilter::new("JSON", vec!["json".to_owned()])]
 }
 
 impl PresetEditState {

--- a/application/apps/indexer/gui/application/src/session/ui/side_panel/observing/file.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/side_panel/observing/file.rs
@@ -104,19 +104,25 @@ impl FilesObserveUi {
                             FileFormat::PcapNG => (
                                 "Attach PcapNG Files",
                                 vec![FileDialogFilter::new(
-                                    "PcapNG",
+                                    "PcapNG (*.pcapng)",
                                     vec![String::from("pcapng")],
                                 )],
                             ),
                             FileFormat::PcapLegacy => (
                                 "Attach Pcap Files",
-                                vec![FileDialogFilter::new("Pcap", vec![String::from("pcap")])],
+                                vec![FileDialogFilter::new(
+                                    "Pcap (*.pcap)",
+                                    vec![String::from("pcap")],
+                                )],
                             ),
                             FileFormat::Text => ("Attach Files", Vec::new()),
                             FileFormat::Binary => match parser {
                                 ParserNames::Dlt => (
                                     "Attach DLT Files",
-                                    vec![FileDialogFilter::new("DLT", vec![String::from("dlt")])],
+                                    vec![FileDialogFilter::new(
+                                        "DLT (*.dlt)",
+                                        vec![String::from("dlt")],
+                                    )],
                                 ),
                                 ParserNames::SomeIP | ParserNames::Text => {
                                     ("Attach Files", Vec::new())


### PR DESCRIPTION
This PR closes #2544 

It provides:
* Include all file option in file pickers where we expected users to have their files in none standard extension.
* Include the extension in file name to make it clear which file filters are applied.