### PR TITLE
Native: Subfolder for File Explorer & Selection in Recent Sessions & Cleanup + Fixes

### DIFF
--- a/application/apps/indexer/gui/application/src/host/command.rs
+++ b/application/apps/indexer/gui/application/src/host/command.rs
@@ -48,7 +48,7 @@ pub enum HostCommand {
         data: Box<StorageSaveData>,
         confirm_tx: StdSender<Result<(), StorageError>>,
     },
-    /// Scans one or more favorite folders without blocking the UI thread.
+    /// Scans one or more favorite folder trees without blocking the UI thread.
     ScanFavoriteFolders(Box<ScanFavoriteFoldersParam>),
     CloseSessionSetup(Uuid),
     CloseMultiSetup(Uuid),
@@ -87,7 +87,7 @@ pub struct DltStatisticsParam {
 pub struct ScanFavoriteFoldersParam {
     /// Local request identifier echoed back with the scan result.
     pub request_id: u64,
-    /// Favorite-folder paths to scan without recursing into subdirectories.
+    /// Favorite-folder paths to scan recursively.
     pub paths: Vec<PathBuf>,
 }
 

--- a/application/apps/indexer/gui/application/src/host/service/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/service/mod.rs
@@ -95,6 +95,7 @@ impl HostService {
                     storage,
                 };
 
+                Self::spawn_startup_cleanup();
                 release_info::spawn_update_check(host.communication.senders.clone());
                 host.run().await;
             });
