### PR TITLE
Native: Persist Application UI Lightweight State

### DIFF
--- a/application/apps/indexer/gui/application/src/host/ui/home/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/mod.rs
@@ -15,7 +15,7 @@ use crate::host::{
     ui::{
         UiActions,
         actions::FileDialogOptions,
-        state::PanelsVisibility,
+        state::HostPreferences,
         storage::{HostStorage, RecentSessionsStorage},
     },
 };
@@ -57,7 +57,7 @@ impl HomeView {
         &mut self,
         storage: &mut HostStorage,
         actions: &mut UiActions,
-        panels_visibility: &PanelsVisibility,
+        preferences: &mut HostPreferences,
         ui: &mut Ui,
     ) {
         self.handle_pending_file_dialog(actions);
@@ -66,7 +66,7 @@ impl HomeView {
             .size_range(RESIZABLE_PANEL_MIN_SIZE..=RESIZABLE_PANEL_MAX_SIZE)
             .default_size(RESIZABLE_PANEL_DEFAULT_SIZE)
             .resizable(true)
-            .show_animated_inside(ui, panels_visibility.right, |ui| {
+            .show_animated_inside(ui, preferences.panels_visibility.right, |ui| {
                 self.file_explorer
                     .render_content(actions, &mut storage.file_explorer, ui);
             });

--- a/application/apps/indexer/gui/application/src/host/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/mod.rs
@@ -45,6 +45,7 @@ mod info;
 mod menu;
 pub mod multi_setup;
 mod notification;
+mod persist;
 mod recent_session;
 pub mod registry;
 pub mod session_setup;
@@ -101,6 +102,8 @@ impl Host {
                 };
 
                 ctx.egui_ctx.all_styles_mut(app_style::global_styles);
+
+                persist::load(ctx.storage, &mut host);
 
                 host.handle_cli(cli_cmds)?;
 
@@ -320,17 +323,17 @@ impl Host {
             sessions,
             session_setups,
             multi_setups,
-            panels_visibility,
+            preferences,
             registry,
             ..
         } = state;
 
         match active_tab {
-            TabType::Home => home_view.render_content(storage, ui_actions, panels_visibility, ui),
+            TabType::Home => home_view.render_content(storage, ui_actions, preferences, ui),
             TabType::Session(id) => sessions
                 .get_mut(&id)
                 .expect("Session with provieded ID from active tab must exist")
-                .render_content(ui_actions, registry, panels_visibility, ui),
+                .render_content(ui_actions, registry, preferences, ui),
             TabType::SessionSetup(id) => session_setups
                 .get_mut(&id)
                 .expect("Session Setup with provided ID form active tab must exist")
@@ -418,7 +421,7 @@ fn render_tab_bar_utilities(
 
             render_panel_toggle(
                 ui,
-                &mut state.panels_visibility.right,
+                &mut state.preferences.panels_visibility.right,
                 icons::fill::SQUARE_HALF,
                 "Right panel",
             );
@@ -427,7 +430,7 @@ fn render_tab_bar_utilities(
         if state.show_bottom_panel_toggle() {
             render_panel_toggle(
                 ui,
-                &mut state.panels_visibility.bottom,
+                &mut state.preferences.panels_visibility.bottom,
                 icons::fill::SQUARE_HALF_BOTTOM,
                 "Bottom panel",
             );
@@ -502,7 +505,8 @@ impl eframe::App for Host {
         self.handle_ui_actions(ui.ctx());
     }
 
-    fn save(&mut self, _storage: &mut dyn eframe::Storage) {
+    fn save(&mut self, storage: &mut dyn eframe::Storage) {
+        persist::save(storage, self);
         self.storage.schedule_save(&mut self.ui_actions);
     }
 

--- a/application/apps/indexer/gui/application/src/host/ui/persist.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/persist.rs
@@ -1,0 +1,27 @@
+//! Lightweight host UI persistence stored through eframe.
+//!
+//! Use this module for small UI preferences and presentation state that belongs
+//! to the host UI, such as panel visibility. Heavier app-domain state that affects
+//! application behavior should live in `storage` and be saved through the host service.
+
+use eframe::{Storage, get_value, set_value};
+
+use super::{Host, state::HostPreferences};
+
+const HOST_PREFERENCES_KEY: &str = "chipmunk.host_preferences";
+
+/// Loads persisted host UI preferences into the application.
+pub fn load(storage: Option<&dyn Storage>, host: &mut Host) {
+    if let Some(preferences) = storage.and_then(load_preferences) {
+        host.state.preferences = preferences;
+    }
+}
+
+/// Saves host UI preferences into eframe storage.
+pub fn save(storage: &mut dyn Storage, host: &mut Host) {
+    set_value(storage, HOST_PREFERENCES_KEY, &host.state.preferences);
+}
+
+fn load_preferences(storage: &dyn Storage) -> Option<HostPreferences> {
+    get_value(storage, HOST_PREFERENCES_KEY)
+}

--- a/application/apps/indexer/gui/application/src/host/ui/shortcuts/handler.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/shortcuts/handler.rs
@@ -3,10 +3,10 @@
 use egui::{Context, Event};
 
 use crate::host::ui::{
-    Host, HostAction,
+    Host, HostAction, UiActions,
     actions::FileDialogOptions,
     menu,
-    state::{self, HostModal},
+    state::{self, HostModal, HostState},
     tabs::TabType,
 };
 
@@ -78,13 +78,17 @@ fn handle_app_shortcuts(host: &mut Host, ctx: &Context) -> bool {
         open_shortcuts: _,
     } = app_shortcuts();
 
+    let Host {
+        state, ui_actions, ..
+    } = host;
+
     if consume_shortcut(ctx, home_tab) {
-        host.state.activate_tab(state::HOME_TAB_IDX);
+        state.activate_tab(state::HOME_TAB_IDX);
         return true;
     }
 
     if consume_shortcut(ctx, open_files) {
-        host.ui_actions.file_dialog.pick_files(
+        ui_actions.file_dialog.pick_files(
             menu::OPEN_FILES_ID,
             FileDialogOptions::new().title("Open Files"),
         );
@@ -92,77 +96,79 @@ fn handle_app_shortcuts(host: &mut Host, ctx: &Context) -> bool {
     }
 
     if consume_shortcut(ctx, close_tab) {
-        close_active_tab(host);
+        close_active_tab(state, ui_actions);
         return true;
     }
 
     if consume_shortcut(ctx, previous_tab) {
-        host.state.activate_previous_tab();
+        state.activate_previous_tab();
         return true;
     }
 
     if consume_shortcut(ctx, next_tab) {
-        host.state.activate_next_tab();
+        state.activate_next_tab();
         return true;
     }
 
     if consume_shortcut(ctx, tab_1) {
-        host.state.activate_tab(0);
+        state.activate_tab(0);
         return true;
     }
 
     if consume_shortcut(ctx, tab_2) {
-        host.state.activate_tab(1);
+        state.activate_tab(1);
         return true;
     }
 
     if consume_shortcut(ctx, tab_3) {
-        host.state.activate_tab(2);
+        state.activate_tab(2);
         return true;
     }
 
     if consume_shortcut(ctx, tab_4) {
-        host.state.activate_tab(3);
+        state.activate_tab(3);
         return true;
     }
 
     if consume_shortcut(ctx, tab_5) {
-        host.state.activate_tab(4);
+        state.activate_tab(4);
         return true;
     }
 
     if consume_shortcut(ctx, tab_6) {
-        host.state.activate_tab(5);
+        state.activate_tab(5);
         return true;
     }
 
     if consume_shortcut(ctx, tab_7) {
-        host.state.activate_tab(6);
+        state.activate_tab(6);
         return true;
     }
 
     if consume_shortcut(ctx, tab_8) {
-        host.state.activate_tab(7);
+        state.activate_tab(7);
         return true;
     }
 
     if consume_shortcut(ctx, tab_9) {
-        host.state.activate_tab(8);
+        state.activate_tab(8);
         return true;
     }
 
-    if host.state.show_right_panel_toggle() && consume_shortcut(ctx, toggle_right_panel) {
-        host.state.panels_visibility.right = !host.state.panels_visibility.right;
+    if state.show_right_panel_toggle() && consume_shortcut(ctx, toggle_right_panel) {
+        let visible = &mut state.preferences.panels_visibility.right;
+        *visible = !*visible;
         return true;
     }
 
-    if host.state.show_bottom_panel_toggle() && consume_shortcut(ctx, toggle_bottom_panel) {
-        host.state.panels_visibility.bottom = !host.state.panels_visibility.bottom;
+    if state.show_bottom_panel_toggle() && consume_shortcut(ctx, toggle_bottom_panel) {
+        let visible = &mut state.preferences.panels_visibility.bottom;
+        *visible = !*visible;
         return true;
     }
 
     if consume_binding(ctx, &OPEN_SHORTCUTS_F1) || consume_questionmark(ctx) {
-        host.state.active_modal = Some(HostModal::Shortcuts);
+        state.active_modal = Some(HostModal::Shortcuts);
         return true;
     }
 
@@ -186,26 +192,22 @@ fn handle_active_tab_shortcuts(
         return false;
     };
 
-    session.handle_shortcuts(ui_actions, &mut state.panels_visibility, ctx, last_key)
+    session.handle_shortcuts(ui_actions, &mut state.preferences, ctx, last_key)
 }
 
-fn close_active_tab(host: &mut Host) {
-    match host.state.active_tab().clone() {
+fn close_active_tab(state: &mut HostState, ui_actions: &mut UiActions) {
+    match state.active_tab().clone() {
         TabType::Home => {}
-        TabType::Session(id) => host
-            .ui_actions
-            .add_host_action(HostAction::CloseSession(id)),
-        TabType::SessionSetup(id) => host
-            .state
+        TabType::Session(id) => ui_actions.add_host_action(HostAction::CloseSession(id)),
+        TabType::SessionSetup(id) => state
             .session_setups
             .get(&id)
             .expect("Session setup from active tab must exist")
-            .close(&mut host.ui_actions),
-        TabType::MultiFileSetup(id) => host
-            .state
+            .close(ui_actions),
+        TabType::MultiFileSetup(id) => state
             .multi_setups
             .get(&id)
             .expect("Multiple files setup from active tab must exist")
-            .close(&mut host.ui_actions),
+            .close(ui_actions),
     }
 }

--- a/application/apps/indexer/gui/application/src/host/ui/state/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/state/mod.rs
@@ -4,6 +4,7 @@ use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
 
 pub mod info;
+pub mod preferences;
 mod presets;
 
 use crate::{
@@ -22,6 +23,7 @@ use crate::{
 };
 
 use self::info::AppInfoState;
+pub use preferences::HostPreferences;
 
 pub const HOME_TAB_IDX: usize = 0;
 
@@ -33,22 +35,13 @@ pub struct HostState {
     pub sessions: FxHashMap<Uuid, Session>,
     pub session_setups: FxHashMap<Uuid, SessionSetup>,
     pub multi_setups: FxHashMap<Uuid, MultiFileSetup>,
-    /// Shared visibility for the host right panel and session auxiliary panels.
-    pub panels_visibility: PanelsVisibility,
+    /// Persisted host UI preferences.
+    pub preferences: HostPreferences,
     pub registry: HostRegistry,
     pub app_info: AppInfoState,
     pub shortcuts: ShortcutState,
     /// Modal currently owned by the host UI.
     pub active_modal: Option<HostModal>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-/// Shared visibility state for the host right panel and session auxiliary panels.
-pub struct PanelsVisibility {
-    /// Controls the right-side panel visibility in home and session views.
-    pub right: bool,
-    /// Controls the session bottom panel visibility.
-    pub bottom: bool,
 }
 
 /// Host-level modal dialogs that should be exclusive.
@@ -69,7 +62,7 @@ impl HostState {
             sessions: FxHashMap::default(),
             session_setups: FxHashMap::default(),
             multi_setups: FxHashMap::default(),
-            panels_visibility: PanelsVisibility::default(),
+            preferences: HostPreferences::default(),
             registry: HostRegistry::default(),
             app_info: AppInfoState::default(),
             shortcuts: ShortcutState::default(),
@@ -260,15 +253,6 @@ impl HostState {
         } else if self.active_tab_idx > removed_idx {
             // Tabs after the deleted one will be shifted one place to the left.
             self.active_tab_idx -= 1;
-        }
-    }
-}
-
-impl Default for PanelsVisibility {
-    fn default() -> Self {
-        Self {
-            right: true,
-            bottom: true,
         }
     }
 }

--- a/application/apps/indexer/gui/application/src/host/ui/state/preferences.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/state/preferences.rs
@@ -1,0 +1,35 @@
+//! Persisted host UI preferences.
+
+use serde::{Deserialize, Serialize};
+
+/// Host UI preferences stored through eframe persistence.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct HostPreferences {
+    /// Shared visibility for the host right panel and session auxiliary panels.
+    pub panels_visibility: PanelsVisibility,
+}
+
+/// Shared visibility state for the host right panel and session auxiliary panels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PanelsVisibility {
+    /// Controls the right-side panel visibility in home and session views.
+    #[serde(default = "panel_visible_default")]
+    pub right: bool,
+    /// Controls the session bottom panel visibility.
+    #[serde(default = "panel_visible_default")]
+    pub bottom: bool,
+}
+
+impl Default for PanelsVisibility {
+    fn default() -> Self {
+        Self {
+            right: true,
+            bottom: true,
+        }
+    }
+}
+
+fn panel_visible_default() -> bool {
+    true
+}

--- a/application/apps/indexer/gui/application/src/host/ui/storage/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/storage/mod.rs
@@ -1,7 +1,12 @@
-//! Host-side storage coordination.
+//! Host-side storage coordination for app-domain state.
 //!
 //! `HostStorage` owns the UI-facing storage domains and coordinates load/save
 //! requests, while the host service storage worker remains responsible for disk I/O.
+//!
+//! Use this module for heavier application logic state that needs service-owned
+//! persistence, such as recent sessions and file explorer data. Lightweight UI
+//! preferences and presentation state should use `persist`, which is saved directly
+//! through eframe.
 
 use std::{
     sync::mpsc::{self as std_mpsc, Receiver as StdReceiver},
@@ -32,6 +37,7 @@ type SaveConfirmationRx = StdReceiver<Result<(), StorageError>>;
 
 const WAIT_PENDING_SAVE_TIMEOUT: Duration = Duration::from_millis(1000);
 
+/// Coordinates service-backed app-domain storage.
 #[derive(Debug)]
 pub struct HostStorage {
     cmd_tx: mpsc::Sender<HostCommand>,

--- a/application/apps/indexer/gui/application/src/session/ui/logs_table/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/logs_table/mod.rs
@@ -14,7 +14,7 @@ use stypes::GrabbedElement;
 use crate::{
     host::{
         common::parsers::ParserNames,
-        ui::{UiActions, state::PanelsVisibility},
+        ui::{UiActions, state::HostPreferences},
     },
     session::{
         command::{ExportTarget, SessionCommand},
@@ -78,7 +78,7 @@ impl LogsTable {
         &mut self,
         shared: &mut SessionShared,
         actions: &mut UiActions,
-        panels_visibility: &PanelsVisibility,
+        preferences: &mut HostPreferences,
         ui: &mut Ui,
     ) {
         // Disable fade effects on tables to avoid highlighting clashing.
@@ -99,7 +99,7 @@ impl LogsTable {
         }
 
         let search_table_visible =
-            panels_visibility.bottom && shared.bottom_tab == BottomTabType::Search;
+            preferences.panels_visibility.bottom && shared.bottom_tab == BottomTabType::Search;
 
         if let Some(focus) = shared.logs.take_main_row_focus() {
             const OFFSET: u64 = 3;

--- a/application/apps/indexer/gui/application/src/session/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/mod.rs
@@ -16,7 +16,7 @@ use crate::{
             HostAction, UiActions,
             registry::{HostRegistry, filters::FilterRegistry},
             shortcuts::state::LastShortcutKey,
-            state::PanelsVisibility,
+            state::HostPreferences,
             storage::{HostStorage, RecentSessionSource, RecentSessionStateSnapshot},
         },
     },
@@ -116,7 +116,7 @@ impl Session {
         &mut self,
         actions: &mut UiActions,
         registry: &mut HostRegistry,
-        panels_visibility: &mut PanelsVisibility,
+        preferences: &mut HostPreferences,
         ui: &mut Ui,
     ) {
         let Self {
@@ -149,7 +149,7 @@ impl Session {
             .size_range(RESIZABLE_PANEL_MIN_SIZE..=RESIZABLE_PANEL_MAX_SIZE)
             .default_size(RESIZABLE_PANEL_DEFAULT_SIZE)
             .resizable(true)
-            .show_animated_inside(ui, panels_visibility.right, |ui| {
+            .show_animated_inside(ui, preferences.panels_visibility.right, |ui| {
                 ui.take_available_width();
                 side_panel.render_content(ui, shared, actions, registry);
             });
@@ -159,7 +159,7 @@ impl Session {
             .size_range(RESIZABLE_PANEL_MIN_SIZE..=RESIZABLE_PANEL_MAX_SIZE)
             .default_size(RESIZABLE_PANEL_DEFAULT_SIZE)
             .resizable(true)
-            .show_animated_inside(ui, panels_visibility.bottom, |ui| {
+            .show_animated_inside(ui, preferences.panels_visibility.bottom, |ui| {
                 ui.take_available_height();
                 bottom_panel.render_content(shared, actions, registry, ui);
             });
@@ -171,7 +171,7 @@ impl Session {
                 // they will be used as identifiers for table state to avoid ID clashes between
                 // tables from different tabs (different sessions).
                 ui.push_id(shared.get_id(), |ui| {
-                    logs_table.render_content(shared, actions, panels_visibility, ui);
+                    logs_table.render_content(shared, actions, preferences, ui);
                 });
             });
 
@@ -180,7 +180,7 @@ impl Session {
         self.attachment_modal
             .render_content(&mut shared.attachments, ui);
 
-        self.handle_signals(registry, panels_visibility);
+        self.handle_signals(registry, preferences);
     }
 
     fn render_busy_indicator(shared: &SessionShared, actions: &mut UiActions, ui: &Ui) {
@@ -200,16 +200,12 @@ impl Session {
     }
 
     /// Processes frame-local signals queued by child session components.
-    fn handle_signals(
-        &mut self,
-        registry: &mut HostRegistry,
-        panels_visibility: &mut PanelsVisibility,
-    ) {
+    fn handle_signals(&mut self, registry: &mut HostRegistry, preferences: &mut HostPreferences) {
         let signals = std::mem::take(&mut self.shared.signals);
         for event in signals {
             match event {
                 SessionSignal::SearchDropped => self.handle_search_dropped(),
-                SessionSignal::CapturePreset => self.capture_preset(registry, panels_visibility),
+                SessionSignal::CapturePreset => self.capture_preset(registry, preferences),
             }
         }
     }
@@ -220,12 +216,8 @@ impl Session {
     }
 
     /// Opens the presets panel and captures the current session filters and charts.
-    fn capture_preset(
-        &mut self,
-        registry: &mut HostRegistry,
-        panels_visibility: &mut PanelsVisibility,
-    ) {
-        panels_visibility.bottom = true;
+    fn capture_preset(&mut self, registry: &mut HostRegistry, preferences: &mut HostPreferences) {
+        preferences.panels_visibility.bottom = true;
         self.shared.bottom_tab = BottomTabType::Presets;
         self.bottom_panel
             .presets
@@ -462,16 +454,16 @@ impl Session {
     pub fn handle_shortcuts(
         &mut self,
         actions: &mut UiActions,
-        panels_visibility: &mut PanelsVisibility,
+        preferences: &mut HostPreferences,
         ctx: &Context,
         last_key: Option<&LastShortcutKey>,
     ) -> bool {
-        shortcuts::handle(self, actions, panels_visibility, ctx, last_key)
+        shortcuts::handle(self, actions, preferences, ctx, last_key)
     }
 
-    fn activate_search_tab(&mut self, panels_visibility: &mut PanelsVisibility) {
+    fn activate_search_tab(&mut self, preferences: &mut HostPreferences) {
         self.bottom_panel.search.bar.request_focus();
-        self.activate_bottom_tab(BottomTabType::Search, panels_visibility);
+        self.activate_bottom_tab(BottomTabType::Search, preferences);
     }
 
     fn activate_main_logs_table(&mut self, ctx: &Context) {
@@ -479,27 +471,19 @@ impl Session {
         clear_text_edit_focus(ctx);
     }
 
-    fn activate_search_results_table(
-        &mut self,
-        panels_visibility: &mut PanelsVisibility,
-        ctx: &Context,
-    ) {
-        self.activate_bottom_tab(BottomTabType::Search, panels_visibility);
+    fn activate_search_results_table(&mut self, preferences: &mut HostPreferences, ctx: &Context) {
+        self.activate_bottom_tab(BottomTabType::Search, preferences);
         self.shared.view.active_log_table = LogTableKind::Search;
         clear_text_edit_focus(ctx);
     }
 
-    fn activate_bottom_tab(
-        &mut self,
-        tab: BottomTabType,
-        panels_visibility: &mut PanelsVisibility,
-    ) {
-        panels_visibility.bottom = true;
+    fn activate_bottom_tab(&mut self, tab: BottomTabType, preferences: &mut HostPreferences) {
+        preferences.panels_visibility.bottom = true;
         self.shared.bottom_tab = tab;
     }
 
-    fn activate_side_tab(&mut self, tab: SideTabType, panels_visibility: &mut PanelsVisibility) {
-        panels_visibility.right = true;
+    fn activate_side_tab(&mut self, tab: SideTabType, preferences: &mut HostPreferences) {
+        preferences.panels_visibility.right = true;
         self.shared.side_tab = tab;
     }
 
@@ -510,13 +494,13 @@ impl Session {
     fn scroll_active_table(
         &mut self,
         action: TableScroll,
-        panels_visibility: &PanelsVisibility,
+        preferences: &mut HostPreferences,
         ctx: &Context,
     ) {
         let active_target = match self.shared.view.log_table_target(ctx) {
             Some(LogTableKind::Search) => {
-                let search_table_visible =
-                    panels_visibility.bottom && self.shared.bottom_tab == BottomTabType::Search;
+                let search_table_visible = preferences.panels_visibility.bottom
+                    && self.shared.bottom_tab == BottomTabType::Search;
                 if search_table_visible {
                     LogTableKind::Search
                 } else {
@@ -529,13 +513,14 @@ impl Session {
 
         match active_target {
             LogTableKind::Main => self.scroll_main_table(action),
-            LogTableKind::Search => self.scroll_search_table(action, panels_visibility),
+            LogTableKind::Search => self.scroll_search_table(action, preferences),
         }
     }
 
-    fn scroll_search_table(&mut self, action: TableScroll, panels_visibility: &PanelsVisibility) {
+    fn scroll_search_table(&mut self, action: TableScroll, preferences: &mut HostPreferences) {
         // Don't scroll if search table isn't visible.
-        if !panels_visibility.bottom || self.shared.bottom_tab != BottomTabType::Search {
+        if !preferences.panels_visibility.bottom || self.shared.bottom_tab != BottomTabType::Search
+        {
             return;
         }
 

--- a/application/apps/indexer/gui/application/src/session/ui/shortcuts.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/shortcuts.rs
@@ -10,7 +10,7 @@ use crate::{
             matching::{consume_outside_text, consume_shortcut},
             state::LastShortcutKey,
         },
-        state::PanelsVisibility,
+        state::HostPreferences,
     },
     session::command::SessionCommand,
 };
@@ -244,7 +244,7 @@ pub fn shortcut_defs() -> [&'static Shortcut; 21] {
 pub fn handle(
     session: &mut Session,
     actions: &mut UiActions,
-    panels_visibility: &mut PanelsVisibility,
+    preferences: &mut HostPreferences,
     ctx: &Context,
     last_key: Option<&LastShortcutKey>,
 ) -> bool {
@@ -279,17 +279,17 @@ pub fn handle(
     }
 
     if consume_shortcut(ctx, activate_search_output) {
-        session.activate_search_results_table(panels_visibility, ctx);
+        session.activate_search_results_table(preferences, ctx);
         return true;
     }
 
     if consume_shortcut(ctx, active_page_up) {
-        session.scroll_active_table(TableScroll::PageUp, panels_visibility, ctx);
+        session.scroll_active_table(TableScroll::PageUp, preferences, ctx);
         return true;
     }
 
     if consume_shortcut(ctx, active_page_down) {
-        session.scroll_active_table(TableScroll::PageDown, panels_visibility, ctx);
+        session.scroll_active_table(TableScroll::PageDown, preferences, ctx);
         return true;
     }
 
@@ -297,64 +297,64 @@ pub fn handle(
     if last_key.is_some_and(|last_key| last_key.matches_key(Modifiers::NONE, Key::G))
         && consume_outside_text(ctx, active_top)
     {
-        session.scroll_active_table(TableScroll::Top, panels_visibility, ctx);
+        session.scroll_active_table(TableScroll::Top, preferences, ctx);
         return true;
     }
 
     if consume_shortcut(ctx, active_top_direct) {
-        session.scroll_active_table(TableScroll::Top, panels_visibility, ctx);
+        session.scroll_active_table(TableScroll::Top, preferences, ctx);
         return true;
     }
 
     if consume_outside_text(ctx, active_bottom) || consume_shortcut(ctx, active_bottom_direct) {
-        session.scroll_active_table(TableScroll::Bottom, panels_visibility, ctx);
+        session.scroll_active_table(TableScroll::Bottom, preferences, ctx);
         return true;
     }
 
     if consume_shortcut(ctx, activate_search_tab)
         || consume_outside_text(ctx, activate_search_tab_outside_text)
     {
-        session.activate_search_tab(panels_visibility);
+        session.activate_search_tab(preferences);
         return true;
     }
 
     if consume_shortcut(ctx, activate_filters_tab) {
-        session.activate_side_tab(SideTabType::Filters, panels_visibility);
+        session.activate_side_tab(SideTabType::Filters, preferences);
         return true;
     }
 
     if consume_shortcut(ctx, activate_observing_tab) {
-        session.activate_side_tab(SideTabType::Observing, panels_visibility);
+        session.activate_side_tab(SideTabType::Observing, preferences);
         return true;
     }
 
     if consume_shortcut(ctx, activate_attachments_tab) {
-        session.activate_side_tab(SideTabType::Attachments, panels_visibility);
+        session.activate_side_tab(SideTabType::Attachments, preferences);
         return true;
     }
 
     if consume_shortcut(ctx, activate_bottom_search_tab) {
-        session.activate_bottom_tab(BottomTabType::Search, panels_visibility);
+        session.activate_bottom_tab(BottomTabType::Search, preferences);
         return true;
     }
 
     if consume_shortcut(ctx, activate_details_tab) {
-        session.activate_bottom_tab(BottomTabType::Details, panels_visibility);
+        session.activate_bottom_tab(BottomTabType::Details, preferences);
         return true;
     }
 
     if consume_shortcut(ctx, activate_library_tab) {
-        session.activate_bottom_tab(BottomTabType::Library, panels_visibility);
+        session.activate_bottom_tab(BottomTabType::Library, preferences);
         return true;
     }
 
     if consume_shortcut(ctx, activate_presets_tab) {
-        session.activate_bottom_tab(BottomTabType::Presets, panels_visibility);
+        session.activate_bottom_tab(BottomTabType::Presets, preferences);
         return true;
     }
 
     if consume_shortcut(ctx, activate_chart_tab) {
-        session.activate_bottom_tab(BottomTabType::Chart, panels_visibility);
+        session.activate_bottom_tab(BottomTabType::Chart, preferences);
         return true;
     }
 


### PR DESCRIPTION
This PR includes:

* Add persist functionality for UI state used for UI lightweight changes like panels visibility
* Group host UI preferences in one struct and move panels visibility to it.