### PR TITLE
Native: Improve log row header numbering and width sync

### DIFF
--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/chart/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/chart/mod.rs
@@ -179,12 +179,12 @@ impl ChartUI {
             let offset = *logs_rng.start() as f64;
             (ratio, offset)
         } else {
-            let ratio = shared.logs.logs_count as f64 / self.data.bars.len() as f64;
+            let ratio = shared.logs.logs_count() as f64 / self.data.bars.len() as f64;
             (ratio, 0.)
         };
 
         // Function to convert value from x axis while ensuring it's in logs valid bound.
-        let convert_bounded = |x: f64| (x as u64).min(shared.logs.logs_count.saturating_sub(1));
+        let convert_bounded = |x: f64| (x as u64).min(shared.logs.logs_count().saturating_sub(1));
 
         let plot = Plot::new(shared.get_id())
             .legend(Legend::default())
@@ -227,7 +227,7 @@ impl ChartUI {
                 // We need to reset X axis manually to show all logs span.
                 // Y axis can be reset manually since we are not modifying it manually.
 
-                let logs_count = shared.logs.logs_count as f64;
+                let logs_count = shared.logs.logs_count() as f64;
                 let offset = logs_count * CHART_OFFSET;
                 plot_ui.set_plot_bounds_x(-offset..=logs_count + offset);
                 plot_ui.set_auto_bounds([false, true]);
@@ -349,7 +349,7 @@ impl ChartUI {
                 shared.logs.focus_main_row(log_nr, SearchTableSync::Sync);
             }
             PlotResponse::RequestForRange(bound_x) => {
-                self.update_throttle_config(shared.logs.logs_count);
+                self.update_throttle_config(shared.logs.logs_count());
                 self.pending_request_range = None;
                 let retry_range = bound_x.clone();
 
@@ -412,12 +412,12 @@ impl ChartUI {
 
     /// Returns the full chartable log span for the current session.
     fn get_full_range(shared: &SessionShared) -> RangeInclusive<u64> {
-        0..=shared.logs.logs_count.saturating_sub(1)
+        0..=shared.logs.logs_count().saturating_sub(1)
     }
 
     /// Returns the default full-range X bounds applied when the chart follows the live span.
     fn default_bounds(shared: &SessionShared) -> PlotBounds {
-        let logs_count = shared.logs.logs_count as f64;
+        let logs_count = shared.logs.logs_count() as f64;
         let offset = logs_count * CHART_OFFSET;
         PlotBounds::from_min_max([-offset, 0.0], [logs_count + offset, 1.0])
     }
@@ -458,7 +458,7 @@ impl ChartUI {
     fn bounds_request_range(bounds: &PlotBounds, shared: &SessionShared) -> RangeInclusive<u64> {
         let min_x = bounds.min()[0].max(0.0) as u64;
         let max_x = bounds.max()[0].max(0.0) as u64;
-        let max_x = max_x.min(shared.logs.logs_count.saturating_sub(1));
+        let max_x = max_x.min(shared.logs.logs_count().saturating_sub(1));
         min_x..=max_x
     }
 
@@ -550,7 +550,7 @@ mod tests {
         };
 
         let mut shared = SessionShared::new(session_info, observe_op);
-        shared.logs.logs_count = logs_count;
+        shared.logs.set_logs_count(logs_count);
         shared
     }
 
@@ -626,7 +626,7 @@ mod tests {
         let mut chart = new_chart();
         chart.current_request_range = Some(0..=9);
 
-        shared.logs.logs_count = 12;
+        shared.logs.set_logs_count(12);
         chart.on_chart_data_changes(&shared);
 
         assert_eq!(chart.viewport_mode, ChartViewportMode::FollowFullRange);

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_bar.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_bar.rs
@@ -336,7 +336,7 @@ impl SearchBar {
     }
 
     fn render_filter_status(&mut self, shared: &SessionShared, ui: &mut Ui) {
-        let logs_count = shared.logs.logs_count;
+        let logs_count = shared.logs.logs_count();
         if !shared.search.is_search_active() || logs_count == 0 {
             return;
         }

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_table.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/search/search_table.rs
@@ -451,9 +451,11 @@ impl<'a> LogsDelegate<'a> {
                 }
             });
 
+        let row_number_digits = self.shared.logs.row_number_digits();
         let header = render_row_header(
             ui,
-            log_position.to_string(),
+            log_position as u64,
+            row_number_digits,
             source_color_idx,
             is_bookmarked,
             attachment_info,
@@ -552,7 +554,7 @@ impl<'a> LogsDelegate<'a> {
 
 impl TableDelegate for LogsDelegate<'_> {
     fn prepare(&mut self, info: &PrefetchInfo) {
-        if self.shared.logs.logs_count == 0 {
+        if self.shared.logs.logs_count() == 0 {
             return;
         }
 

--- a/application/apps/indexer/gui/application/src/session/ui/common/log_table/table.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/common/log_table/table.rs
@@ -8,7 +8,9 @@ use std::ops::{Range, RangeInclusive};
 
 use egui::{
     Align, Color32, CursorIcon, Frame, Label, Layout, Margin, Rect, Response, RichText, Sense,
-    Shape, Stroke, Ui, Widget as _, vec2,
+    Shape, Stroke, TextStyle, Ui, Widget as _,
+    text::{LayoutJob, TextFormat},
+    vec2,
 };
 use egui_table::{Column, TableState};
 use stypes::ObserveOrigin;
@@ -50,6 +52,8 @@ pub mod grab_cmd_consts {
 const ROW_HEADER_SOURCE_COLOR_WIDTH: f32 = 5.0;
 const ROW_HEADER_BOOKMARK_WIDTH: f32 = 8.0;
 const COLUMN_WIDTH_EPSILON: f32 = 0.25;
+
+const BOOKMARK_EXTRA_SPACING: f32 = 3.0;
 
 /// Vertical scroll command for log-like tables.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -278,16 +282,36 @@ pub struct RowHeaderResponse {
     pub bookmark_clicked: bool,
 }
 
+/// Calculates the minimum width for the first log-table column.
+///
+/// Keep this in sync with [`render_row_header`].
+pub fn row_header_column_width(ui: &Ui, largest_row_nr: u64) -> f32 {
+    let font_id = TextStyle::Monospace.resolve(ui.style());
+    let row_number_width = ui
+        .painter()
+        .layout_no_wrap(largest_row_nr.to_string(), font_id, Color32::TRANSPARENT)
+        .size()
+        .x;
+    let bookmark_width = BOOKMARK_EXTRA_SPACING + ROW_HEADER_BOOKMARK_WIDTH;
+
+    let spacing = ui.spacing().item_spacing.x;
+    // This is a baseline width for row numbers; optional row affordances can still
+    // use egui_table's normal growth because the column is not locked.
+    row_number_width + spacing + bookmark_width + spacing
+}
+
 /// Render the row header for log tables.
 ///
-/// The header contains three parts:
+/// The header contains:
 /// - an optional left-side source-color strip for multi-source sessions,
 /// - the row text,
+/// - an optional attachment affordance,
 /// - a right-side bookmark affordance that owns its own hover/click behavior.
 ///
 pub fn render_row_header(
     ui: &mut Ui,
-    text: String,
+    row_number: u64,
+    row_number_digits: usize,
     source_color_idx: Option<usize>,
     is_bookmarked: bool,
     attachment_info: LogAttachmentInfo,
@@ -308,7 +332,7 @@ pub fn render_row_header(
             }
 
             // Header text
-            let text_res = ui.monospace(text);
+            let text_res = render_row_number(ui, row_number, row_number_digits);
 
             // Attachments
             if let LogAttachmentInfo::WithAttachment { color } = attachment_info {
@@ -325,7 +349,7 @@ pub fn render_row_header(
 
             // Bookmarks
             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                ui.add_space(3.0);
+                ui.add_space(BOOKMARK_EXTRA_SPACING);
                 let (mut bookmark_res, painter) = ui.allocate_painter(
                     vec2(ROW_HEADER_BOOKMARK_WIDTH, ui.available_height()),
                     Sense::click(),
@@ -366,6 +390,32 @@ pub fn render_row_header(
         attachment_clicked,
         bookmark_clicked,
     }
+}
+
+fn render_row_number(ui: &mut Ui, row_number: u64, row_number_digits: usize) -> Response {
+    let row_number = row_number.to_string();
+    let leading_zero_count = row_number_digits.saturating_sub(row_number.len());
+
+    let font_id = TextStyle::Monospace.resolve(ui.style());
+    let normal_format = TextFormat {
+        font_id: font_id.clone(),
+        color: ui.visuals().text_color(),
+        ..Default::default()
+    };
+    let weak_format = TextFormat {
+        font_id,
+        color: ui.visuals().weak_text_color(),
+        ..Default::default()
+    };
+
+    let mut job = LayoutJob::default();
+    if leading_zero_count > 0 {
+        let leading_zeros = "0".repeat(leading_zero_count);
+        job.append(&leading_zeros, 0.0, weak_format);
+    }
+    job.append(&row_number, 0.0, normal_format);
+
+    Label::new(job).ui(ui)
 }
 
 /// Frame for table content cells.

--- a/application/apps/indexer/gui/application/src/session/ui/logs_table/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/logs_table/mod.rs
@@ -27,9 +27,10 @@ use crate::{
                 log_table::{
                     LogTableKind,
                     table::{
-                        self, TableScroll, activate_table_on_click, columns_filling_last,
-                        grab_cmd_consts, render_active_table_indicator, render_row_header,
-                        should_stick_to_bottom, sync_column_widths,
+                        self, TableScroll, activate_table_on_click, apply_columns_to_table_state,
+                        columns_filling_last, grab_cmd_consts, render_active_table_indicator,
+                        render_row_header, row_header_column_width, should_stick_to_bottom,
+                        sync_column_widths,
                     },
                     text::render_log_cell_text,
                 },
@@ -84,12 +85,14 @@ impl LogsTable {
         // Disable fade effects on tables to avoid highlighting clashing.
         ui.style_mut().spacing.scroll.fade.strength = 0.0;
 
+        self.update_row_header_width(shared, ui);
+
         // Ensure the border of last column isn't visible.
         let columns = columns_filling_last(ui, TABLE_ID_SALT, &shared.view.log_columns);
 
         let mut table = egui_table::Table::new()
             .id_salt(TABLE_ID_SALT)
-            .num_rows(shared.logs.logs_count)
+            .num_rows(shared.logs.logs_count())
             .columns(columns)
             .num_sticky_cols(1)
             .stick_to_bottom(should_stick_to_bottom(shared));
@@ -242,7 +245,7 @@ impl LogsTable {
             ParserNames::Text | ParserNames::Plugins => {
                 if ui
                     .add_enabled(
-                        can_start_export && shared.logs.logs_count > 0,
+                        can_start_export && shared.logs.logs_count() > 0,
                         egui::Button::new("Export All Logs"),
                     )
                     .clicked()
@@ -262,7 +265,7 @@ impl LogsTable {
             ParserNames::Dlt | ParserNames::SomeIP => {
                 if ui
                     .add_enabled(
-                        can_start_export && shared.logs.logs_count > 0,
+                        can_start_export && shared.logs.logs_count() > 0,
                         egui::Button::new("Export All as Table"),
                     )
                     .clicked()
@@ -279,6 +282,26 @@ impl LogsTable {
                     ui.close();
                 }
             }
+        }
+    }
+
+    /// Grows the row-header column when the largest row number gains another digit.
+    ///
+    /// # Note:
+    ///
+    /// egui_table can grow the visible main table column on its own, but the search
+    /// table follows this table's columns and may show larger row numbers.
+    fn update_row_header_width(&mut self, shared: &mut SessionShared, ui: &Ui) {
+        let largest_row_nr = shared.logs.logs_count().saturating_sub(1);
+        let width = row_header_column_width(ui, largest_row_nr);
+
+        let Some(column) = shared.view.log_columns.first_mut() else {
+            return;
+        };
+
+        if column.current < width {
+            column.current = width;
+            apply_columns_to_table_state(ui, TABLE_ID_SALT, &shared.view.log_columns);
         }
     }
 
@@ -399,9 +422,11 @@ impl<'a> LogsDelegate<'a> {
                 }
             });
 
+        let row_number_digits = self.shared.logs.row_number_digits();
         let header = render_row_header(
             ui,
-            cell.row_nr.to_string(),
+            cell.row_nr,
+            row_number_digits,
             source_color_idx,
             is_bookmarked,
             attachment_info,
@@ -503,7 +528,7 @@ impl<'a> LogsDelegate<'a> {
 
 impl TableDelegate for LogsDelegate<'_> {
     fn prepare(&mut self, info: &PrefetchInfo) {
-        if self.shared.logs.logs_count == 0 {
+        if self.shared.logs.logs_count() == 0 {
             return;
         }
 

--- a/application/apps/indexer/gui/application/src/session/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/mod.rs
@@ -184,7 +184,10 @@ impl Session {
     }
 
     fn render_busy_indicator(shared: &SessionShared, actions: &mut UiActions, ui: &Ui) {
-        if shared.observe.show_startup_spinner(shared.logs.logs_count) {
+        if shared
+            .observe
+            .show_startup_spinner(shared.logs.logs_count())
+        {
             show_busy_indicator(
                 ui,
                 Some("Initializing Session"),
@@ -242,7 +245,7 @@ impl Session {
         while let Ok(msg) = self.receivers.message_rx.try_recv() {
             match msg {
                 SessionMessage::LogsCount(count) => {
-                    self.shared.logs.logs_count = count;
+                    self.shared.logs.set_logs_count(count);
                     // Keep live-follow charts attached to the growing session span.
                     self.bottom_panel.chart.on_chart_data_changes(&self.shared);
                 }
@@ -478,7 +481,8 @@ impl Session {
     }
 
     fn scroll_main_table(&mut self, action: TableScroll) {
-        self.logs_table.scroll(action, self.shared.logs.logs_count);
+        self.logs_table
+            .scroll(action, self.shared.logs.logs_count());
     }
 
     fn scroll_active_table(

--- a/application/apps/indexer/gui/application/src/session/ui/shared/logs.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/shared/logs.rs
@@ -1,8 +1,11 @@
 use rustc_hash::FxHashSet;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct LogsState {
-    pub logs_count: u64,
+    /// Number of logs currently known for this session.
+    logs_count: u64,
+    /// Digits needed to display the largest zero-based row number.
+    row_number_digits: usize,
     /// Pending request for the main logs table to bring a row into view.
     main_row_focus: Option<MainRowFocus>,
     /// Selected rows keyed by original stream position.
@@ -76,7 +79,39 @@ pub enum SelectionIntent {
     ExtendRange,
 }
 
+impl Default for LogsState {
+    fn default() -> Self {
+        Self {
+            logs_count: 0,
+            row_number_digits: 1,
+            main_row_focus: None,
+            selected_rows: FxHashSet::default(),
+            last_selected_row: None,
+            bookmarked_rows: FxHashSet::default(),
+        }
+    }
+}
+
 impl LogsState {
+    /// Returns the number of known logs in the session.
+    pub fn logs_count(&self) -> u64 {
+        self.logs_count
+    }
+
+    /// Updates the number of known logs and its derived row-number width metadata.
+    pub fn set_logs_count(&mut self, logs_count: u64) {
+        self.logs_count = logs_count;
+        let largest_row = logs_count.saturating_sub(1);
+        self.row_number_digits = largest_row
+            .checked_ilog10()
+            .map_or(1, |digits| digits as usize + 1);
+    }
+
+    /// Returns the digit count needed to display any known zero-based row number.
+    pub fn row_number_digits(&self) -> usize {
+        self.row_number_digits
+    }
+
     /// Returns whether `row` is part of the current selection.
     pub fn is_selected(&self, row: u64) -> bool {
         self.selected_rows.contains(&row)

--- a/application/apps/indexer/gui/application/src/session/ui/status_bar.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/status_bar.rs
@@ -10,7 +10,7 @@ pub fn render_content(shared: &SessionShared, ui: &mut Ui) {
     let selected_count = shared.logs.selected_count();
     let single_selected_row = shared.logs.single_selected_row();
     let search_count = shared.search.search_result_count();
-    let total_count = shared.logs.logs_count;
+    let total_count = shared.logs.logs_count();
 
     ui.horizontal_centered(|ui| {
         Label::new(status_summary_text(


### PR DESCRIPTION
* Render log row numbers with weak leading zero padding so row numbers stay aligned as the log count grows.
* Ensure log row columns has always the minimum size to show maximum log number and the bookmark indicator to avoid cases where search table log numbers are cramped