@@ -103,6 +104,16 @@ impl HostService {
         handle_rx
             .recv()
             .expect("Receiving startup state should never fail")
+    }
+
+    fn spawn_startup_cleanup() {
+        tokio::task::spawn_blocking(|| {
+            if let Err(errs) = session_core::unbound::cleanup_temp_files() {
+                for err in errs {
+                    log::error!("Error while cleaning up temporary files. Error: {err:?}");
+                }
+            }
+        });
     }
 
     async fn run(mut self) {

--- a/application/apps/indexer/gui/application/src/host/service/storage/file_explorer.rs
+++ b/application/apps/indexer/gui/application/src/host/service/storage/file_explorer.rs
@@ -11,14 +11,14 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
 use super::storage_path;
-use crate::host::{
-    common::file_utls,
-    ui::storage::{
-        FavoriteFolder, FileExplorerData, FileUiInfo, StorageError, StorageErrorKind, StorageEvent,
-    },
+use crate::host::ui::storage::{
+    FavoriteFolder, FileExplorerData, FileTreeNode, FileTreeNodeKind, StorageError,
+    StorageErrorKind, StorageEvent,
 };
 
 const FILE_EXPLORER_FILE: &str = "file_explorer.json";
+const FAVORITE_SCAN_MAX_DEPTH: usize = 5;
+pub const FAVORITE_SCAN_MAX_ENTRIES: usize = 20_000;
 
 /// Path-only file-explorer schema stored on disk.
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -45,9 +45,8 @@ pub fn spawn_load(event_tx: mpsc::Sender<StorageEvent>) {
 
         match result {
             Ok(data) => {
-                let data = FileExplorerData {
-                    favorite_folders: scan_favorite_folders(&data.favorite_folders),
-                };
+                let favorite_folders = scan_favorite_folders(&data.favorite_folders, &event_tx);
+                let data = FileExplorerData { favorite_folders };
                 _ = event_tx.blocking_send(StorageEvent::FileExplorerLoaded(Ok(Box::new(data))));
             }
             Err(err) => {
@@ -94,9 +93,46 @@ fn load(path: &Path) -> Result<PersistedFileExplorerData, StorageError> {
     })
 }
 
-/// Scans the provided favorite folders and returns runtime file snapshots.
-pub fn scan_favorite_folders(paths: &[PathBuf]) -> Vec<FavoriteFolder> {
-    paths.iter().map(|p| scan_folder(p)).collect()
+/// Scans the provided favorite folders and returns runtime tree snapshots.
+pub fn scan_favorite_folders(
+    paths: &[PathBuf],
+    event_tx: &mpsc::Sender<StorageEvent>,
+) -> Vec<FavoriteFolder> {
+    scan_favorite_folders_with_limit(paths, FAVORITE_SCAN_MAX_ENTRIES, event_tx)
+}
+
+fn scan_favorite_folders_with_limit(
+    paths: &[PathBuf],
+    max_entries: usize,
+    event_tx: &mpsc::Sender<StorageEvent>,
+) -> Vec<FavoriteFolder> {
+    let mut favorite_folders = Vec::with_capacity(paths.len());
+    let mut limited_folder_names = Vec::new();
+
+    for path in paths {
+        let mut remaining_entries = max_entries;
+        favorite_folders.push(scan_folder(path, &mut remaining_entries));
+        if remaining_entries == 0 {
+            limited_folder_names.push(
+                path.file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| path.to_string_lossy().into_owned()),
+            );
+        }
+    }
+
+    if !limited_folder_names.is_empty()
+        && event_tx
+            .blocking_send(StorageEvent::FavoriteFolderLimitReached {
+                folder_names: limited_folder_names,
+                max_entries_count: max_entries,
+            })
+            .is_err()
+    {
+        warn!("Failed to send favorite-folder scan limit warning");
+    }
+
+    favorite_folders
 }
 
 /// Persists the file-explorer domain to its storage file.
@@ -124,20 +160,53 @@ fn get_path() -> Result<PathBuf, StorageError> {
     storage_path().map(|storage_dir| storage_dir.join(FILE_EXPLORER_FILE))
 }
 
-/// Scans one favorite folder without recursing into subdirectories.
-fn scan_folder(path: &Path) -> FavoriteFolder {
+fn scan_folder(path: &Path, remaining_entries: &mut usize) -> FavoriteFolder {
     let mut folder = FavoriteFolder::new(path.to_owned());
+
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) => {
+            warn!(
+                "Failed to read metadata for favorite folder {}: {err}",
+                path.display()
+            );
+            return folder;
+        }
+    };
+
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return folder;
+    }
+
+    folder.children = scan_children(path, 0, remaining_entries);
+    folder
+}
+
+fn scan_children(
+    path: &Path,
+    parent_depth: usize,
+    remaining_entries: &mut usize,
+) -> Vec<FileTreeNode> {
+    if *remaining_entries == 0 {
+        return Vec::new();
+    }
 
     let entries = match std::fs::read_dir(path) {
         Ok(entries) => entries,
         Err(err) => {
             warn!("Failed to scan favorite folder {}: {err}", path.display());
-
-            return folder;
+            return Vec::new();
         }
     };
 
+    let child_depth = parent_depth + 1;
+    let mut children = Vec::new();
+
     for entry in entries {
+        if *remaining_entries == 0 {
+            break;
+        }
+
         let entry = match entry {
             Ok(entry) => entry,
             Err(err) => {
@@ -149,60 +218,97 @@ fn scan_folder(path: &Path) -> FavoriteFolder {
             }
         };
 
-        let metadata = match entry.metadata() {
+        let entry_path = entry.path();
+        let metadata = match std::fs::symlink_metadata(&entry_path) {
             Ok(metadata) => metadata,
             Err(err) => {
                 warn!(
                     "Failed to read metadata for {} while scanning favorite folder {}: {err}",
-                    entry.path().display(),
+                    entry_path.display(),
                     path.display()
                 );
                 continue;
             }
         };
 
-        if metadata.file_type().is_symlink() || !metadata.is_file() {
+        let file_type = metadata.file_type();
+        if file_type.is_symlink() {
             continue;
         }
 
-        let file_name = entry.file_name().display().to_string();
-        if file_name.starts_with('.') {
+        let kind = if file_type.is_dir() {
+            if child_depth >= FAVORITE_SCAN_MAX_DEPTH {
+                continue;
+            }
+            *remaining_entries -= 1;
+            FileTreeNodeKind::Folder(scan_children(&entry_path, child_depth, remaining_entries))
+        } else if file_type.is_file() {
+            if child_depth > FAVORITE_SCAN_MAX_DEPTH {
+                continue;
+            }
+            *remaining_entries -= 1;
+            FileTreeNodeKind::File
+        } else {
             continue;
-        }
+        };
 
-        folder.files.push(FileUiInfo::new(
-            file_name,
-            file_utls::format_file_size(metadata.len()),
-        ));
+        children.push(FileTreeNode {
+            path: entry_path,
+            name: entry.file_name().to_string_lossy().into_owned(),
+            kind,
+        });
     }
 
-    folder
+    sort_tree_nodes(&mut children);
+    children
+}
+
+fn sort_tree_nodes(nodes: &mut [FileTreeNode]) {
+    nodes.sort_unstable_by(|left, right| {
+        tree_node_kind_rank(&left.kind)
+            .cmp(&tree_node_kind_rank(&right.kind))
+            .then_with(|| left.name.cmp(&right.name))
+    });
+}
+
+fn tree_node_kind_rank(kind: &FileTreeNodeKind) -> u8 {
+    match kind {
+        FileTreeNodeKind::Folder(_) => 0,
+        FileTreeNodeKind::File => 1,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::{
         fs,
-        os::unix::fs::symlink,
         path::{Path, PathBuf},
+        sync::atomic::{AtomicU64, Ordering},
         time::{SystemTime, UNIX_EPOCH},
     };
 
+    use tokio::sync::mpsc;
+
     use crate::host::service::storage::storage_path_from_home;
     use crate::host::ui::storage::{
-        FavoriteFolder, FileExplorerData, StorageError, StorageErrorKind,
+        FavoriteFolder, FileExplorerData, FileTreeNode, FileTreeNodeKind, StorageError,
+        StorageErrorKind, StorageEvent,
     };
 
     use super::{
-        FILE_EXPLORER_FILE, PersistedFileExplorerData, load, save_to_path, scan_favorite_folders,
+        FAVORITE_SCAN_MAX_ENTRIES, FILE_EXPLORER_FILE, PersistedFileExplorerData, load,
+        save_to_path, scan_favorite_folders_with_limit,
     };
+
+    static NEXT_TEST_DIR_ID: AtomicU64 = AtomicU64::new(0);
 
     fn test_home_dir() -> PathBuf {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system time must be after unix epoch")
             .as_nanos();
-        let path = std::env::temp_dir().join(format!("chipmunk-file-explorer-test-{unique}"));
+        let id = NEXT_TEST_DIR_ID.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!("chipmunk-file-explorer-test-{unique}-{id}"));
         fs::create_dir_all(&path).expect("temp test home dir should be created");
         path
     }
@@ -216,6 +322,41 @@ mod tests {
         PersistedFileExplorerData {
             favorite_folders: paths.to_vec(),
         }
+    }
+
+    fn file_node(path: PathBuf, name: &str) -> FileTreeNode {
+        FileTreeNode {
+            path,
+            name: name.into(),
+            kind: FileTreeNodeKind::File,
+        }
+    }
+
+    fn child_names(nodes: &[FileTreeNode]) -> Vec<&str> {
+        nodes.iter().map(|node| node.name.as_str()).collect()
+    }
+
+    fn folder_children<'a>(nodes: &'a [FileTreeNode], name: &str) -> &'a [FileTreeNode] {
+        let node = nodes
+            .iter()
+            .find(|node| node.name == name)
+            .unwrap_or_else(|| panic!("folder {name} should exist"));
+
+        let FileTreeNodeKind::Folder(children) = &node.kind else {
+            panic!("{name} should be a folder");
+        };
+
+        children
+    }
+
+    fn scan(paths: &[PathBuf]) -> Vec<FavoriteFolder> {
+        let (event_tx, _event_rx) = mpsc::channel(1);
+        scan_favorite_folders_with_limit(paths, FAVORITE_SCAN_MAX_ENTRIES, &event_tx)
+    }
+
+    fn scan_with_limit(paths: &[PathBuf], max_entries: usize) -> Vec<FavoriteFolder> {
+        let (event_tx, _event_rx) = mpsc::channel(1);
+        scan_favorite_folders_with_limit(paths, max_entries, &event_tx)
     }
 
     #[test]
@@ -242,18 +383,16 @@ mod tests {
     }
 
     #[test]
-    fn save_skips_scanned_files() {
+    fn save_skips_scanned_tree() {
         let home_dir = test_home_dir();
         let path = path_from_home(&home_dir).expect("path should resolve");
         let mut runtime = FileExplorerData {
             favorite_folders: vec![FavoriteFolder::new(PathBuf::from("/tmp/favorites"))],
         };
-        runtime.favorite_folders[0]
-            .files
-            .push(crate::host::ui::storage::FileUiInfo::new(
-                "visible.log".into(),
-                "1 B".into(),
-            ));
+        runtime.favorite_folders[0].children.push(file_node(
+            PathBuf::from("/tmp/favorites/visible.log"),
+            "visible.log",
+        ));
 
         save_to_path(&path, &PersistedFileExplorerData::from(&runtime))
             .expect("save should succeed");
@@ -287,35 +426,149 @@ mod tests {
     }
 
     #[test]
-    fn scan_filters_entries() {
+    fn scan_includes_nested_content_and_hidden_files() {
         let dir = test_home_dir();
-        let visible = dir.join("visible.log");
-        let hidden = dir.join(".hidden.log");
         let nested_dir = dir.join("nested");
-        let symlink_path = dir.join("linked.log");
-
-        fs::write(&visible, "hello").expect("visible file should be written");
-        fs::write(&hidden, "secret").expect("hidden file should be written");
         fs::create_dir(&nested_dir).expect("nested dir should be created");
-        symlink(&visible, &symlink_path).expect("symlink should be created");
+        fs::write(dir.join("visible.log"), "hello").expect("visible file should be written");
+        fs::write(dir.join(".hidden.log"), "secret").expect("hidden file should be written");
+        fs::write(nested_dir.join("nested.log"), "nested").expect("nested file should be written");
 
-        let scanned = scan_favorite_folders(std::slice::from_ref(&dir));
+        let scanned = scan(std::slice::from_ref(&dir));
 
         assert_eq!(scanned.len(), 1);
         assert_eq!(scanned[0].path, dir);
-        assert_eq!(scanned[0].files.len(), 1);
-        assert_eq!(scanned[0].files[0].name, "visible.log");
+        assert_eq!(
+            child_names(&scanned[0].children),
+            vec!["nested", ".hidden.log", "visible.log"]
+        );
+        assert_eq!(
+            child_names(folder_children(&scanned[0].children, "nested")),
+            vec!["nested.log"]
+        );
+
+        let _ = fs::remove_dir_all(scanned[0].path.clone());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scan_skips_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let dir = test_home_dir();
+        let visible = dir.join("visible.log");
+        let symlink_path = dir.join("linked.log");
+
+        fs::write(&visible, "hello").expect("visible file should be written");
+        symlink(&visible, &symlink_path).expect("symlink should be created");
+
+        let scanned = scan(std::slice::from_ref(&dir));
+
+        assert_eq!(child_names(&scanned[0].children), vec!["visible.log"]);
+
+        let _ = fs::remove_dir_all(scanned[0].path.clone());
+    }
+
+    #[test]
+    fn scan_applies_limit_per_root() {
+        let first = test_home_dir();
+        let second = test_home_dir();
+        let counted_folder = first.join("counted_folder");
+        fs::create_dir(&counted_folder).expect("folder should be created");
+        fs::write(counted_folder.join("nested.log"), "nested")
+            .expect("nested file should be written");
+        fs::write(second.join("second.log"), "second").expect("second file should be written");
+
+        let scanned = scan_with_limit(&[first.clone(), second.clone()], 1);
+
+        assert_eq!(child_names(&scanned[0].children), vec!["counted_folder"]);
+        assert!(folder_children(&scanned[0].children, "counted_folder").is_empty());
+        assert_eq!(child_names(&scanned[1].children), vec!["second.log"]);
+
+        let _ = fs::remove_dir_all(first);
+        let _ = fs::remove_dir_all(second);
+    }
+
+    #[test]
+    fn scan_limit_sends_one_warning_with_folder_names() {
+        let first = test_home_dir();
+        let second = test_home_dir();
+        fs::write(first.join("first.log"), "first").expect("first file should be written");
+        fs::write(second.join("second.log"), "second").expect("second file should be written");
+
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        let scanned =
+            scan_favorite_folders_with_limit(&[first.clone(), second.clone()], 1, &event_tx);
+
+        assert_eq!(child_names(&scanned[0].children), vec!["first.log"]);
+        assert_eq!(child_names(&scanned[1].children), vec!["second.log"]);
+        assert!(matches!(
+            event_rx.try_recv(),
+            Ok(StorageEvent::FavoriteFolderLimitReached {
+                folder_names,
+                max_entries_count: 1,
+            }) if folder_names == vec![
+                first.file_name().unwrap().to_string_lossy().into_owned(),
+                second.file_name().unwrap().to_string_lossy().into_owned(),
+            ]
+        ));
+        assert!(event_rx.try_recv().is_err());
+
+        let _ = fs::remove_dir_all(first);
+        let _ = fs::remove_dir_all(second);
+    }
+
+    #[test]
+    fn scan_sorts_folders_before_files_by_name() {
+        let dir = test_home_dir();
+        fs::create_dir(dir.join("b_folder")).expect("folder should be created");
+        fs::create_dir(dir.join("a_folder")).expect("folder should be created");
+        fs::write(dir.join("b.log"), "b").expect("file should be written");
+        fs::write(dir.join("a.log"), "a").expect("file should be written");
+
+        let scanned = scan(std::slice::from_ref(&dir));
+
+        assert_eq!(
+            child_names(&scanned[0].children),
+            vec!["a_folder", "b_folder", "a.log", "b.log"]
+        );
 
         let _ = fs::remove_dir_all(scanned[0].path.clone());
     }
 
     #[test]
     fn missing_folder_returns_empty_snapshot() {
-        let missing = std::env::temp_dir().join("chipmunk-missing-favorite-folder");
-        let scanned = scan_favorite_folders(std::slice::from_ref(&missing));
+        let home_dir = test_home_dir();
+        let missing = home_dir.join("missing");
+        let scanned = scan(std::slice::from_ref(&missing));
 
         assert_eq!(scanned.len(), 1);
         assert_eq!(scanned[0].path, missing);
-        assert!(scanned[0].files.is_empty());
+        assert!(scanned[0].children.is_empty());
+
+        let _ = fs::remove_dir_all(home_dir);
+    }
+
+    #[test]
+    fn folders_at_max_depth_are_not_shown_as_empty() {
+        let dir = test_home_dir();
+        let d1 = dir.join("d1");
+        let d2 = d1.join("d2");
+        let d3 = d2.join("d3");
+        let d4 = d3.join("d4");
+        let d5 = d4.join("d5");
+        fs::create_dir_all(&d5).expect("deep folders should be created");
+        fs::write(d4.join("depth5.log"), "depth 5").expect("depth 5 file should be written");
+        fs::write(d5.join("too-deep.log"), "too deep").expect("too deep file should be written");
+
+        let scanned = scan(std::slice::from_ref(&dir));
+        let d1_children = folder_children(&scanned[0].children, "d1");
+        let d2_children = folder_children(d1_children, "d2");
+        let d3_children = folder_children(d2_children, "d3");
+        let d4_children = folder_children(d3_children, "d4");
+
+        assert_eq!(child_names(d4_children), vec!["depth5.log"]);
+
+        let _ = fs::remove_dir_all(scanned[0].path.clone());
     }
 }

--- a/application/apps/indexer/gui/application/src/host/service/storage/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/service/storage/mod.rs
@@ -56,11 +56,11 @@ impl StorageService {
         let event_tx = self.event_tx.clone();
 
         tokio::task::spawn_blocking(move || {
-            let result = file_explorer::scan_favorite_folders(&paths);
+            let favorite_folders = file_explorer::scan_favorite_folders(&paths, &event_tx);
 
             let event = StorageEvent::FavoriteFoldersScanned {
                 request_id,
-                result: Ok(result),
+                result: Ok(favorite_folders),
             };
 
             if event_tx.blocking_send(event).is_err() {

--- a/application/apps/indexer/gui/application/src/host/service/storage/recent.rs
+++ b/application/apps/indexer/gui/application/src/host/service/storage/recent.rs
@@ -170,11 +170,11 @@ fn normalize_recent_sessions(sessions: &mut Vec<RecentSessionSnapshot>) -> bool 
 fn sanitize_recent_sessions(sessions: &mut Vec<RecentSessionSnapshot>) -> bool {
     let initial_len = sessions.len();
 
-    sessions.retain(|session| match validate_source_snapshot(session) {
+    sessions.retain(|session| match session.validate() {
         Ok(()) => true,
-        Err(err) => {
+        Err(message) => {
             warn!(
-                "Removed invalid recent session \"{}\" ({}): {err}",
+                "Removed invalid recent session \"{}\" ({}): {message}",
                 session.title(),
                 session.source_key
             );
@@ -205,31 +205,6 @@ fn trim_recent_sessions(sessions: &mut Vec<RecentSessionSnapshot>) -> bool {
     }
 
     changed
-}
-
-fn validate_source_snapshot(session: &RecentSessionSnapshot) -> std::io::Result<()> {
-    if session.sources().is_empty() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "Recent session has no sources",
-        ));
-    }
-
-    for source in session.sources() {
-        match source {
-            RecentSessionSource::File { path, .. } => {
-                if !path.exists() {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::NotFound,
-                        format!("File not found: {}", path.display()),
-                    ));
-                }
-            }
-            RecentSessionSource::Stream { .. } => {}
-        }
-    }
-
-    Ok(())
 }
 
 /// Persists the current recent-sessions snapshot to its storage file.
@@ -345,39 +320,6 @@ mod tests {
         let mut session = stream_snapshot(bind_addr.into());
         session.last_opened = last_opened;
         session
-    }
-
-    #[test]
-    fn validate_accepts_existing_file() {
-        let dir = test_home_dir();
-        let path = dir.join("valid.log");
-        fs::write(&path, "test").expect("test file should be written");
-        let session = file_snapshot(path);
-
-        let result = validate_source_snapshot(&session);
-
-        assert!(result.is_ok());
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn validate_rejects_missing_file() {
-        let dir = test_home_dir();
-        let session = file_snapshot(dir.join("missing.log"));
-
-        let result = validate_source_snapshot(&session);
-
-        assert!(matches!(result, Err(err) if err.kind() == std::io::ErrorKind::NotFound));
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn validate_accepts_stream_snapshot() {
-        let session = stream_snapshot("127.0.0.1:5555");
-
-        let result = validate_source_snapshot(&session);
-
-        assert!(result.is_ok());
     }
 
     #[test]

--- a/application/apps/indexer/gui/application/src/host/ui/home/file_explorer.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/file_explorer.rs
@@ -3,7 +3,7 @@
 //! This module renders the home-screen file explorer, manages its transient UI
 //! state, and bridges user actions to the host/storage layers.
 
-use std::path::Path;
+use std::{hash::Hash, ops::Not, path::PathBuf};
 
 use egui::{Align, Layout, TextStyle};
 use egui::{
@@ -19,27 +19,48 @@ use crate::host::{
     ui::{
         UiActions,
         actions::FileDialogOptions,
-        storage::{FavoriteFoldersScanRequest, FileExplorerStorage, FileUiInfo, LoadState},
+        storage::{
+            FavoriteFolder, FavoriteFoldersScanRequest, FileExplorerStorage, FileTreeNode,
+            FileTreeNodeKind, LoadState,
+        },
     },
 };
 
 const FAVORITES_FOLDER_ID: &str = "favorites_folder";
-const TEXT_EDIT_HEIGHT: f32 = 25.0;
+const CONTROL_ROW_HEIGHT: f32 = 25.0;
 
+/// Home-screen favorite-folder tree UI state and command bridge.
 #[derive(Debug)]
 pub struct FileExplorerUi {
-    favorite_search: String,
-    favorite_search_matcher: SubstringMatcher,
+    /// Host command channel used for file opens and favorite-folder scans.
     cmd_tx: Sender<HostCommand>,
+    /// Current favorite-file search text entered by the user.
+    search_query: String,
+    /// Reusable matcher compiled from `search_query` when the query changes.
+    search_matcher: SubstringMatcher,
+    /// Filtered favorite-tree snapshot derived from the latest storage revision.
+    search_cache: FavoriteSearchCache,
+}
+
+/// Cached favorite-file search results and their invalidation keys.
+#[derive(Debug, Default)]
+struct FavoriteSearchCache {
+    /// Search text used to build `roots`.
+    query: String,
+    /// File-explorer storage revision used to build `roots`.
+    revision: u64,
+    /// Filtered favorite roots for the cached query and revision.
+    roots: Option<Vec<FavoriteFolder>>,
 }
 
 impl FileExplorerUi {
     /// Creates the home-screen file-explorer UI controller.
     pub fn new(cmd_tx: Sender<HostCommand>) -> Self {
         Self {
-            favorite_search: String::new(),
-            favorite_search_matcher: SubstringMatcher::default(),
             cmd_tx,
+            search_query: String::new(),
+            search_matcher: SubstringMatcher::default(),
+            search_cache: FavoriteSearchCache::default(),
         }
     }
 
@@ -59,19 +80,36 @@ impl FileExplorerUi {
             .truncate()
             .ui(ui);
 
-        if let Some(paths) = actions.file_dialog.take_output(FAVORITES_FOLDER_ID) {
-            let paths = paths
+        if let Some(selected_paths) = actions.file_dialog.take_output(FAVORITES_FOLDER_ID) {
+            let new_paths: Vec<PathBuf> = selected_paths
                 .into_iter()
                 .filter(|path| !file_explorer.contains_favorite_folder(path))
                 .collect();
 
-            if let Some(request) = file_explorer.prepare_add_scan(paths) {
-                self.send_favorite_folder_scan(actions, file_explorer, request);
+            if !new_paths.is_empty() {
+                let mut scan_paths = match &file_explorer.state {
+                    LoadState::Ready(data) => data
+                        .favorite_folders
+                        .iter()
+                        .map(|folder| folder.path.clone())
+                        .collect(),
+                    LoadState::Loading => Vec::new(),
+                };
+
+                for path in new_paths {
+                    if !scan_paths.iter().any(|existing| existing == &path) {
+                        scan_paths.push(path);
+                    }
+                }
+
+                if let Some(request) = file_explorer.prepare_add_scan(scan_paths) {
+                    self.send_favorite_folder_scan(actions, file_explorer, request);
+                }
             }
         }
 
         ui.allocate_ui_with_layout(
-            vec2(ui.available_width(), TEXT_EDIT_HEIGHT),
+            vec2(ui.available_width(), CONTROL_ROW_HEIGHT),
             Layout::right_to_left(Align::Center),
             |ui| {
                 let icon_size = 15.0;
@@ -120,25 +158,21 @@ impl FileExplorerUi {
                     }
                 }
 
-                ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
-                    let txt_input = sized_singleline_text_edit(
-                        ui,
-                        &mut self.favorite_search,
-                        vec2(ui.available_width(), TEXT_EDIT_HEIGHT),
-                        7,
-                    )
-                    .hint_text("Type to filter...");
+                let search_response = sized_singleline_text_edit(
+                    ui,
+                    &mut self.search_query,
+                    vec2(ui.available_width(), CONTROL_ROW_HEIGHT),
+                    7,
+                )
+                .hint_text("Search files")
+                .ui(ui);
 
-                    let response = ui.add_enabled(!busy, txt_input);
-                    if response.changed() {
-                        self.favorite_search_matcher
-                            .build_query(&self.favorite_search);
-                    }
-                });
+                if search_response.changed() {
+                    self.search_matcher.build_query(&self.search_query);
+                    self.search_cache.roots = None;
+                }
             },
         );
-
-        let has_search_filter = self.favorite_search_matcher.has_query();
 
         ui.add_space(2.0);
 
@@ -151,6 +185,8 @@ impl FileExplorerUi {
             });
             ui.add_space(6.0);
         }
+
+        self.refresh_search_cache(file_explorer);
 
         egui::ScrollArea::vertical()
             .id_salt("favorite_folders_scroll")
@@ -165,85 +201,29 @@ impl FileExplorerUi {
                     return;
                 };
 
-                let expand = if has_search_filter { Some(true) } else { None };
+                let search_active = !self.search_query.is_empty();
 
                 let mut remove_path = None;
 
-                for folder in &data.favorite_folders {
-                    let folder_id = ui.make_persistent_id(("favorite_folder", &folder.path));
-                    let mut folder_state =
-                        CollapsingState::load_with_default_open(ui.ctx(), folder_id, false);
+                let favorite_folders = if search_active {
+                    self.search_cache.roots.as_deref().unwrap_or(&[])
+                } else {
+                    data.favorite_folders.as_slice()
+                };
 
-                    if let Some(open) = expand {
-                        folder_state.set_open(open);
-                    }
+                if search_active && favorite_folders.is_empty() {
+                    ui.label("No favorite files match the current search.");
+                }
 
-                    let (rect, mut header_response) = ui.allocate_exact_size(
-                        vec2(ui.available_width(), ui.spacing().interact_size.y),
-                        Sense::click(),
+                for folder in favorite_folders {
+                    self.render_favorite_folder(
+                        ui,
+                        actions,
+                        folder,
+                        busy,
+                        search_active,
+                        &mut remove_path,
                     );
-
-                    if header_response.clicked() {
-                        folder_state.toggle(ui);
-                        header_response.mark_changed();
-                    }
-
-                    let visuals = ui.style().interact_selectable(&header_response, false);
-                    let text_color = visuals.text_color();
-                    let icon = if folder_state.is_open() {
-                        icons::regular::CARET_DOWN
-                    } else {
-                        icons::regular::CARET_RIGHT
-                    };
-
-                    ui.scope_builder(
-                        UiBuilder::new()
-                            .max_rect(rect.shrink2(ui.spacing().button_padding))
-                            .layout(Layout::left_to_right(Align::Center)),
-                        |ui| {
-                            ui.style_mut().spacing.item_spacing.x = 4.0;
-                            ui.label(RichText::new(icon).size(14.0).color(text_color));
-                            let folder_label = truncate_path_to_width(
-                                ui,
-                                &folder.path,
-                                ui.available_width(),
-                                TextStyle::Body,
-                            );
-                            let response =
-                                Label::new(RichText::new(&folder_label.text).color(text_color))
-                                    .truncate()
-                                    .show_tooltip_when_elided(false)
-                                    .ui(ui);
-                            if folder_label.truncated {
-                                response.on_hover_ui(|ui| {
-                                    ui.set_max_width(ui.spacing().tooltip_width);
-                                    ui.label(folder.path.to_string_lossy());
-                                });
-                            }
-                        },
-                    );
-
-                    header_response.context_menu(|ui| {
-                        if ui
-                            .add_enabled(!busy, Button::new("Remove from favorite folders"))
-                            .clicked()
-                        {
-                            remove_path = Some(folder.path.clone());
-                            ui.close();
-                        }
-                    });
-
-                    folder_state.show_body_indented(&header_response, ui, |ui| {
-                        for file in &folder.files {
-                            if has_search_filter
-                                && !self.favorite_search_matcher.matches(file.name.as_str())
-                            {
-                                continue;
-                            }
-
-                            self.render_file_entry(ui, actions, &folder.path, file, busy);
-                        }
-                    });
                 }
 
                 if let Some(path) = remove_path {
@@ -252,12 +232,116 @@ impl FileExplorerUi {
             });
     }
 
+    fn render_favorite_folder(
+        &self,
+        ui: &mut Ui,
+        actions: &mut UiActions,
+        folder: &FavoriteFolder,
+        busy: bool,
+        force_expanded: bool,
+        remove_path: &mut Option<PathBuf>,
+    ) {
+        let (header_response, mut folder_state) = render_folder_header(
+            ui,
+            ("favorite_folder", &folder.path),
+            force_expanded,
+            |ui, text_color| {
+                let folder_label =
+                    truncate_path_to_width(ui, &folder.path, ui.available_width(), TextStyle::Body);
+                let response = Label::new(RichText::new(&folder_label.text).color(text_color))
+                    .truncate()
+                    .show_tooltip_when_elided(false)
+                    .ui(ui);
+                if folder_label.truncated {
+                    response.on_hover_ui(|ui| {
+                        ui.set_max_width(ui.spacing().tooltip_width);
+                        ui.label(folder.path.to_string_lossy());
+                    });
+                }
+            },
+        );
+
+        header_response.context_menu(|ui| {
+            if ui
+                .add_enabled(!busy, Button::new("Remove from favorite folders"))
+                .clicked()
+            {
+                *remove_path = Some(folder.path.clone());
+                ui.close();
+            }
+        });
+
+        if force_expanded {
+            ui.indent(("favorite_folder_search_body", &folder.path), |ui| {
+                self.render_tree_nodes(ui, actions, &folder.children, busy, force_expanded);
+            });
+        } else if let Some(folder_state) = &mut folder_state {
+            folder_state.show_body_indented(&header_response, ui, |ui| {
+                self.render_tree_nodes(ui, actions, &folder.children, busy, force_expanded);
+            });
+        }
+    }
+
+    fn render_tree_nodes(
+        &self,
+        ui: &mut Ui,
+        actions: &mut UiActions,
+        nodes: &[FileTreeNode],
+        busy: bool,
+        force_expanded: bool,
+    ) {
+        for node in nodes {
+            match &node.kind {
+                FileTreeNodeKind::Folder(children) => {
+                    self.render_folder_node(ui, actions, node, children, busy, force_expanded);
+                }
+                FileTreeNodeKind::File => {
+                    self.render_file_entry(ui, actions, node, busy);
+                }
+            }
+        }
+    }
+
+    fn render_folder_node(
+        &self,
+        ui: &mut Ui,
+        actions: &mut UiActions,
+        node: &FileTreeNode,
+        children: &[FileTreeNode],
+        busy: bool,
+        force_expanded: bool,
+    ) {
+        let (header_response, mut folder_state) = render_folder_header(
+            ui,
+            ("favorite_tree_folder", &node.path),
+            force_expanded,
+            |ui, text_color| {
+                let response = Label::new(RichText::new(node.name.as_str()).color(text_color))
+                    .truncate()
+                    .ui(ui);
+                response.on_hover_ui(|ui| {
+                    ui.set_max_width(ui.spacing().tooltip_width);
+                    ui.label(node.path.to_string_lossy());
+                });
+            },
+        );
+
+        if force_expanded {
+            ui.indent(("favorite_tree_folder_search_body", &node.path), |ui| {
+                self.render_tree_nodes(ui, actions, children, busy, force_expanded);
+            });
+        } else if let Some(folder_state) = &mut folder_state {
+            folder_state.show_body_indented(&header_response, ui, |ui| {
+                self.render_tree_nodes(ui, actions, children, busy, force_expanded);
+            });
+        }
+    }
+
     fn render_file_entry(
         &self,
         ui: &mut Ui,
         actions: &mut UiActions,
-        folder_path: &Path,
-        file: &FileUiInfo,
+        node: &FileTreeNode,
         busy: bool,
     ) -> Response {
         const ROW_HEIGHT: f32 = 24.0;
@@ -265,7 +349,7 @@ impl FileExplorerUi {
         const VERTICAL_PADDING: f32 = 4.0;
 
         let sense = if busy { Sense::hover() } else { Sense::click() };
-        let (rect, mut response) =
+        let (rect, response) =
             ui.allocate_exact_size(vec2(ui.available_width(), ROW_HEIGHT), sense);
 
         if response.hovered() || response.is_pointer_button_down_on() {
@@ -275,26 +359,28 @@ impl FileExplorerUi {
 
         let inner_rect = rect.shrink2(vec2(HORIZONTAL_PADDING, VERTICAL_PADDING));
         ui.scope_builder(UiBuilder::new().max_rect(inner_rect), |ui| {
-            Label::new(file.name.as_str()).truncate().ui(ui);
+            Label::new(node.name.as_str()).truncate().ui(ui);
         });
 
-        response = if busy {
-            response.on_hover_text(&file.name)
-        } else {
+        let response = if busy {
             response
-                .on_hover_cursor(egui::CursorIcon::PointingHand)
-                .on_hover_text(&file.name)
+        } else {
+            response.on_hover_cursor(egui::CursorIcon::PointingHand)
         };
+        let response = response.on_hover_ui(|ui| {
+            ui.set_max_width(ui.spacing().tooltip_width);
+            ui.label(node.path.to_string_lossy());
+        });
 
         response.context_menu(|ui| {
             if ui.add_enabled(!busy, Button::new("Open File")).clicked() {
-                self.open_favorite_file(actions, folder_path.join(&file.name));
+                self.open_favorite_file(actions, node.path.clone());
                 ui.close();
             }
         });
 
         if !busy && response.clicked() {
-            self.open_favorite_file(actions, folder_path.join(&file.name));
+            self.open_favorite_file(actions, node.path.clone());
         }
 
         response
@@ -318,9 +404,133 @@ impl FileExplorerUi {
         }
     }
 
-    fn open_favorite_file(&self, actions: &mut UiActions, path: std::path::PathBuf) {
+    fn open_favorite_file(&self, actions: &mut UiActions, path: PathBuf) {
         actions.try_send_command(&self.cmd_tx, HostCommand::OpenFiles(vec![path]));
     }
+
+    /// Refreshes the cached favorite-file search result when its invalidation keys change.
+    ///
+    /// Empty search text clears the cache. Non-empty searches rebuild only when the query or
+    /// `FileExplorerStorage::revision` differs from the cached values.
+    fn refresh_search_cache(&mut self, file_explorer: &FileExplorerStorage) {
+        if self.search_query.is_empty() {
+            self.search_cache.roots = None;
+            return;
+        }
+
+        if self.search_cache.roots.is_some()
+            && self.search_cache.query == self.search_query
+            && self.search_cache.revision == file_explorer.revision
+        {
+            return;
+        }
+
+        self.search_matcher.build_query(&self.search_query);
+        let roots = match &file_explorer.state {
+            LoadState::Ready(data) => {
+                filter_favorite_folders(&data.favorite_folders, &mut self.search_matcher)
+            }
+            LoadState::Loading => Vec::new(),
+        };
+
+        self.search_cache.query.clone_from(&self.search_query);
+        self.search_cache.revision = file_explorer.revision;
+        self.search_cache.roots = Some(roots);
+    }
+}
+
+/// Renders a favorite-tree folder header row.
+///
+/// The returned response is the clickable header row. The returned collapsing
+/// state is `None` when `force_expanded` is true, because search results are
+/// rendered expanded without mutating normal egui expansion state.
+///
+/// # Arguments
+///
+/// * `ui` - Target egui UI.
+/// * `id_salt` - Stable id salt for the persisted folder expansion state.
+/// * `force_expanded` - Whether to render the folder as open without loading or updating persisted expansion state.
+/// * `render_label` - Renders the caller-specific label after the caret icon, using the provided text color.
+fn render_folder_header(
+    ui: &mut Ui,
+    id_salt: impl Hash,
+    force_expanded: bool,
+    render_label: impl FnOnce(&mut Ui, egui::Color32),
+) -> (Response, Option<CollapsingState>) {
+    let folder_id = ui.make_persistent_id(id_salt);
+    let mut folder_state = force_expanded
+        .not()
+        .then(|| CollapsingState::load_with_default_open(ui.ctx(), folder_id, false));
+
+    let (rect, mut header_response) = ui.allocate_exact_size(
+        vec2(ui.available_width(), ui.spacing().interact_size.y),
+        Sense::click(),
+    );
+
+    if header_response.clicked()
+        && let Some(folder_state) = &mut folder_state
+    {
+        folder_state.toggle(ui);
+        header_response.mark_changed();
+    }
+
+    let visuals = ui.style().interact_selectable(&header_response, false);
+    let text_color = visuals.text_color();
+    let icon = if force_expanded
+        || folder_state
+            .as_ref()
+            .is_some_and(|folder_state| folder_state.is_open())
+    {
+        icons::regular::CARET_DOWN
+    } else {
+        icons::regular::CARET_RIGHT
+    };
+
+    ui.scope_builder(
+        UiBuilder::new()
+            .max_rect(rect.shrink2(ui.spacing().button_padding))
+            .layout(Layout::left_to_right(Align::Center)),
+        |ui| {
+            ui.style_mut().spacing.item_spacing.x = 4.0;
+            ui.label(RichText::new(icon).size(14.0).color(text_color));
+            render_label(ui, text_color);
+        },
+    );
+
+    (header_response, folder_state)
+}
+
+fn filter_favorite_folders(
+    favorite_folders: &[FavoriteFolder],
+    matcher: &mut SubstringMatcher,
+) -> Vec<FavoriteFolder> {
+    favorite_folders
+        .iter()
+        .filter_map(|folder| {
+            let children = filter_tree_nodes(&folder.children, matcher);
+            children.is_empty().not().then(|| FavoriteFolder {
+                path: folder.path.clone(),
+                children,
+            })
+        })
+        .collect()
+}
+
+fn filter_tree_nodes(nodes: &[FileTreeNode], matcher: &mut SubstringMatcher) -> Vec<FileTreeNode> {
+    nodes
+        .iter()
+        .filter_map(|node| match &node.kind {
+            FileTreeNodeKind::Folder(children) => {
+                let children = filter_tree_nodes(children, matcher);
+                children.is_empty().not().then(|| FileTreeNode {
+                    path: node.path.clone(),
+                    name: node.name.clone(),
+                    kind: FileTreeNodeKind::Folder(children),
+                })
+            }
+            FileTreeNodeKind::File => matcher.matches(node.name.as_str()).then(|| node.clone()),
+        })
+        .collect()
 }
 
 fn favorite_folders_busy_label(file_explorer: &FileExplorerStorage) -> Option<&'static str> {
@@ -330,5 +540,161 @@ fn favorite_folders_busy_label(file_explorer: &FileExplorerStorage) -> Option<&'
         Some("Scanning favorite folders")
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{
+        FavoriteFolder, FileExplorerUi, FileTreeNode, FileTreeNodeKind, LoadState,
+        filter_favorite_folders,
+    };
+    use crate::{
+        common::ui::substring_matcher::SubstringMatcher,
+        host::ui::storage::{FileExplorerData, FileExplorerStorage},
+    };
+
+    fn build_matcher(query: &str) -> SubstringMatcher {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query(query);
+        matcher
+    }
+
+    fn file_node(path: &str, name: &str) -> FileTreeNode {
+        FileTreeNode {
+            path: PathBuf::from(path),
+            name: name.into(),
+            kind: FileTreeNodeKind::File,
+        }
+    }
+
+    fn folder_node(path: &str, name: &str, children: Vec<FileTreeNode>) -> FileTreeNode {
+        FileTreeNode {
+            path: PathBuf::from(path),
+            name: name.into(),
+            kind: FileTreeNodeKind::Folder(children),
+        }
+    }
+
+    fn favorite_folder(path: &str, children: Vec<FileTreeNode>) -> FavoriteFolder {
+        FavoriteFolder {
+            path: PathBuf::from(path),
+            children,
+        }
+    }
+
+    fn child_names(nodes: &[FileTreeNode]) -> Vec<&str> {
+        nodes.iter().map(|node| node.name.as_str()).collect()
+    }
+
+    fn folder_children<'a>(nodes: &'a [FileTreeNode], name: &str) -> &'a [FileTreeNode] {
+        let node = nodes
+            .iter()
+            .find(|node| node.name == name)
+            .unwrap_or_else(|| panic!("folder {name} should exist"));
+
+        let FileTreeNodeKind::Folder(children) = &node.kind else {
+            panic!("{name} should be a folder");
+        };
+
+        children
+    }
+
+    fn file_explorer_ui(query: &str) -> FileExplorerUi {
+        let (cmd_tx, _cmd_rx) = tokio::sync::mpsc::channel(1);
+        let mut ui = FileExplorerUi::new(cmd_tx);
+        ui.search_query = query.into();
+        ui.search_matcher.build_query(query);
+        ui
+    }
+
+    fn storage_with(favorite_folders: Vec<FavoriteFolder>, revision: u64) -> FileExplorerStorage {
+        let mut storage = FileExplorerStorage::new();
+        storage.state = LoadState::Ready(FileExplorerData { favorite_folders });
+        storage.revision = revision;
+        storage
+    }
+
+    #[test]
+    fn search_keeps_matching_file_ancestors_and_omits_siblings() {
+        let root = favorite_folder(
+            "/root",
+            vec![
+                folder_node(
+                    "/root/logs",
+                    "logs",
+                    vec![
+                        file_node("/root/logs/target.log", "target.log"),
+                        file_node("/root/logs/other.log", "other.log"),
+                    ],
+                ),
+                folder_node(
+                    "/root/target-folder",
+                    "target-folder",
+                    vec![file_node("/root/target-folder/other.log", "other.log")],
+                ),
+                file_node("/root/top.log", "top.log"),
+            ],
+        );
+
+        let filtered = filter_favorite_folders(&[root], &mut build_matcher("target"));
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(child_names(&filtered[0].children), vec!["logs"]);
+        assert_eq!(
+            child_names(folder_children(&filtered[0].children, "logs")),
+            vec!["target.log"]
+        );
+    }
+
+    #[test]
+    fn search_omits_roots_without_matching_files() {
+        let root = favorite_folder(
+            "/root",
+            vec![folder_node(
+                "/root/target-folder",
+                "target-folder",
+                vec![file_node("/root/target-folder/other.log", "other.log")],
+            )],
+        );
+
+        let filtered = filter_favorite_folders(&[root], &mut build_matcher("target"));
+
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn search_cache_rebuilds_when_revision_changes() {
+        let mut ui = file_explorer_ui("target");
+        let mut storage = storage_with(
+            vec![favorite_folder(
+                "/root",
+                vec![file_node("/root/old.log", "old.log")],
+            )],
+            1,
+        );
+
+        ui.refresh_search_cache(&storage);
+        assert!(ui.search_cache.roots.as_ref().is_some_and(Vec::is_empty));
+
+        storage.state = LoadState::Ready(FileExplorerData {
+            favorite_folders: vec![favorite_folder(
+                "/root",
+                vec![file_node("/root/target.log", "target.log")],
+            )],
+        });
+        storage.revision = 2;
+
+        ui.refresh_search_cache(&storage);
+
+        let roots = ui
+            .search_cache
+            .roots
+            .as_ref()
+            .expect("search cache should be populated");
+        assert_eq!(ui.search_cache.revision, 2);
+        assert_eq!(child_names(&roots[0].children), vec!["target.log"]);
     }
 }

--- a/application/apps/indexer/gui/application/src/host/ui/home/recent.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/recent.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use egui::{Align, Layout, Ui, Widget, vec2};
+use egui::{Align, Key, Layout, Modifiers, Response, Ui, Widget, vec2};
 use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
 
@@ -20,7 +20,7 @@ use crate::{
         ui::{
             UiActions,
             recent_session::{
-                RecentSessionRowAction, RecentSessionRowOptions, render_recent_session_row,
+                RecentSessionRowAction, RecentSessionRowParams, render_recent_session_row,
             },
             storage::{RecentSessionReopenMode, RecentSessionSnapshot, RecentSessionsStorage},
         },
@@ -36,6 +36,11 @@ pub struct RecentSessionsUi {
     visibility_tracker: VisibilityTracker,
     /// Arbitrary value to avoid persisting scroll state after app restart.
     scroll_salt: Uuid,
+    /// Source key of the recent session selected by keyboard navigation.
+    selected_source_key: Option<Arc<str>>,
+    /// True for one frame after keyboard navigation should reveal the selected row.
+    scroll_selected_into_view: bool,
+    /// Invalid-session prompt currently awaiting user confirmation.
     pending_invalid_session: Option<InvalidRecentPrompt>,
 }
 
@@ -44,6 +49,12 @@ pub struct RecentSessionsUi {
 struct InvalidRecentPrompt {
     source_key: Arc<str>,
     message: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SelectionDirection {
+    Previous,
+    Next,
 }
 
 impl RecentSessionsUi {
@@ -55,6 +66,8 @@ impl RecentSessionsUi {
             cmd_tx,
             visibility_tracker: VisibilityTracker::default(),
             scroll_salt: Uuid::new_v4(),
+            selected_source_key: None,
+            scroll_selected_into_view: false,
             pending_invalid_session: None,
         }
     }
@@ -83,6 +96,23 @@ impl RecentSessionsUi {
             self.matcher.build_query(self.query.trim());
         }
 
+        if query_changed {
+            self.refresh_selection(recent_sessions, true);
+            self.scroll_selected_into_view = self.selected_source_key.is_some();
+        } else if focus_filter && self.selected_source_key.is_none() {
+            // Seed selection on first focus so Enter opens the top recent session immediately.
+            self.refresh_selection(recent_sessions, false);
+        }
+
+        let filter_has_focus = query_response.has_focus();
+        self.handle_filter_keys(
+            actions,
+            recent_sessions,
+            ui,
+            &query_response,
+            filter_has_focus,
+        );
+
         ui.add_space(4.0);
 
         egui::ScrollArea::vertical()
@@ -105,11 +135,15 @@ impl RecentSessionsUi {
 
                         any_visible = true;
 
-                        const OPTIONS: RecentSessionRowOptions = RecentSessionRowOptions {
+                        let selected = self.session_is_selected(session);
+                        let params = RecentSessionRowParams {
                             show_clean_open: true,
+                            selected,
+                            selection_active: filter_has_focus,
+                            scroll_to_row: selected && self.scroll_selected_into_view,
                         };
 
-                        if let Some(action) = render_recent_session_row(ui, session, &OPTIONS) {
+                        if let Some(action) = render_recent_session_row(ui, session, &params) {
                             self.apply_row_action(actions, session, action, &mut remove_session);
                         }
                         ui.add_space(4.0);
@@ -124,10 +158,138 @@ impl RecentSessionsUi {
 
                 if let Some(source_key) = remove_session {
                     recent_sessions.remove_session(&source_key);
+                    self.refresh_selection(recent_sessions, false);
                 }
             });
+        self.scroll_selected_into_view = false;
 
         self.render_invalid_session_modal(recent_sessions, ui);
+    }
+
+    fn refresh_selection(
+        &mut self,
+        recent_sessions: &RecentSessionsStorage,
+        force_first_match: bool,
+    ) {
+        let mut first_visible = None;
+
+        for session in &recent_sessions.sessions {
+            if !matches_recent_session_query(&mut self.matcher, session) {
+                continue;
+            }
+
+            if force_first_match {
+                self.selected_source_key = Some(session.source_key.clone());
+                return;
+            }
+
+            if self.session_is_selected(session) {
+                return;
+            }
+            first_visible.get_or_insert_with(|| session.source_key.clone());
+        }
+
+        self.selected_source_key = first_visible;
+    }
+
+    fn handle_filter_keys(
+        &mut self,
+        actions: &mut UiActions,
+        recent_sessions: &RecentSessionsStorage,
+        ui: &mut Ui,
+        query_response: &Response,
+        filter_has_focus: bool,
+    ) {
+        if filter_has_focus {
+            let select_direction = ui.input_mut(|input| {
+                if input.consume_key(Modifiers::NONE, Key::ArrowDown)
+                    || input.consume_key(Modifiers::CTRL, Key::N)
+                {
+                    return Some(SelectionDirection::Next);
+                }
+
+                if input.consume_key(Modifiers::NONE, Key::ArrowUp)
+                    || input.consume_key(Modifiers::CTRL, Key::P)
+                {
+                    return Some(SelectionDirection::Previous);
+                }
+
+                None
+            });
+
+            if let Some(direction) = select_direction {
+                self.move_selection(recent_sessions, direction);
+            }
+        }
+
+        let filter_submitted =
+            query_response.lost_focus() && ui.input(|input| input.key_pressed(Key::Enter));
+        let should_restore = filter_submitted
+            || (filter_has_focus
+                && ui.input_mut(|input| input.consume_key(Modifiers::NONE, Key::Enter)));
+        if should_restore {
+            self.open_selected_session(actions, recent_sessions);
+        }
+    }
+
+    fn move_selection(
+        &mut self,
+        recent_sessions: &RecentSessionsStorage,
+        direction: SelectionDirection,
+    ) {
+        let source_keys: Vec<_> = recent_sessions
+            .sessions
+            .iter()
+            .filter(|session| matches_recent_session_query(&mut self.matcher, session))
+            .map(|session| &session.source_key)
+            .collect();
+        if source_keys.is_empty() {
+            self.selected_source_key = None;
+            return;
+        }
+
+        let current_index = self.selected_source_key.as_ref().and_then(|selected| {
+            source_keys
+                .iter()
+                .position(|&source_key| source_key.as_ref() == selected.as_ref())
+        });
+
+        let next_index = match direction {
+            SelectionDirection::Previous => current_index
+                .map(|index| index.checked_sub(1).unwrap_or(source_keys.len() - 1))
+                .unwrap_or(source_keys.len() - 1),
+            SelectionDirection::Next => current_index
+                .map(|index| (index + 1) % source_keys.len())
+                .unwrap_or(0),
+        };
+
+        self.selected_source_key = Some(Arc::clone(source_keys[next_index]));
+        self.scroll_selected_into_view = true;
+    }
+
+    fn open_selected_session(
+        &mut self,
+        actions: &mut UiActions,
+        recent_sessions: &RecentSessionsStorage,
+    ) {
+        let Some(selected_source_key) = self.selected_source_key.clone() else {
+            return;
+        };
+        let Some(session) = recent_sessions
+            .sessions
+            .iter()
+            .find(|session| session.source_key.as_ref() == selected_source_key.as_ref())
+        else {
+            return;
+        };
+
+        self.open_recent_session(actions, session, RecentSessionReopenMode::RestoreSession);
+    }
+
+    fn session_is_selected(&self, session: &RecentSessionSnapshot) -> bool {
+        self.selected_source_key
+            .as_ref()
+            .is_some_and(|source_key| source_key.as_ref() == session.source_key.as_ref())
     }
 
     fn apply_row_action(
@@ -223,6 +385,7 @@ impl RecentSessionsUi {
 
         if remove_session {
             recent_sessions.remove_session(&source_key);
+            self.refresh_selection(recent_sessions, false);
         }
 
         if remove_session || modal.should_close() {
@@ -244,10 +407,10 @@ mod tests {
 
     use stypes::{FileFormat, ParserType, TCPTransportConfig, Transport};
 
-    use super::matches_recent_session_query;
+    use super::{RecentSessionsUi, SelectionDirection, matches_recent_session_query};
     use crate::{
         common::ui::substring_matcher::SubstringMatcher,
-        host::ui::storage::{RecentSessionSnapshot, RecentSessionSource},
+        host::ui::storage::{RecentSessionSnapshot, RecentSessionSource, RecentSessionsStorage},
     };
 
     fn file_session(path: &str, parser: ParserType) -> RecentSessionSnapshot {
@@ -279,6 +442,17 @@ mod tests {
         let mut matcher = SubstringMatcher::default();
         matcher.build_query(query.trim());
         matcher
+    }
+
+    fn recent_ui() -> RecentSessionsUi {
+        let (cmd_tx, _cmd_rx) = tokio::sync::mpsc::channel(1);
+        RecentSessionsUi::new(cmd_tx)
+    }
+
+    fn storage_with(sessions: Vec<RecentSessionSnapshot>) -> RecentSessionsStorage {
+        let mut storage = RecentSessionsStorage::default();
+        storage.sessions = sessions;
+        storage
     }
 
     #[test]
@@ -333,5 +507,45 @@ mod tests {
             &mut build_matcher("/logs"),
             &session
         ));
+    }
+
+    #[test]
+    fn query_change_selects_first_visible_session() {
+        let alpha = file_session("alpha.log", ParserType::Text(()));
+        let beta = file_session("beta.log", ParserType::Text(()));
+        let storage = storage_with(vec![beta.clone(), alpha.clone()]);
+        let mut recent_ui = recent_ui();
+        recent_ui.selected_source_key = Some(alpha.source_key.clone());
+        recent_ui.matcher.build_query("log");
+
+        recent_ui.refresh_selection(&storage, true);
+
+        assert_eq!(
+            recent_ui.selected_source_key.as_deref(),
+            Some(beta.source_key.as_ref())
+        );
+    }
+
+    #[test]
+    fn keyboard_selection_wraps_through_visible_sessions() {
+        let alpha = file_session("visible-alpha.log", ParserType::Text(()));
+        let hidden = file_session("hidden.log", ParserType::Text(()));
+        let beta = file_session("visible-beta.log", ParserType::Text(()));
+        let storage = storage_with(vec![alpha.clone(), hidden, beta.clone()]);
+        let mut recent_ui = recent_ui();
+        recent_ui.matcher.build_query("visible");
+        recent_ui.refresh_selection(&storage, true);
+
+        recent_ui.move_selection(&storage, SelectionDirection::Previous);
+        assert_eq!(
+            recent_ui.selected_source_key.as_deref(),
+            Some(beta.source_key.as_ref())
+        );
+
+        recent_ui.move_selection(&storage, SelectionDirection::Next);
+        assert_eq!(
+            recent_ui.selected_source_key.as_deref(),
+            Some(alpha.source_key.as_ref())
+        );
     }
 }

--- a/application/apps/indexer/gui/application/src/host/ui/home/recent.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/recent.rs
@@ -3,12 +3,17 @@
 //! This module renders the recent-sessions panel and forwards reopen actions to
 //! the host service.
 
-use egui::{Ui, Widget, vec2};
+use std::sync::Arc;
+
+use egui::{Align, Layout, Ui, Widget, vec2};
 use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
 
 use crate::{
-    common::ui::{substring_matcher::SubstringMatcher, visibility_tracker::VisibilityTracker},
+    common::{
+        modal::{ModalSize, show_modal},
+        ui::{buttons, substring_matcher::SubstringMatcher, visibility_tracker::VisibilityTracker},
+    },
     host::{
         command::{HostCommand, OpenRecentSessionParam},
         common::ui_utls::sized_singleline_text_edit,
@@ -31,6 +36,14 @@ pub struct RecentSessionsUi {
     visibility_tracker: VisibilityTracker,
     /// Arbitrary value to avoid persisting scroll state after app restart.
     scroll_salt: Uuid,
+    pending_invalid_session: Option<InvalidRecentPrompt>,
+}
+
+/// Pending validation failure shown before a recent session is removed.
+#[derive(Debug)]
+struct InvalidRecentPrompt {
+    source_key: Arc<str>,
+    message: String,
 }
 
 impl RecentSessionsUi {
@@ -42,6 +55,7 @@ impl RecentSessionsUi {
             cmd_tx,
             visibility_tracker: VisibilityTracker::default(),
             scroll_salt: Uuid::new_v4(),
+            pending_invalid_session: None,
         }
     }
 
@@ -112,14 +126,16 @@ impl RecentSessionsUi {
                     recent_sessions.remove_session(&source_key);
                 }
             });
+
+        self.render_invalid_session_modal(recent_sessions, ui);
     }
 
     fn apply_row_action(
-        &self,
+        &mut self,
         actions: &mut UiActions,
         session: &RecentSessionSnapshot,
         action: RecentSessionRowAction,
-        remove_session: &mut Option<std::sync::Arc<str>>,
+        remove_session: &mut Option<Arc<str>>,
     ) {
         match action {
             RecentSessionRowAction::RestoreSession => {
@@ -142,17 +158,76 @@ impl RecentSessionsUi {
     }
 
     fn open_recent_session(
-        &self,
+        &mut self,
         actions: &mut UiActions,
         snapshot: &RecentSessionSnapshot,
         mode: RecentSessionReopenMode,
     ) {
+        if let Err(message) = snapshot.validate() {
+            self.pending_invalid_session = Some(InvalidRecentPrompt {
+                source_key: snapshot.source_key.clone(),
+                message,
+            });
+            return;
+        }
+
         let cmd = HostCommand::OpenRecentSession(Box::new(OpenRecentSessionParam {
             snapshot: snapshot.clone(),
             mode,
             session_setup_id: None,
         }));
         actions.try_send_command(&self.cmd_tx, cmd);
+    }
+
+    fn render_invalid_session_modal(
+        &mut self,
+        recent_sessions: &mut RecentSessionsStorage,
+        ui: &mut Ui,
+    ) {
+        let Some(prompt) = &self.pending_invalid_session else {
+            return;
+        };
+
+        let source_key = prompt.source_key.clone();
+        let message = prompt.message.clone();
+        let mut remove_session = false;
+
+        let modal = show_modal(
+            ui,
+            "invalid_recent_session",
+            ModalSize::MaxWidth(530.0),
+            |ui, _size| {
+                ui.vertical_centered(|ui| {
+                    ui.heading("Unable to open recent session");
+                });
+
+                ui.add_space(8.0);
+                ui.label(message.as_str());
+                ui.add_space(12.0);
+
+                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                    if ui.add(buttons::command("Cancel", None)).clicked() {
+                        ui.close();
+                    }
+
+                    if ui
+                        .add(buttons::command("Remove recent session", Some(150.0)))
+                        .clicked()
+                    {
+                        remove_session = true;
+                        ui.close();
+                    }
+                });
+            },
+        );
+
+        if remove_session {
+            recent_sessions.remove_session(&source_key);
+        }
+
+        if remove_session || modal.should_close() {
+            self.pending_invalid_session = None;
+        }
     }
 }
 

--- a/application/apps/indexer/gui/application/src/host/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/mod.rs
@@ -187,7 +187,6 @@ impl Host {
                     session.apply_recent_restore(
                         restore_state,
                         registry,
-                        &mut self.ui_actions,
                         &mut self.state.panels_visibility,
                     );
                 }
@@ -487,11 +486,11 @@ impl eframe::App for Host {
 
         storage.poll_pending_save(ui_actions);
 
-        let filters = &self.state.registry.filters;
-        self.state
-            .sessions
-            .iter_mut()
-            .for_each(|(_id, session)| session.handle_messages(ui_actions, storage, filters));
+        let registry = &mut self.state.registry;
+        let panels_visibility = &mut self.state.panels_visibility;
+        for session in self.state.sessions.values_mut() {
+            session.handle_messages(ui_actions, storage, registry, panels_visibility);
+        }
 
         self.handle_recent_sessions();
     }

--- a/application/apps/indexer/gui/application/src/host/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/mod.rs
@@ -184,11 +184,7 @@ impl Host {
                 };
 
                 if let Some(restore_state) = restore_state {
-                    session.apply_recent_restore(
-                        restore_state,
-                        registry,
-                        &mut self.state.panels_visibility,
-                    );
+                    session.apply_recent_restore(restore_state, registry);
                 }
 
                 if let Some(recent_registration) = recent_registration {
@@ -486,10 +482,11 @@ impl eframe::App for Host {
 
         storage.poll_pending_save(ui_actions);
 
-        let registry = &mut self.state.registry;
-        let panels_visibility = &mut self.state.panels_visibility;
-        for session in self.state.sessions.values_mut() {
-            session.handle_messages(ui_actions, storage, registry, panels_visibility);
+        let HostState {
+            sessions, registry, ..
+        } = &mut self.state;
+        for session in sessions.values_mut() {
+            session.handle_messages(ui_actions, storage, registry);
         }
 
         self.handle_recent_sessions();

--- a/application/apps/indexer/gui/application/src/host/ui/recent_session.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/recent_session.rs
@@ -21,29 +21,50 @@ pub enum RecentSessionRowAction {
     Remove,
 }
 
-/// Row-level feature flags for one recent-session entry.
+/// Render parameters for one recent-session entry.
 #[derive(Debug, Clone, Default)]
-pub struct RecentSessionRowOptions {
+pub struct RecentSessionRowParams {
     /// Enables the clean-open button and menu action for surfaces that support it.
     pub show_clean_open: bool,
+    /// Marks this row as the current keyboard selection.
+    pub selected: bool,
+    /// Uses the active selection highlight when keyboard control is focused here.
+    pub selection_active: bool,
+    /// Scrolls the selected row into view after keyboard navigation.
+    pub scroll_to_row: bool,
 }
 
 /// Renders one recent-session row and returns the user action triggered on it.
 pub fn render_recent_session_row(
     ui: &mut Ui,
     session: &RecentSessionSnapshot,
-    options: &RecentSessionRowOptions,
+    params: &RecentSessionRowParams,
 ) -> Option<RecentSessionRowAction> {
     let (rect, response) =
         ui.allocate_exact_size(vec2(ui.available_width(), ROW_HEIGHT), Sense::click());
     let mut action = None;
 
     let response = response.on_hover_cursor(egui::CursorIcon::PointingHand);
-    response.context_menu(|ui| render_row_menu(ui, session, options, &mut action));
+    response.context_menu(|ui| render_row_menu(ui, session, params, &mut action));
 
-    if response.hovered() {
-        ui.painter()
-            .rect_filled(rect, 0.0, ui.visuals().widgets.hovered.bg_fill);
+    let background = if params.selected {
+        Some(if params.selection_active {
+            ui.visuals().selection.bg_fill
+        } else {
+            ui.visuals().selection.bg_fill.gamma_multiply(0.45)
+        })
+    } else if response.hovered() {
+        Some(ui.visuals().widgets.hovered.bg_fill)
+    } else {
+        None
+    };
+
+    if let Some(background) = background {
+        ui.painter().rect_filled(rect, 0.0, background);
+    }
+
+    if params.scroll_to_row {
+        response.scroll_to_me(Some(Align::Center));
     }
 
     let content_rect = rect.shrink2(vec2(CONTENT_PADDING_X, CONTENT_PADDING_Y));
@@ -77,7 +98,7 @@ pub fn render_recent_session_row(
                         ui.label(session.tooltip());
                     });
                 },
-                |ui| render_row_actions(ui, session, options, &mut action),
+                |ui| render_row_actions(ui, session, params, &mut action),
             );
     });
 
@@ -91,7 +112,7 @@ pub fn render_recent_session_row(
 fn render_row_actions(
     ui: &mut Ui,
     session: &RecentSessionSnapshot,
-    options: &RecentSessionRowOptions,
+    params: &RecentSessionRowParams,
     action: &mut Option<RecentSessionRowAction>,
 ) {
     ui.horizontal_centered(|ui| {
@@ -113,7 +134,7 @@ fn render_row_actions(
             *action = Some(RecentSessionRowAction::RestoreParserConfiguration);
         }
 
-        if options.show_clean_open {
+        if params.show_clean_open {
             let clean_open = ui
                 .add_enabled(
                     session.supports_clean_open(),
@@ -134,7 +155,7 @@ fn render_row_actions(
 fn render_row_menu(
     ui: &mut Ui,
     session: &RecentSessionSnapshot,
-    options: &RecentSessionRowOptions,
+    params: &RecentSessionRowParams,
     action: &mut Option<RecentSessionRowAction>,
 ) {
     if ui.button("Restore session").clicked() {
@@ -145,7 +166,7 @@ fn render_row_menu(
         *action = Some(RecentSessionRowAction::RestoreParserConfiguration);
     }
 
-    if options.show_clean_open
+    if params.show_clean_open
         && session.supports_clean_open()
         && ui.button("Open without saved state").clicked()
     {

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/mod.rs
@@ -97,10 +97,11 @@ fn render_files(
     ui: &mut Ui,
 ) -> RenderOutcome {
     match parser {
-        ParserConfig::Dlt(dlt) => dlt::render_statistics(dlt, ui),
-        ParserConfig::SomeIP(..) | ParserConfig::Text | ParserConfig::Plugins => {
-            RenderOutcome::None
-        }
+        ParserConfig::Dlt(dlt) if dlt.with_storage_header => dlt::render_statistics(dlt, ui),
+        ParserConfig::Dlt(..)
+        | ParserConfig::SomeIP(..)
+        | ParserConfig::Text
+        | ParserConfig::Plugins => RenderOutcome::None,
     }
 }
 

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/recent.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/recent.rs
@@ -10,7 +10,7 @@ use crate::host::{
     ui::{
         UiActions,
         recent_session::{
-            RecentSessionRowAction, RecentSessionRowOptions, render_recent_session_row,
+            RecentSessionRowAction, RecentSessionRowParams, render_recent_session_row,
         },
         storage::{RecentSessionReopenMode, RecentSessionSnapshot, RecentSessionsStorage},
     },
@@ -37,11 +37,14 @@ pub fn render_matching_recent_sessions(
 
         has_matches = true;
 
-        const OPTIONS: RecentSessionRowOptions = RecentSessionRowOptions {
+        const PARAMS: RecentSessionRowParams = RecentSessionRowParams {
             show_clean_open: false,
+            selected: false,
+            selection_active: false,
+            scroll_to_row: false,
         };
 
-        let render_action = render_recent_session_row(ui, session, &OPTIONS);
+        let render_action = render_recent_session_row(ui, session, &PARAMS);
         if let Some(action) = render_action {
             match action {
                 RecentSessionRowAction::RestoreSession => {

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/recent.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/main_config/recent.rs
@@ -6,6 +6,7 @@ use tokio::sync::mpsc::Sender;
 use crate::host::{
     command::{HostCommand, OpenRecentSessionParam},
     common::{parsers::ParserNames, sources::StreamNames},
+    notification::AppNotification,
     ui::{
         UiActions,
         recent_session::{
@@ -91,6 +92,11 @@ fn open_recent_session(
     mode: RecentSessionReopenMode,
     session_setup_id: Option<uuid::Uuid>,
 ) {
+    if let Err(message) = snapshot.validate() {
+        actions.add_notification(AppNotification::Error(message));
+        return;
+    }
+
     let cmd = HostCommand::OpenRecentSession(Box::new(OpenRecentSessionParam {
         snapshot,
         mode,

--- a/application/apps/indexer/gui/application/src/host/ui/storage/file_explorer.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/storage/file_explorer.rs
@@ -9,6 +9,9 @@ use super::{LoadState, SaveOutcome, StorageError};
 pub struct FileExplorerStorage {
     /// Current loaded file-explorer snapshot.
     pub state: LoadState<FileExplorerData>,
+    /// Monotonic revision for runtime tree data changes.
+    /// This is used to keep file storage and their search cache in sync.
+    pub revision: u64,
     /// True when the favorite-folder path list still needs to be saved.
     dirty: bool,
     next_scan_request_id: u64,
@@ -24,22 +27,33 @@ pub struct FileExplorerData {
     pub favorite_folders: Vec<FavoriteFolder>,
 }
 
-/// One favorite folder and its currently scanned top-level files.
-#[derive(Debug, Clone)]
+/// One favorite folder and its currently scanned tree children.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FavoriteFolder {
     /// Directory path saved as a favorite.
     pub path: PathBuf,
-    /// Runtime-only file list rebuilt by scanning the directory.
-    pub files: Vec<FileUiInfo>,
+    /// Runtime-only tree rebuilt by scanning the directory.
+    pub children: Vec<FileTreeNode>,
 }
 
-/// File row data rendered under a favorite folder.
+/// Runtime file-tree node rendered under a favorite folder.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FileUiInfo {
-    /// File name shown in the UI.
+pub struct FileTreeNode {
+    /// Absolute path to the file-system entry.
+    pub path: PathBuf,
+    /// File or folder name shown in the UI.
     pub name: String,
-    /// Preformatted human-readable size text.
-    pub size_txt: String,
+    /// Entry kind and nested folder contents.
+    pub kind: FileTreeNodeKind,
+}
+
+/// Runtime file-tree node kind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileTreeNodeKind {
+    /// Folder children from the latest scan snapshot.
+    Folder(Vec<FileTreeNode>),
+    /// Regular file.
+    File,
 }
 
 /// Prepared scan request for favorite folders.
@@ -56,6 +70,7 @@ impl FileExplorerStorage {
     pub fn new() -> Self {
         Self {
             state: LoadState::Loading,
+            revision: 0,
             dirty: false,
             next_scan_request_id: 1,
             active_scan_request_id: None,
@@ -74,7 +89,7 @@ impl FileExplorerStorage {
             .any(|folder| folder.path == path)
     }
 
-    /// Returns the current snapshot only when the domain is ready and dirty.
+    /// Returns the path-only save snapshot when the domain is ready and dirty.
     pub fn get_save_data(&self) -> Option<FileExplorerData> {
         if !self.dirty {
             return None;
@@ -84,7 +99,13 @@ impl FileExplorerStorage {
             return None;
         };
 
-        Some(data.clone())
+        Some(FileExplorerData {
+            favorite_folders: data
+                .favorite_folders
+                .iter()
+                .map(|folder| FavoriteFolder::new(folder.path.clone()))
+                .collect(),
+        })
     }
 
     /// Applies a load result, falling back to the default ready state on error.
@@ -105,6 +126,7 @@ impl FileExplorerStorage {
         self.dirty = false;
         self.active_scan_request_id = None;
         self.active_scan_marks_dirty = false;
+        self.bump_revision();
 
         err
     }
@@ -165,8 +187,11 @@ impl FileExplorerStorage {
                     return None;
                 };
 
-                upsert_favorite_folders(&mut data.favorite_folders, scanned_folders);
+                let changed = upsert_favorite_folders(&mut data.favorite_folders, scanned_folders);
                 sort_favorite_folders(&mut data.favorite_folders);
+                if changed {
+                    self.bump_revision();
+                }
                 self.dirty |= mark_dirty;
                 None
             }
@@ -182,7 +207,11 @@ impl FileExplorerStorage {
 
         let initial_len = data.favorite_folders.len();
         data.favorite_folders.retain(|folder| folder.path != path);
-        self.dirty |= data.favorite_folders.len() != initial_len;
+        let removed = data.favorite_folders.len() != initial_len;
+        if removed {
+            self.dirty = true;
+            self.bump_revision();
+        }
     }
 
     pub(super) fn apply_save_outcome(&mut self, outcome: SaveOutcome) {
@@ -191,6 +220,10 @@ impl FileExplorerStorage {
             SaveOutcome::Failed => true,
         };
     }
+
+    fn bump_revision(&mut self) {
+        self.revision = self.revision.wrapping_add(1);
+    }
 }
 
 impl FavoriteFolder {
@@ -198,32 +231,33 @@ impl FavoriteFolder {
     pub fn new(path: PathBuf) -> Self {
         Self {
             path,
-            files: Vec::new(),
+            children: Vec::new(),
         }
-    }
-}
-
-impl FileUiInfo {
-    /// Creates one rendered file entry.
-    pub fn new(name: String, size_txt: String) -> Self {
-        Self { name, size_txt }
     }
 }
 
 fn upsert_favorite_folders(
     favorite_folders: &mut Vec<FavoriteFolder>,
     scanned: Vec<FavoriteFolder>,
-) {
+) -> bool {
+    let mut changed = false;
+
     for folder in scanned {
         if let Some(existing) = favorite_folders
             .iter_mut()
             .find(|existing| existing.path == folder.path)
         {
-            *existing = folder;
+            if *existing != folder {
+                *existing = folder;
+                changed = true;
+            }
         } else {
             favorite_folders.push(folder);
+            changed = true;
         }
     }
+
+    changed
 }
 
 fn sort_favorite_folders(favorite_folders: &mut [FavoriteFolder]) {
@@ -235,7 +269,8 @@ mod tests {
     use std::path::{Path, PathBuf};
 
     use super::{
-        FavoriteFolder, FileExplorerData, FileExplorerStorage, FileUiInfo, LoadState, StorageError,
+        FavoriteFolder, FileExplorerData, FileExplorerStorage, FileTreeNode, FileTreeNodeKind,
+        LoadState, StorageError,
     };
     use crate::host::ui::storage::StorageErrorKind;
 
@@ -244,12 +279,22 @@ mod tests {
     }
 
     fn folder(path: &str, file_names: &[&str]) -> FavoriteFolder {
+        let path = PathBuf::from(path);
+
         FavoriteFolder {
-            path: PathBuf::from(path),
-            files: file_names
+            path: path.clone(),
+            children: file_names
                 .iter()
-                .map(|name| FileUiInfo::new((*name).into(), "1 B".into()))
+                .map(|name| file_node(path.join(name), name))
                 .collect(),
+        }
+    }
+
+    fn file_node(path: PathBuf, name: &str) -> FileTreeNode {
+        FileTreeNode {
+            path,
+            name: name.into(),
+            kind: FileTreeNodeKind::File,
         }
     }
 
@@ -263,6 +308,7 @@ mod tests {
 
         assert!(error.is_none());
         assert!(!storage.dirty);
+        assert_eq!(storage.revision, 1);
         assert!(matches!(
             storage.state,
             LoadState::Ready(FileExplorerData { favorite_folders })
@@ -287,6 +333,7 @@ mod tests {
                 ..
             })
         ));
+        assert_eq!(storage.revision, 1);
         assert!(matches!(
             storage.state,
             LoadState::Ready(FileExplorerData { favorite_folders }) if favorite_folders.is_empty()
@@ -317,6 +364,7 @@ mod tests {
 
         assert!(error.is_none());
         assert_eq!(storage.active_scan_request_id, Some(1));
+        assert_eq!(storage.revision, 1);
         assert!(matches!(
             storage.state,
             LoadState::Ready(FileExplorerData { favorite_folders }) if favorite_folders.is_empty()
@@ -336,15 +384,32 @@ mod tests {
         let error = storage.finish_scan(request.request_id, Ok(vec![folder("/tmp", &["new.log"])]));
 
         assert!(error.is_none());
+        assert_eq!(storage.revision, 2);
         assert!(matches!(
             storage.state,
             LoadState::Ready(FileExplorerData { favorite_folders })
                 if favorite_folders.len() == 2
                     && favorite_folders[0].path.as_path() == Path::new("/other")
                     && favorite_folders[1].path.as_path() == Path::new("/tmp")
-                    && favorite_folders[1].files[0].name == "new.log"
+                    && favorite_folders[1].children[0].name == "new.log"
         ));
         assert!(storage.active_scan_request_id.is_none());
+    }
+
+    #[test]
+    fn finish_scan_keeps_revision_when_snapshot_is_same() {
+        let mut storage = test_storage();
+        storage.finish_load(Ok(Box::new(FileExplorerData {
+            favorite_folders: vec![folder("/tmp", &["old.log"])],
+        })));
+        let request = storage
+            .prepare_scan(vec![PathBuf::from("/tmp")])
+            .expect("scan request should be prepared");
+
+        let error = storage.finish_scan(request.request_id, Ok(vec![folder("/tmp", &["old.log"])]));
+
+        assert!(error.is_none());
+        assert_eq!(storage.revision, 1);
     }
 
     #[test]
@@ -360,6 +425,28 @@ mod tests {
 
         assert!(error.is_none());
         assert!(storage.dirty);
+        assert_eq!(storage.revision, 2);
+    }
+
+    #[test]
+    fn save_data_omits_scanned_tree() {
+        let mut storage = test_storage();
+        storage.finish_load(Ok(Box::new(FileExplorerData::default())));
+        let request = storage
+            .prepare_add_scan(vec![PathBuf::from("/tmp")])
+            .expect("add scan request should be prepared");
+        storage.finish_scan(
+            request.request_id,
+            Ok(vec![folder("/tmp", &["runtime.log"])]),
+        );
+
+        let save_data = storage
+            .get_save_data()
+            .expect("dirty file explorer data should be saved");
+
+        assert_eq!(save_data.favorite_folders.len(), 1);
+        assert_eq!(save_data.favorite_folders[0].path, PathBuf::from("/tmp"));
+        assert!(save_data.favorite_folders[0].children.is_empty());
     }
 
     #[test]
@@ -377,10 +464,11 @@ mod tests {
 
         assert!(error.is_none());
         assert!(!storage.dirty);
+        assert_eq!(storage.revision, 2);
         assert!(matches!(
             storage.state,
             LoadState::Ready(FileExplorerData { favorite_folders })
-                if favorite_folders.len() == 1 && favorite_folders[0].files[0].name == "new.log"
+                if favorite_folders.len() == 1 && favorite_folders[0].children[0].name == "new.log"
         ));
     }
 
@@ -394,6 +482,7 @@ mod tests {
         storage.remove_favorite_folder(Path::new("/tmp"));
 
         assert!(storage.dirty);
+        assert_eq!(storage.revision, 2);
         assert!(matches!(
             storage.state,
             LoadState::Ready(FileExplorerData { favorite_folders })

--- a/application/apps/indexer/gui/application/src/host/ui/storage/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/storage/mod.rs
@@ -14,7 +14,8 @@ use tokio::sync::mpsc;
 use crate::host::{command::HostCommand, notification::AppNotification, ui::UiActions};
 
 pub use file_explorer::{
-    FavoriteFolder, FavoriteFoldersScanRequest, FileExplorerData, FileExplorerStorage, FileUiInfo,
+    FavoriteFolder, FavoriteFoldersScanRequest, FileExplorerData, FileExplorerStorage,
+    FileTreeNode, FileTreeNodeKind,
 };
 pub use recent::MAX_RECENT_SESSIONS;
 pub use recent::{
@@ -192,6 +193,16 @@ impl HostStorage {
             StorageEvent::FavoriteFoldersScanned { request_id, result } => {
                 let err = self.file_explorer.finish_scan(request_id, result);
                 self.notify_storage_error(err, ui_actions);
+            }
+            StorageEvent::FavoriteFolderLimitReached {
+                folder_names,
+                max_entries_count,
+            } => {
+                ui_actions.add_notification(AppNotification::Warning(format!(
+                    "Favorite folder scan reached the {max_entries_count} entry limit for: {}.\n\
+                    Some entries may be omitted.",
+                    folder_names.join(", ")
+                )));
             }
         }
     }
@@ -448,6 +459,25 @@ mod tests {
         assert!(matches!(
             storage.file_explorer.state,
             LoadState::Ready(FileExplorerData { favorite_folders }) if favorite_folders.len() == 1
+        ));
+    }
+
+    #[test]
+    fn file_explorer_scan_limit_events_notify_warning() {
+        let (mut storage, _) = test_storage();
+        let (_runtime, mut ui_actions) = test_ui_actions();
+
+        storage.handle_event(
+            StorageEvent::FavoriteFolderLimitReached {
+                folder_names: vec!["logs".into()],
+                max_entries_count: 20_000,
+            },
+            &mut ui_actions,
+        );
+
+        assert!(matches!(
+            ui_actions.drain_notifications().next(),
+            Some(AppNotification::Warning(_))
         ));
     }
 }

--- a/application/apps/indexer/gui/application/src/host/ui/storage/recent/session.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/storage/recent/session.rs
@@ -231,6 +231,26 @@ impl RecentSessionSnapshot {
         Some((options, additional_sources))
     }
 
+    /// Validates whether the stored snapshot can be reopened.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.sources.is_empty() {
+            return Err(String::from("Recent session has no sources."));
+        }
+
+        for source in &self.sources {
+            match source {
+                RecentSessionSource::File { path, .. } => {
+                    if !path.exists() {
+                        return Err(format!("File is no longer available:\n{}", path.display()));
+                    }
+                }
+                RecentSessionSource::Stream { .. } => {}
+            }
+        }
+
+        Ok(())
+    }
+
     /// Returns whether the snapshot can be reopened through the normal open/setup flow.
     pub fn supports_clean_open(&self) -> bool {
         supports_clean_open(&self.sources)
@@ -451,7 +471,7 @@ fn supports_bookmarks(sources: &[RecentSessionSource]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::{fs, path::PathBuf};
 
     use stypes::{
         DltParserSettings, ObserveOptions, ObserveOrigin, ParserType, TCPTransportConfig,
@@ -688,6 +708,53 @@ mod tests {
         assert_eq!(items.len(), 2);
         assert_ne!(items[0].0, "first-id");
         assert_ne!(items[1].0, "second-id");
+    }
+
+    #[test]
+    fn validate_accepts_existing_file() {
+        let path = std::env::temp_dir().join(format!(
+            "chipmunk-recent-validation-{}.log",
+            uuid::Uuid::new_v4()
+        ));
+        fs::write(&path, "test").expect("test file should be written");
+        let snapshot = snapshot_from_observe_options(ObserveOptions::file(
+            path.clone(),
+            stypes::FileFormat::Text,
+            ParserType::Text(()),
+        ));
+
+        assert!(snapshot.validate().is_ok());
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn validate_rejects_missing_file() {
+        let path = std::env::temp_dir().join(format!(
+            "chipmunk-missing-recent-validation-{}.log",
+            uuid::Uuid::new_v4()
+        ));
+        let snapshot = snapshot_from_observe_options(ObserveOptions::file(
+            path,
+            stypes::FileFormat::Text,
+            ParserType::Text(()),
+        ));
+
+        assert!(snapshot.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_stream() {
+        let snapshot = stream_snapshot("127.0.0.1:5556");
+
+        assert!(snapshot.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_empty_sources() {
+        let snapshot =
+            RecentSessionSnapshot::new(1, Vec::new(), ParserType::Text(()), Default::default());
+
+        assert!(snapshot.validate().is_err());
     }
 
     #[test]

--- a/application/apps/indexer/gui/application/src/host/ui/storage/types.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/storage/types.rs
@@ -18,10 +18,15 @@ pub enum LoadState<T> {
 pub enum StorageEvent {
     /// File-explorer startup load results.
     FileExplorerLoaded(Result<Box<FileExplorerData>, StorageError>),
-    /// Favorite-folder scan results for a specific request.
+    /// Favorite-folder tree scan results for a specific request.
     FavoriteFoldersScanned {
         request_id: u64,
         result: Result<Vec<FavoriteFolder>, StorageError>,
+    },
+    /// Favorite-folder tree scan reached the per-root entry limit for one or more roots.
+    FavoriteFolderLimitReached {
+        folder_names: Vec<String>,
+        max_entries_count: usize,
     },
 }
 

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/library/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/library/mod.rs
@@ -409,7 +409,7 @@ impl LibraryUI {
         target: SearchSyncTarget,
     ) {
         shared
-            .sync_search_pipelines(registry, target)
+            .sync_search(registry, target)
             .into_iter()
             .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
     }

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/mod.rs
@@ -780,7 +780,7 @@ impl PresetsUI {
         // Preset apply mutates session state first, then issues the same explicit
         // sync commands used by the rest of the search/filter UI.
         shared
-            .sync_search_pipelines(registry, target)
+            .sync_search(registry, target)
             .into_iter()
             .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
     }

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_bar.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_bar.rs
@@ -99,7 +99,7 @@ impl SearchBar {
                 && shared.pin_temp_search(registry)
             {
                 shared
-                    .sync_search_pipelines(registry, SearchSyncTarget::Filter)
+                    .sync_search(registry, SearchSyncTarget::Filter)
                     .into_iter()
                     .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
             }
@@ -189,7 +189,7 @@ impl SearchBar {
                 self.query.clear();
                 shared.filters.set_temp_search(filter);
                 shared
-                    .sync_search_pipelines(registry, SearchSyncTarget::Filter)
+                    .sync_search(registry, SearchSyncTarget::Filter)
                     .into_iter()
                     .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
             }
@@ -258,7 +258,7 @@ impl SearchBar {
                             if add_btn.clicked() && shared.pin_temp_search(registry) {
                                 // Re-apply search which now includes new filter and NO active_search
                                 shared
-                                    .sync_search_pipelines(registry, SearchSyncTarget::Filter)
+                                    .sync_search(registry, SearchSyncTarget::Filter)
                                     .into_iter()
                                     .for_each(|cmd| {
                                         _ = actions.try_send_command(&self.cmd_tx, cmd)
@@ -300,7 +300,7 @@ impl SearchBar {
                                     // We need to consider both targets (filters and search values)
                                     // because we are removed the current temp filter here.
                                     shared
-                                        .sync_search_pipelines(registry, SearchSyncTarget::Both)
+                                        .sync_search(registry, SearchSyncTarget::Both)
                                         .into_iter()
                                         .for_each(|cmd| {
                                             _ = actions.try_send_command(&self.cmd_tx, cmd)
@@ -373,7 +373,7 @@ impl SearchBar {
     ) {
         shared.filters.clear_temp_search();
         shared
-            .sync_search_pipelines(registry, SearchSyncTarget::Filter)
+            .sync_search(registry, SearchSyncTarget::Filter)
             .into_iter()
             .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
     }

--- a/application/apps/indexer/gui/application/src/session/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/mod.rs
@@ -27,7 +27,7 @@ use crate::{
         error::SessionError,
         message::{BookmarkUpdate, SessionMessage},
         types::{OperationPhase, attachment::PreviewTarget},
-        ui::shared::{SearchTableSync, SessionSignal},
+        ui::shared::{SearchSyncOutcome, SearchTableSync, SessionSignal},
     },
 };
 use bottom_panel::{BottomPanelUI, BottomTabType};
@@ -237,8 +237,7 @@ impl Session {
         &mut self,
         actions: &mut UiActions,
         storage: &mut HostStorage,
-        registry: &mut HostRegistry,
-        panels_visibility: &mut PanelsVisibility,
+        registry: &HostRegistry,
     ) {
         while let Ok(msg) = self.receivers.message_rx.try_recv() {
             match msg {
@@ -350,12 +349,23 @@ impl Session {
                         .consumed()
                     {
                         if observe_started_processing {
-                            self.recent_session.on_session_file_ready(
-                                &mut self.shared,
-                                actions,
-                                &self.cmd_tx,
-                                &registry.filters,
-                            );
+                            let outcome = self
+                                .recent_session
+                                .on_session_file_ready(&mut self.shared, &registry.filters);
+                            if let Some(outcome) = outcome {
+                                let SearchSyncOutcome {
+                                    commands,
+                                    log_search_dropped,
+                                } = outcome;
+
+                                if log_search_dropped {
+                                    self.handle_search_dropped();
+                                }
+
+                                for cmd in commands {
+                                    actions.try_send_command(&self.cmd_tx, cmd);
+                                }
+                            }
                         }
                         continue;
                     }
@@ -407,22 +417,24 @@ impl Session {
             }
         }
 
-        self.handle_signals(registry, panels_visibility);
+        debug_assert!(
+            self.shared.signals.is_empty(),
+            "Session messages must not emit render-frame signals."
+        );
     }
 
     /// Applies the restored recent-session state through the normal session and registry path.
-    ///
-    /// Any UI signals emitted while rebuilding that state are handled immediately so the first
-    /// render starts from a clean signal queue.
     pub fn apply_recent_restore(
         &mut self,
         restore_state: RecentSessionStateSnapshot,
         registry: &mut HostRegistry,
-        panels_visibility: &mut PanelsVisibility,
     ) {
         self.recent_session
             .apply_restore(restore_state, &mut self.shared, &mut registry.filters);
-        self.handle_signals(registry, panels_visibility);
+        debug_assert!(
+            self.shared.signals.is_empty(),
+            "Recent-session restore must not emit render-frame signals."
+        );
     }
 
     /// Captures the canonical recent-session state after restore and establishes the update baseline.

--- a/application/apps/indexer/gui/application/src/session/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/mod.rs
@@ -26,7 +26,7 @@ use crate::{
         communication::{UiHandle, UiReceivers},
         error::SessionError,
         message::{BookmarkUpdate, SessionMessage},
-        types::attachment::PreviewTarget,
+        types::{OperationPhase, attachment::PreviewTarget},
         ui::shared::{SearchTableSync, SessionSignal},
     },
 };
@@ -237,7 +237,8 @@ impl Session {
         &mut self,
         actions: &mut UiActions,
         storage: &mut HostStorage,
-        registry: &FilterRegistry,
+        registry: &mut HostRegistry,
+        panels_visibility: &mut PanelsVisibility,
     ) {
         while let Ok(msg) = self.receivers.message_rx.try_recv() {
             match msg {
@@ -317,7 +318,7 @@ impl Session {
                     // Rebind this live session to the appended source-set snapshot.
                     let recent_state = self
                         .recent_session
-                        .capture_opened_state(&self.shared, registry);
+                        .capture_opened_state(&self.shared, &registry.filters);
 
                     let rebind_res = storage.recent_sessions.rebind_after_append(
                         current_source_key,
@@ -334,11 +335,28 @@ impl Session {
                     operation_id,
                     phase,
                 } => {
+                    // Observe processing starts after the backend creates or links the session file.
+                    let observe_started_processing = phase == OperationPhase::Processing
+                        && self
+                            .shared
+                            .observe
+                            .operations()
+                            .iter()
+                            .any(|operation| operation.id == operation_id);
+
                     if self
                         .shared
                         .update_operation(operation_id, phase, actions)
                         .consumed()
                     {
+                        if observe_started_processing {
+                            self.recent_session.on_session_file_ready(
+                                &mut self.shared,
+                                actions,
+                                &self.cmd_tx,
+                                &registry.filters,
+                            );
+                        }
                         continue;
                     }
                     // Potential components which keep track for operations can go here.
@@ -388,6 +406,8 @@ impl Session {
                 },
             }
         }
+
+        self.handle_signals(registry, panels_visibility);
     }
 
     /// Applies the restored recent-session state through the normal session and registry path.
@@ -398,16 +418,10 @@ impl Session {
         &mut self,
         restore_state: RecentSessionStateSnapshot,
         registry: &mut HostRegistry,
-        actions: &mut UiActions,
         panels_visibility: &mut PanelsVisibility,
     ) {
-        self.recent_session.apply_restore(
-            restore_state,
-            &mut self.shared,
-            actions,
-            &self.cmd_tx,
-            &mut registry.filters,
-        );
+        self.recent_session
+            .apply_restore(restore_state, &mut self.shared, &mut registry.filters);
         self.handle_signals(registry, panels_visibility);
     }
 

--- a/application/apps/indexer/gui/application/src/session/ui/recent.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/recent.rs
@@ -11,7 +11,7 @@ use crate::{
     session::command::SessionCommand,
 };
 
-use super::shared::{SearchSyncTarget, SessionShared};
+use super::shared::{SearchSyncOutcome, SearchSyncTarget, SessionShared};
 
 #[derive(Debug)]
 /// Runtime recent-session tracking for one live session.
@@ -93,22 +93,16 @@ impl RecentSessionRuntime {
         self.pending_search_restore = target;
     }
 
-    /// Replays restored searches once the backend has created the session file.
+    /// Returns restored search work once the backend has created the session file.
     pub fn on_session_file_ready(
         &mut self,
         shared: &mut SessionShared,
-        actions: &mut UiActions,
-        cmd_tx: &Sender<SessionCommand>,
         registry: &FilterRegistry,
-    ) {
-        let Some(target) = self.pending_search_restore.take() else {
-            return;
-        };
+    ) -> Option<SearchSyncOutcome> {
+        let target = self.pending_search_restore.take()?;
 
-        shared
-            .sync_search_pipelines(registry, target)
-            .into_iter()
-            .for_each(|cmd| _ = actions.try_send_command(cmd_tx, cmd));
+        let outcome = shared.sync_search_outcome(registry, target);
+        Some(outcome)
     }
 
     /// Replays restored bookmarks into the backend once file loading completed.
@@ -446,7 +440,20 @@ mod tests {
 
         assert!(cmd_rx.try_recv().is_err());
 
-        recent.on_session_file_ready(&mut shared, &mut actions, &cmd_tx, &registry);
+        let outcome = recent
+            .on_session_file_ready(&mut shared, &registry)
+            .expect("restored search should be ready");
+        let SearchSyncOutcome {
+            commands,
+            log_search_dropped,
+        } = outcome;
+
+        assert!(log_search_dropped);
+        assert!(shared.signals.is_empty());
+
+        for cmd in commands {
+            actions.try_send_command(&cmd_tx, cmd);
+        }
 
         match cmd_rx.try_recv() {
             Ok(SessionCommand::ApplySearchFilter { filters, .. }) => {
@@ -464,8 +471,10 @@ mod tests {
 
         assert!(cmd_rx.try_recv().is_err());
 
-        recent.on_session_file_ready(&mut shared, &mut actions, &cmd_tx, &registry);
+        let outcome = recent.on_session_file_ready(&mut shared, &registry);
 
+        assert!(outcome.is_none());
+        assert!(shared.signals.is_empty());
         assert!(cmd_rx.try_recv().is_err());
     }
 

--- a/application/apps/indexer/gui/application/src/session/ui/recent.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/recent.rs
@@ -27,6 +27,8 @@ pub struct RecentSessionRuntime {
     last_revision: u64,
     /// True while restored bookmarks still need backend replay after file read completes.
     pending_bookmark_restore: bool,
+    /// Restored searches waiting until the backend has created the session file.
+    pending_search_restore: Option<SearchSyncTarget>,
 }
 
 impl RecentSessionRuntime {
@@ -37,6 +39,7 @@ impl RecentSessionRuntime {
             supports_bookmarks,
             last_revision: 0,
             pending_bookmark_restore: false,
+            pending_search_restore: None,
         }
     }
 
@@ -47,16 +50,15 @@ impl RecentSessionRuntime {
             supports_bookmarks: false,
             last_revision: 0,
             pending_bookmark_restore: false,
+            pending_search_restore: None,
         }
     }
 
-    /// Applies restored recent-session state through the normal session and registry path.
+    /// Applies restored recent-session state and defers backend search until the session file exists.
     pub fn apply_restore(
         &mut self,
         restore_state: RecentSessionStateSnapshot,
         shared: &mut SessionShared,
-        actions: &mut UiActions,
-        cmd_tx: &Sender<SessionCommand>,
         registry: &mut FilterRegistry,
     ) {
         let mut changed_filters = false;
@@ -88,12 +90,25 @@ impl RecentSessionRuntime {
             (true, true) => Some(SearchSyncTarget::Both),
         };
 
-        if let Some(target) = target {
-            shared
-                .sync_search_pipelines(registry, target)
-                .into_iter()
-                .for_each(|cmd| _ = actions.try_send_command(cmd_tx, cmd));
-        }
+        self.pending_search_restore = target;
+    }
+
+    /// Replays restored searches once the backend has created the session file.
+    pub fn on_session_file_ready(
+        &mut self,
+        shared: &mut SessionShared,
+        actions: &mut UiActions,
+        cmd_tx: &Sender<SessionCommand>,
+        registry: &FilterRegistry,
+    ) {
+        let Some(target) = self.pending_search_restore.take() else {
+            return;
+        };
+
+        shared
+            .sync_search_pipelines(registry, target)
+            .into_iter()
+            .for_each(|cmd| _ = actions.try_send_command(cmd_tx, cmd));
     }
 
     /// Replays restored bookmarks into the backend once file loading completed.
@@ -131,6 +146,7 @@ impl RecentSessionRuntime {
     pub fn clear_source_key(&mut self) {
         self.source_key = None;
         self.pending_bookmark_restore = false;
+        self.pending_search_restore = None;
     }
 
     /// Returns the stable recent-session identity for this live session.
@@ -401,6 +417,59 @@ mod tests {
     }
 
     #[test]
+    fn restore_search_waits_for_session_file_ready() {
+        let runtime = Runtime::new().expect("runtime should initialize");
+        let mut actions = UiActions::new(runtime.handle().clone());
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(8);
+        let mut shared = new_shared(ObserveOrigin::File(
+            String::from("source"),
+            FileFormat::PcapNG,
+            PathBuf::from("source.pcapng"),
+        ));
+        let mut registry = FilterRegistry::default();
+        let mut recent = file_runtime();
+        let filter = SearchFilter::plain("level=warn");
+        let search_value = SearchFilter::plain("cpu=(\\d+)");
+        let restore_state = RecentSessionStateSnapshot {
+            filters: vec![SearchFilterSnapshot {
+                filter: filter.clone(),
+                enabled: true,
+            }],
+            search_values: vec![SearchFilterSnapshot {
+                filter: search_value.clone(),
+                enabled: true,
+            }],
+            bookmarks: vec![],
+        };
+
+        recent.apply_restore(restore_state, &mut shared, &mut registry);
+
+        assert!(cmd_rx.try_recv().is_err());
+
+        recent.on_session_file_ready(&mut shared, &mut actions, &cmd_tx, &registry);
+
+        match cmd_rx.try_recv() {
+            Ok(SessionCommand::ApplySearchFilter { filters, .. }) => {
+                assert_eq!(filters, vec![filter]);
+            }
+            other => panic!("expected ApplySearchFilter command, got {other:?}"),
+        }
+
+        match cmd_rx.try_recv() {
+            Ok(SessionCommand::ApplySearchValuesFilter { filters, .. }) => {
+                assert_eq!(filters, vec![search_value.value]);
+            }
+            other => panic!("expected ApplySearchValuesFilter command, got {other:?}"),
+        }
+
+        assert!(cmd_rx.try_recv().is_err());
+
+        recent.on_session_file_ready(&mut shared, &mut actions, &cmd_tx, &registry);
+
+        assert!(cmd_rx.try_recv().is_err());
+    }
+
+    #[test]
     fn restore_waits_for_file_read() {
         let runtime = Runtime::new().expect("runtime should initialize");
         let mut actions = UiActions::new(runtime.handle().clone());
@@ -418,13 +487,7 @@ mod tests {
             bookmarks: vec![5, 2],
         };
 
-        recent.apply_restore(
-            restore_state,
-            &mut shared,
-            &mut actions,
-            &cmd_tx,
-            &mut registry,
-        );
+        recent.apply_restore(restore_state, &mut shared, &mut registry);
 
         assert!(cmd_rx.try_recv().is_err());
         assert!(shared.logs.is_bookmarked(2));

--- a/application/apps/indexer/gui/application/src/session/ui/shared/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/shared/mod.rs
@@ -68,13 +68,20 @@ pub struct SessionShared {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Selects which backend search pipeline(s) should be synchronized for a UI action.
-pub(crate) enum SearchSyncTarget {
+pub enum SearchSyncTarget {
     /// Synchronize only the logs search pipeline (`ApplySearchFilter` / `DropSearch`).
     Filter,
     /// Synchronize only the chart search-values pipeline.
     SearchValue,
     /// Synchronize both pipelines in one pass.
     Both,
+}
+
+#[derive(Debug, Default)]
+/// Commands and local UI effects produced by synchronizing backend search pipelines.
+pub struct SearchSyncOutcome {
+    pub commands: Vec<SessionCommand>,
+    pub log_search_dropped: bool,
 }
 
 impl SessionShared {
@@ -107,11 +114,6 @@ impl SessionShared {
     #[inline]
     pub fn get_info(&self) -> &SessionInfo {
         &self.session_info
-    }
-
-    pub fn drop_search(&mut self) {
-        self.search.drop_search();
-        self.signals.push(SessionSignal::SearchDropped);
     }
 
     pub fn add_operation(&mut self, observe_op: ObserveOperation) {
@@ -162,24 +164,50 @@ impl SessionShared {
         exports.handle_phase(operation_id, phase, actions)
     }
 
-    /// Synchronizes UI state with backend search pipelines and returns the commands to dispatch.
+    /// Synchronizes search for render callers and queues frame-local signals.
+    ///
+    /// Returns backend commands to dispatch. Use `sync_search_outcome` outside render when the
+    /// caller must handle local effects directly instead of using `SessionSignal`.
     ///
     /// `target` selects which pipeline to sync:
     /// - `Filter`: logs search results pipeline (table/search results).
     /// - `SearchValue`: numeric search-values pipeline (charts only).
     /// - `Both`: use when one UI action affects both sets at once.
-    pub fn sync_search_pipelines(
+    pub fn sync_search(
         &mut self,
         registry: &FilterRegistry,
         target: SearchSyncTarget,
     ) -> Vec<SessionCommand> {
+        let outcome = self.sync_search_outcome(registry, target);
+
+        let SearchSyncOutcome {
+            commands,
+            log_search_dropped,
+        } = outcome;
+
+        if log_search_dropped {
+            self.signals.push(SessionSignal::SearchDropped);
+        }
+
+        commands
+    }
+
+    /// Synchronizes search and returns commands plus local effects.
+    ///
+    /// This path does not emit `SessionSignal`, so non-render callers can preserve the
+    /// frame-local signal invariant by applying the returned effects themselves.
+    pub fn sync_search_outcome(
+        &mut self,
+        registry: &FilterRegistry,
+        target: SearchSyncTarget,
+    ) -> SearchSyncOutcome {
         match target {
             SearchSyncTarget::Filter => self.sync_filter_search_pipeline(registry),
             SearchSyncTarget::SearchValue => self.sync_search_values_pipeline(registry),
             SearchSyncTarget::Both => {
-                let mut commands = self.sync_filter_search_pipeline(registry);
-                commands.extend(self.sync_search_values_pipeline(registry));
-                commands
+                let mut outcome = self.sync_filter_search_pipeline(registry);
+                outcome.extend(self.sync_search_values_pipeline(registry));
+                outcome
             }
         }
     }
@@ -188,13 +216,16 @@ impl SessionShared {
     ///
     /// When filters become empty we only drop the active search, otherwise we issue a
     /// drop-then-apply sequence so a running search does not keep the holder in use.
-    fn sync_filter_search_pipeline(&mut self, registry: &FilterRegistry) -> Vec<SessionCommand> {
+    fn sync_filter_search_pipeline(&mut self, registry: &FilterRegistry) -> SearchSyncOutcome {
         let filters = self.search.get_active_filters(&self.filters, registry);
         if filters.is_empty() {
             let operation_id = self.search.processing_search_operation();
             self.search.clear_compiled_filters();
-            self.drop_search();
-            vec![SessionCommand::DropSearch { operation_id }]
+            self.search.drop_search();
+            SearchSyncOutcome {
+                commands: vec![SessionCommand::DropSearch { operation_id }],
+                log_search_dropped: true,
+            }
         } else {
             let mut commands = Vec::with_capacity(2);
             if let Some(operation_id) = self.search.processing_search_operation() {
@@ -202,7 +233,7 @@ impl SessionShared {
                     operation_id: Some(operation_id),
                 });
             }
-            self.drop_search();
+            self.search.drop_search();
             self.search.refresh_compiled_filters(&filters);
             let operation_id = Uuid::new_v4();
             self.search.set_search_operation(operation_id);
@@ -210,7 +241,10 @@ impl SessionShared {
                 operation_id,
                 filters,
             });
-            commands
+            SearchSyncOutcome {
+                commands,
+                log_search_dropped: true,
+            }
         }
     }
 
@@ -218,7 +252,7 @@ impl SessionShared {
     ///
     /// Search values are independent from logs search results, so they are synchronized through
     /// their own drop/apply command pair and operation tracking.
-    fn sync_search_values_pipeline(&mut self, registry: &FilterRegistry) -> Vec<SessionCommand> {
+    fn sync_search_values_pipeline(&mut self, registry: &FilterRegistry) -> SearchSyncOutcome {
         let filters: Vec<_> = self
             .filters
             .enabled_search_value_ids()
@@ -229,7 +263,10 @@ impl SessionShared {
         if filters.is_empty() {
             let operation_id = self.search_values.processing_operation();
             self.search_values.drop_search_values();
-            vec![SessionCommand::DropSearchValues { operation_id }]
+            SearchSyncOutcome {
+                commands: vec![SessionCommand::DropSearchValues { operation_id }],
+                log_search_dropped: false,
+            }
         } else {
             let mut commands = Vec::with_capacity(2);
             if let Some(operation_id) = self.search_values.processing_operation() {
@@ -245,7 +282,10 @@ impl SessionShared {
                 operation_id,
                 filters,
             });
-            commands
+            SearchSyncOutcome {
+                commands,
+                log_search_dropped: false,
+            }
         }
     }
 
@@ -400,6 +440,13 @@ impl SessionShared {
     }
 }
 
+impl SearchSyncOutcome {
+    fn extend(&mut self, other: Self) {
+        self.commands.extend(other.commands);
+        self.log_search_dropped |= other.log_search_dropped;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -479,12 +526,14 @@ mod tests {
     #[test]
     fn drop_search_updates_counts() {
         let mut shared = new_shared();
+        let registry = FilterRegistry::default();
         shared.search.set_search_operation(Uuid::new_v4());
         shared.search.set_search_result_count(4);
         shared.search.set_indexed_result_count(9);
 
-        shared.drop_search();
+        let commands = shared.sync_search(&registry, SearchSyncTarget::Filter);
 
+        assert!(matches!(commands[0], SessionCommand::DropSearch { .. }));
         assert_eq!(shared.search.search_result_count(), 0);
         assert_eq!(shared.search.indexed_result_count(), 5);
         assert!(shared.search.current_matches_map().is_none());
@@ -517,7 +566,7 @@ mod tests {
         let mut shared = new_shared();
         let mut registry = FilterRegistry::default();
         add_filter(&mut shared, &mut registry, "status=ok");
-        let _ = shared.sync_search_pipelines(&registry, SearchSyncTarget::Filter);
+        let _ = shared.sync_search(&registry, SearchSyncTarget::Filter);
         assert_eq!(shared.search.compiled_filters().len(), 1);
         shared.filters.clear_temp_search();
         let filter_id = shared.filters.filter_entries[0].id;
@@ -526,7 +575,7 @@ mod tests {
         // An empty filter set should only tear down the active search operation.
         shared.search.set_search_operation(previous_operation_id);
 
-        let commands = shared.sync_search_pipelines(&registry, SearchSyncTarget::Filter);
+        let commands = shared.sync_search(&registry, SearchSyncTarget::Filter);
 
         assert_eq!(commands.len(), 1);
         match &commands[0] {
@@ -549,7 +598,7 @@ mod tests {
         // Non-empty filter sync keeps the drop-before-apply contract.
         shared.search.set_search_operation(previous_operation_id);
 
-        let commands = shared.sync_search_pipelines(&registry, SearchSyncTarget::Filter);
+        let commands = shared.sync_search(&registry, SearchSyncTarget::Filter);
 
         assert_eq!(commands.len(), 2);
         match &commands[0] {
@@ -587,7 +636,7 @@ mod tests {
             .filters
             .set_temp_search(SearchFilter::plain("temp").ignore_case(true));
 
-        let commands = shared.sync_search_pipelines(&registry, SearchSyncTarget::Filter);
+        let commands = shared.sync_search(&registry, SearchSyncTarget::Filter);
 
         assert_eq!(commands.len(), 1);
         match &commands[0] {
@@ -620,7 +669,7 @@ mod tests {
             .filters
             .set_temp_search(SearchFilter::plain("temp").ignore_case(true));
 
-        let commands = shared.sync_search_pipelines(&registry, SearchSyncTarget::Filter);
+        let commands = shared.sync_search(&registry, SearchSyncTarget::Filter);
 
         let payload_filters = match &commands[0] {
             SessionCommand::ApplySearchFilter { filters, .. } => filters,
@@ -651,7 +700,7 @@ mod tests {
         let filter_id =
             add_filter_def(&mut shared, &mut registry, SearchFilter::plain("status=ok"));
 
-        let initial_commands = shared.sync_search_pipelines(&registry, SearchSyncTarget::Filter);
+        let initial_commands = shared.sync_search(&registry, SearchSyncTarget::Filter);
         assert!(matches!(
             initial_commands[0],
             SessionCommand::ApplySearchFilter { .. }
@@ -667,7 +716,7 @@ mod tests {
             crate::host::ui::registry::filters::RegistryEditOutcome::EditedInPlace
         ));
 
-        let updated_commands = shared.sync_search_pipelines(&registry, SearchSyncTarget::Filter);
+        let updated_commands = shared.sync_search(&registry, SearchSyncTarget::Filter);
         let payload_filters = match &updated_commands[1] {
             SessionCommand::ApplySearchFilter { filters, .. } => filters,
             other => panic!("expected ApplySearchFilter, got {other:?}"),
@@ -688,7 +737,7 @@ mod tests {
         // Search values use the same drop-only behavior when nothing stays enabled.
         shared.search_values.set_operation(previous_operation_id);
 
-        let commands = shared.sync_search_pipelines(&registry, SearchSyncTarget::SearchValue);
+        let commands = shared.sync_search(&registry, SearchSyncTarget::SearchValue);
 
         assert_eq!(commands.len(), 1);
         match &commands[0] {
@@ -709,7 +758,7 @@ mod tests {
         // Search-value sync also reissues its backend operation after dropping the old one.
         shared.search_values.set_operation(previous_operation_id);
 
-        let commands = shared.sync_search_pipelines(&registry, SearchSyncTarget::SearchValue);
+        let commands = shared.sync_search(&registry, SearchSyncTarget::SearchValue);
 
         assert_eq!(commands.len(), 2);
         match &commands[0] {
@@ -742,12 +791,12 @@ mod tests {
         let mut registry = FilterRegistry::default();
         add_filter(&mut shared, &mut registry, "status=ok");
         let filter_id = shared.filters.filter_entries[0].id;
-        let _ = shared.sync_search_pipelines(&registry, SearchSyncTarget::Filter);
+        let _ = shared.sync_search(&registry, SearchSyncTarget::Filter);
         assert_eq!(shared.search.compiled_filters().len(), 1);
         // Disabled filters stay in session state but should not reach backend sync.
         assert!(shared.filters.set_filter_enabled(&filter_id, false));
 
-        let commands = shared.sync_search_pipelines(&registry, SearchSyncTarget::Filter);
+        let commands = shared.sync_search(&registry, SearchSyncTarget::Filter);
 
         assert_eq!(commands.len(), 1);
         assert!(matches!(commands[0], SessionCommand::DropSearch { .. }));
@@ -763,7 +812,7 @@ mod tests {
         // Disabled search values should be treated as absent by the chart pipeline.
         assert!(shared.filters.set_search_value_enabled(&value_id, false));
 
-        let commands = shared.sync_search_pipelines(&registry, SearchSyncTarget::SearchValue);
+        let commands = shared.sync_search(&registry, SearchSyncTarget::SearchValue);
 
         assert_eq!(commands.len(), 1);
         assert!(matches!(
@@ -782,7 +831,7 @@ mod tests {
         shared.search.set_search_operation(Uuid::new_v4());
         shared.search_values.set_operation(Uuid::new_v4());
 
-        let commands = shared.sync_search_pipelines(&registry, SearchSyncTarget::Both);
+        let commands = shared.sync_search(&registry, SearchSyncTarget::Both);
 
         assert_eq!(commands.len(), 4);
         assert!(matches!(commands[0], SessionCommand::DropSearch { .. }));

--- a/application/apps/indexer/gui/application/src/session/ui/side_panel/filters.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/side_panel/filters.rs
@@ -888,7 +888,7 @@ impl FiltersUi {
                         self.clear_filter_edit_for(filter_id);
                         shared.bump_recent_revision();
                         shared
-                            .sync_search_pipelines(registry, SearchSyncTarget::Filter)
+                            .sync_search(registry, SearchSyncTarget::Filter)
                             .into_iter()
                             .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
                     }
@@ -901,7 +901,7 @@ impl FiltersUi {
                         }
                         self.clear_filter_edit_for(filter_id);
                         shared
-                            .sync_search_pipelines(registry, SearchSyncTarget::Filter)
+                            .sync_search(registry, SearchSyncTarget::Filter)
                             .into_iter()
                             .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
                     }
@@ -940,7 +940,7 @@ impl FiltersUi {
                         self.clear_search_value_edit_for(value_id);
                         shared.bump_recent_revision();
                         shared
-                            .sync_search_pipelines(registry, SearchSyncTarget::SearchValue)
+                            .sync_search(registry, SearchSyncTarget::SearchValue)
                             .into_iter()
                             .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
                     }
@@ -953,7 +953,7 @@ impl FiltersUi {
                         }
                         self.clear_search_value_edit_for(value_id);
                         shared
-                            .sync_search_pipelines(registry, SearchSyncTarget::SearchValue)
+                            .sync_search(registry, SearchSyncTarget::SearchValue)
                             .into_iter()
                             .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
                     }
@@ -965,7 +965,7 @@ impl FiltersUi {
             FilterPanelAction::ToggleFilter(filter_id, enabled) => {
                 if shared.set_filter_enabled(&filter_id, enabled) {
                     shared
-                        .sync_search_pipelines(registry, SearchSyncTarget::Filter)
+                        .sync_search(registry, SearchSyncTarget::Filter)
                         .into_iter()
                         .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
                 }
@@ -998,7 +998,7 @@ impl FiltersUi {
                     RegistryEditOutcome::EditedInPlace => {
                         shared.bump_recent_revision();
                         shared
-                            .sync_search_pipelines(registry, SearchSyncTarget::Filter)
+                            .sync_search(registry, SearchSyncTarget::Filter)
                             .into_iter()
                             .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
                     }
@@ -1011,7 +1011,7 @@ impl FiltersUi {
                         }
 
                         shared
-                            .sync_search_pipelines(registry, SearchSyncTarget::Filter)
+                            .sync_search(registry, SearchSyncTarget::Filter)
                             .into_iter()
                             .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
                     }
@@ -1022,7 +1022,7 @@ impl FiltersUi {
                 self.clear_selection_for(SelectedSidebarItem::Filter(filter_id));
                 shared.unapply_filter(registry, &filter_id);
                 shared
-                    .sync_search_pipelines(registry, SearchSyncTarget::Filter)
+                    .sync_search(registry, SearchSyncTarget::Filter)
                     .into_iter()
                     .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
             }
@@ -1042,7 +1042,7 @@ impl FiltersUi {
                         SelectedSidebarItem::SearchValue(value_id),
                     );
                     shared
-                        .sync_search_pipelines(registry, SearchSyncTarget::Both)
+                        .sync_search(registry, SearchSyncTarget::Both)
                         .into_iter()
                         .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
                 }
@@ -1050,7 +1050,7 @@ impl FiltersUi {
             FilterPanelAction::ToggleSearchValue(value_id, enabled) => {
                 if shared.set_search_value_enabled(&value_id, enabled) {
                     shared
-                        .sync_search_pipelines(registry, SearchSyncTarget::SearchValue)
+                        .sync_search(registry, SearchSyncTarget::SearchValue)
                         .into_iter()
                         .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
                 }
@@ -1060,7 +1060,7 @@ impl FiltersUi {
                 self.clear_selection_for(SelectedSidebarItem::SearchValue(value_id));
                 shared.unapply_search_value(registry, &value_id);
                 shared
-                    .sync_search_pipelines(registry, SearchSyncTarget::SearchValue)
+                    .sync_search(registry, SearchSyncTarget::SearchValue)
                     .into_iter()
                     .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
             }
@@ -1080,7 +1080,7 @@ impl FiltersUi {
                         SelectedSidebarItem::Filter(filter_id),
                     );
                     shared
-                        .sync_search_pipelines(registry, SearchSyncTarget::Both)
+                        .sync_search(registry, SearchSyncTarget::Both)
                         .into_iter()
                         .for_each(|cmd| _ = actions.try_send_command(&self.cmd_tx, cmd));
                 }

--- a/application/apps/indexer/session/src/unbound/mod.rs
+++ b/application/apps/indexer/session/src/unbound/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         signal::Signal,
     },
 };
-use cleanup::cleanup_temp_files;
+pub use cleanup::cleanup_temp_files;
 use log::{debug, error, warn};
 use std::{collections::HashMap, sync::Arc};
 use tokio::{


### PR DESCRIPTION
This PR includes multiple changes and fixes:

- Improved favorite folder file explorer with subfolder scanning, UI data updates, broader search, and caching.
- Added keyboard selection/opening for recent sessions.
- Added cleanup on session start and restricted DLT statistics to sources with storage headers.
- Improved recent session validation before opening, with a prompt to remove invalid entries.
- Fixed recent session restore race by waiting for output file writes before applying filters.
