### PR TITLE
Native: Capture preset from filters side panel

### DIFF
--- a/application/apps/indexer/gui/application/src/host/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/mod.rs
@@ -184,7 +184,12 @@ impl Host {
                 };
 
                 if let Some(restore_state) = restore_state {
-                    session.apply_recent_restore(restore_state, registry, &mut self.ui_actions);
+                    session.apply_recent_restore(
+                        restore_state,
+                        registry,
+                        &mut self.ui_actions,
+                        &mut self.state.panels_visibility,
+                    );
                 }
 
                 let filters = &registry.filters;

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/mod.rs
@@ -62,6 +62,8 @@ pub struct PresetsUI {
     query_visibility: VisibilityTracker,
     edit_state: Option<PresetEditState>,
     export_state: Option<ExportSelectionState>,
+    /// Newly captured preset card that should be brought into view once rendered.
+    scroll_to_preset: Option<Uuid>,
 }
 
 /// Cached name-filter state keyed by the preset catalog revision.
@@ -140,6 +142,7 @@ impl PresetsUI {
             query_visibility: VisibilityTracker::default(),
             edit_state: None,
             export_state: None,
+            scroll_to_preset: None,
         }
     }
 
@@ -176,7 +179,7 @@ impl PresetsUI {
                         .on_hover_text("Add preset from session")
                         .clicked()
                     {
-                        self.create_preset_from_session(shared, registry);
+                        self.capture_preset(shared, registry);
                     }
 
                     let can_export_presets = !registry.presets.presets().is_empty();
@@ -266,7 +269,15 @@ impl PresetsUI {
                         }
 
                         any_visible = true;
-                        self.render_preset_card(preset, registry, ui, &mut pending_action);
+                        let card_response =
+                            self.render_preset_card(preset, registry, ui, &mut pending_action);
+                        if self
+                            .scroll_to_preset
+                            .take_if(|target| *target == preset.id)
+                            .is_some()
+                        {
+                            ui.scroll_to_rect(card_response.rect, Some(Align::BOTTOM));
+                        }
                         ui.add_space(8.0);
                     }
                 });
@@ -694,14 +705,13 @@ impl PresetsUI {
         true
     }
 
-    fn create_preset_from_session(
-        &mut self,
-        shared: &SessionShared,
-        registry: &mut HostRegistry,
-    ) -> Uuid {
-        registry
+    /// Captures the current session filters and charts as a named preset.
+    pub fn capture_preset(&mut self, shared: &SessionShared, registry: &mut HostRegistry) -> Uuid {
+        let preset_id = registry
             .presets
-            .add_preset_from_session(shared, &registry.filters)
+            .add_preset_from_session(shared, &registry.filters);
+        self.scroll_to_preset = Some(preset_id);
+        preset_id
     }
 
     fn apply_preset(
@@ -923,9 +933,10 @@ mod tests {
         let shared = new_shared();
         let mut registry = HostRegistry::default();
 
-        let preset_id = presets.create_preset_from_session(&shared, &mut registry);
+        let preset_id = presets.capture_preset(&shared, &mut registry);
 
         assert!(presets.edit_state.is_none());
+        assert_eq!(presets.scroll_to_preset, Some(preset_id));
         assert!(registry.presets.get(&preset_id).is_some());
     }
 

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/render.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/render.rs
@@ -1,8 +1,8 @@
 //! Preset card rendering for browse and edit modes.
 
 use egui::{
-    Align, Frame, Key, Layout, Margin, RichText, ScrollArea, Sense, Sides, StrokeKind, TextEdit,
-    Ui, UiBuilder, vec2,
+    Align, Frame, Key, Layout, Margin, Response, RichText, ScrollArea, Sense, Sides, StrokeKind,
+    TextEdit, Ui, UiBuilder, vec2,
 };
 
 use super::{
@@ -12,14 +12,14 @@ use super::{
 use crate::common::ui::buttons;
 
 impl PresetsUI {
-    /// Renders a single fixed-size preset card in browse or edit mode.
+    /// Renders a single fixed-size preset card and returns its container response.
     pub(super) fn render_preset_card(
         &mut self,
         preset: &Preset,
         registry: &HostRegistry,
         ui: &mut Ui,
         pending_action: &mut Option<PresetAction>,
-    ) {
+    ) -> Response {
         let is_editing = self.is_editing(preset.id);
         let is_export_selected = self.is_selected_for_export(preset.id);
         ui.allocate_ui_with_layout(
@@ -89,7 +89,8 @@ impl PresetsUI {
                         });
                 });
             },
-        );
+        )
+        .response
     }
 
     /// Renders the export-mode header with a single inclusion checkbox.

--- a/application/apps/indexer/gui/application/src/session/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/mod.rs
@@ -112,7 +112,7 @@ impl Session {
         &mut self,
         actions: &mut UiActions,
         registry: &mut HostRegistry,
-        panels_visibility: &PanelsVisibility,
+        panels_visibility: &mut PanelsVisibility,
         ui: &mut Ui,
     ) {
         let Self {
@@ -177,18 +177,40 @@ impl Session {
         self.attachment_modal
             .render_content(&mut shared.attachments, ui);
 
-        self.handle_signals();
+        self.handle_signals(registry, panels_visibility);
     }
 
-    fn handle_signals(&mut self) {
-        for event in self.shared.signals.drain(..) {
+    /// Processes frame-local signals queued by child session components.
+    fn handle_signals(
+        &mut self,
+        registry: &mut HostRegistry,
+        panels_visibility: &mut PanelsVisibility,
+    ) {
+        let signals = std::mem::take(&mut self.shared.signals);
+        for event in signals {
             match event {
-                SessionSignal::SearchDropped => {
-                    self.bottom_panel.search.table.clear();
-                    self.bottom_panel.chart.reset();
-                }
+                SessionSignal::SearchDropped => self.handle_search_dropped(),
+                SessionSignal::CapturePreset => self.capture_preset(registry, panels_visibility),
             }
         }
+    }
+
+    fn handle_search_dropped(&mut self) {
+        self.bottom_panel.search.table.clear();
+        self.bottom_panel.chart.reset();
+    }
+
+    /// Opens the presets panel and captures the current session filters and charts.
+    fn capture_preset(
+        &mut self,
+        registry: &mut HostRegistry,
+        panels_visibility: &mut PanelsVisibility,
+    ) {
+        panels_visibility.bottom = true;
+        self.shared.bottom_tab = BottomTabType::Presets;
+        self.bottom_panel
+            .presets
+            .capture_preset(&self.shared, registry);
     }
 
     /// Check incoming messages and handle them.
@@ -354,6 +376,7 @@ impl Session {
         restore_state: RecentSessionStateSnapshot,
         registry: &mut HostRegistry,
         actions: &mut UiActions,
+        panels_visibility: &mut PanelsVisibility,
     ) {
         self.recent_session.apply_restore(
             restore_state,
@@ -362,7 +385,7 @@ impl Session {
             &self.cmd_tx,
             &mut registry.filters,
         );
-        self.handle_signals();
+        self.handle_signals(registry, panels_visibility);
     }
 
     /// Captures the canonical recent-session state after restore and establishes the update baseline.

--- a/application/apps/indexer/gui/application/src/session/ui/shared/signal.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/shared/signal.rs
@@ -7,4 +7,6 @@
 pub enum SessionSignal {
     /// Indicates that search has been dropped in last frame.
     SearchDropped,
+    /// Requests capturing the current session filters and charts as a preset.
+    CapturePreset,
 }

--- a/application/apps/indexer/gui/application/src/session/ui/side_panel/filters.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/side_panel/filters.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     session::{
         command::SessionCommand,
-        ui::shared::{SearchSyncTarget, SessionShared},
+        ui::shared::{SearchSyncTarget, SessionShared, SessionSignal},
     },
 };
 
@@ -47,6 +47,8 @@ enum FilterPanelAction {
     ToggleSearchValue(Uuid, bool),
     RemoveSearchValue(Uuid),
     MoveValueToFilter(Uuid),
+    /// Requests the parent session to capture the current filters and charts.
+    CapturePreset,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -337,6 +339,13 @@ impl FiltersUi {
                     *side_action = Some(FilterPanelAction::MoveFilterToValue(row.id));
                     ui.close();
                 }
+
+                ui.separator();
+
+                if ui.button("Create Preset from Session").clicked() {
+                    *side_action = Some(FilterPanelAction::CapturePreset);
+                    ui.close();
+                }
             },
         ) {
             *side_action = Some(action);
@@ -402,6 +411,13 @@ impl FiltersUi {
 
                 if ui.button("Move to Filter").clicked() {
                     *side_action = Some(FilterPanelAction::MoveValueToFilter(row.id));
+                    ui.close();
+                }
+
+                ui.separator();
+
+                if ui.button("Create Preset from Session").clicked() {
+                    *side_action = Some(FilterPanelAction::CapturePreset);
                     ui.close();
                 }
             },
@@ -1068,6 +1084,9 @@ impl FiltersUi {
                         .into_iter()
                         .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
                 }
+            }
+            FilterPanelAction::CapturePreset => {
+                shared.signals.push(SessionSignal::CapturePreset);
             }
         }
     }


### PR DESCRIPTION
This PR closed #2545 

It includes:
* Add context menu to filters side panel to capture the session filters as preset. The command will activate the presets view, create the preset and scroll to it.
* Scroll to created presets is implemented for all code paths.