### PR TITLE
Native Pickers: Quick Open & Command Palette

### DIFF
--- a/application/apps/indexer/Cargo.lock
+++ b/application/apps/indexer/Cargo.lock
@@ -333,6 +333,7 @@ dependencies = [
  "stypes",
  "thiserror 2.0.18",
  "tokio",
+ "unicode-segmentation",
  "uuid",
  "winit",
 ]
@@ -6645,9 +6646,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"

--- a/application/apps/indexer/Cargo.toml
+++ b/application/apps/indexer/Cargo.toml
@@ -84,6 +84,7 @@ rustc-hash = "2.1"
 enum-iterator = "2"
 nucleo-matcher = "0.3"
 anstyle-parse = "1.0"
+unicode-segmentation = "1.13"
 
 clap = { version = "4", features = ["derive"] }
 

--- a/application/apps/indexer/gui/application/Cargo.toml
+++ b/application/apps/indexer/gui/application/Cargo.toml
@@ -51,6 +51,7 @@ enum-iterator.workspace = true
 blake3.workspace = true
 nucleo-matcher.workspace = true
 anstyle-parse.workspace = true
+unicode-segmentation.workspace = true
 
 #TODO: Replace env logger with log4rs
 env_logger.workspace = true

--- a/application/apps/indexer/gui/application/README.md
+++ b/application/apps/indexer/gui/application/README.md
@@ -151,4 +151,4 @@ chipmunk --help
 - [x] Attachment support and preview
 - [ ] Log import/export
 - [x] Plugin support
-- [ ] Command palette and keyboard shortcuts
+- [x] Command palette and keyboard shortcuts

--- a/application/apps/indexer/gui/application/src/common/action_throttle.rs
+++ b/application/apps/indexer/gui/application/src/common/action_throttle.rs
@@ -57,6 +57,11 @@ impl ActionThrottle {
         false
     }
 
+    /// Delays the next action until the full interval has elapsed.
+    pub fn delay_next(&mut self) {
+        self.last_action = Instant::now();
+    }
+
     /// Resets the throttle, allowing the very next call to `ready()` to return true.
     pub fn reset(&mut self) {
         // Set last_action to the past to ensure immediate trigger.
@@ -95,6 +100,18 @@ mod tests {
         assert!(!throttle.ready(None));
 
         // Wait for interval to pass
+        thread::sleep(interval + Duration::from_millis(10));
+        assert!(throttle.ready(None));
+    }
+
+    #[test]
+    fn test_throttle_delay_next() {
+        let interval = Duration::from_millis(20);
+        let mut throttle = ActionThrottle::new(interval);
+
+        throttle.delay_next();
+        assert!(!throttle.ready(None));
+
         thread::sleep(interval + Duration::from_millis(10));
         assert!(throttle.ready(None));
     }

--- a/application/apps/indexer/gui/application/src/common/matcher/fuzzy_matcher.rs
+++ b/application/apps/indexer/gui/application/src/common/matcher/fuzzy_matcher.rs
@@ -1,0 +1,180 @@
+//! Case-insensitive fuzzy matching for small UI-side pickers.
+//!
+//! This wraps `nucleo-matcher` behind a tiny API suited for egui state.
+//! Queries are built explicitly on text changes and reused during row matching.
+
+// Stage 2 adds this module before Command Palette consumes it.
+#![allow(dead_code)]
+
+use std::ops::{Not, Range};
+
+use nucleo_matcher::{
+    Matcher, Utf32Str,
+    pattern::{Atom, AtomKind, CaseMatching, Normalization},
+};
+
+use super::nucleo_highlight_ranges;
+
+/// Reusable case-insensitive fuzzy matcher for UI text filtering.
+#[derive(Debug, Clone, Default)]
+pub struct FuzzyMatcher {
+    matcher: Matcher,
+    query: Option<Atom>,
+    text_buf: Vec<char>,
+    /// Reused memory buffer for `Atom::indices`, which nucleo appends into.
+    indices_buf: Vec<u32>,
+}
+
+impl FuzzyMatcher {
+    /// Rebuilds the compiled query for subsequent fuzzy matches.
+    ///
+    /// Passing an empty string clears the current query and resets the matcher.
+    ///
+    /// # Note:
+    /// Call this when the user-entered query changes, not on every frame.
+    pub fn build_query(&mut self, query: &str) {
+        self.query = query.is_empty().not().then(|| {
+            Atom::new(
+                query,
+                CaseMatching::Ignore,
+                Normalization::Never,
+                AtomKind::Fuzzy,
+                false,
+            )
+        });
+    }
+
+    /// Returns whether a non-empty query is currently built.
+    pub fn has_query(&self) -> bool {
+        self.query.is_some()
+    }
+
+    /// Returns the fuzzy score for `text` against the current query.
+    ///
+    /// An empty query matches all input text with score `0`.
+    pub fn score(&mut self, text: &str) -> Option<u16> {
+        let Some(query) = self.query.as_ref() else {
+            return Some(0);
+        };
+
+        query.score(Utf32Str::new(text, &mut self.text_buf), &mut self.matcher)
+    }
+
+    /// Returns whether `text` matches the current query.
+    ///
+    /// An empty query matches all input text.
+    pub fn matches(&mut self, text: &str) -> bool {
+        self.score(text).is_some()
+    }
+
+    /// Returns byte ranges for underlining the current fuzzy match inside `text`.
+    ///
+    /// Nucleo reports match positions as text indices, so this converts them to
+    /// byte ranges that can safely slice the original string. Empty queries and
+    /// non-matching text produce no highlight ranges.
+    pub fn highlight_ranges(&mut self, text: &str) -> Vec<Range<usize>> {
+        let Some(query) = self.query.as_ref() else {
+            return Vec::new();
+        };
+
+        self.indices_buf.clear();
+        let matched = query.indices(
+            Utf32Str::new(text, &mut self.text_buf),
+            &mut self.matcher,
+            &mut self.indices_buf,
+        );
+
+        if matched.is_none() {
+            return Vec::new();
+        }
+
+        nucleo_highlight_ranges(text, &mut self.indices_buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FuzzyMatcher;
+
+    #[test]
+    fn empty_query_matches_all_text() {
+        let mut matcher = FuzzyMatcher::default();
+        matcher.build_query("");
+
+        assert!(!matcher.has_query());
+        assert_eq!(matcher.score("alpha"), Some(0));
+        assert!(matcher.matches("alpha"));
+        assert!(matcher.matches(""));
+    }
+
+    #[test]
+    fn empty_query_has_no_highlight_ranges() {
+        let mut matcher = FuzzyMatcher::default();
+        matcher.build_query("");
+
+        assert!(matcher.highlight_ranges("alpha").is_empty());
+    }
+
+    #[test]
+    fn matching_is_case_insensitive() {
+        let mut matcher = FuzzyMatcher::default();
+        matcher.build_query("ER");
+
+        assert!(matcher.has_query());
+        assert!(matcher.matches("status error"));
+        assert!(matcher.score("ERROR").is_some());
+    }
+
+    #[test]
+    fn fuzzy_matching_supports_gaps() {
+        let mut matcher = FuzzyMatcher::default();
+        matcher.build_query("fb");
+
+        assert!(matcher.matches("foo bar"));
+        assert_eq!(matcher.highlight_ranges("foo bar"), vec![0..1, 4..5]);
+    }
+
+    #[test]
+    fn non_matching_text_returns_no_score_or_match() {
+        let mut matcher = FuzzyMatcher::default();
+        matcher.build_query("fb");
+
+        assert_eq!(matcher.score("foo car"), None);
+        assert!(!matcher.matches("foo car"));
+        assert!(matcher.highlight_ranges("foo car").is_empty());
+    }
+
+    #[test]
+    fn highlight_ranges_are_valid_byte_ranges() {
+        let mut matcher = FuzzyMatcher::default();
+        matcher.build_query("äb");
+        let text = "xxÄyyb";
+
+        let ranges = matcher.highlight_ranges(text);
+
+        assert_eq!(ranges, vec![2..4, 6..7]);
+        for range in ranges {
+            assert!(text.is_char_boundary(range.start));
+            assert!(text.is_char_boundary(range.end));
+        }
+    }
+
+    #[test]
+    fn highlights_full_grapheme_for_combining_text() {
+        let mut matcher = FuzzyMatcher::default();
+        matcher.build_query("e");
+
+        assert_eq!(matcher.highlight_ranges("e\u{301}clair"), vec![0..3]);
+    }
+
+    #[test]
+    fn replaces_previous_query() {
+        let mut matcher = FuzzyMatcher::default();
+        matcher.build_query("foo");
+        assert!(matcher.matches("foo"));
+
+        matcher.build_query("bar");
+        assert!(!matcher.matches("foo"));
+        assert!(matcher.matches("bar"));
+    }
+}

--- a/application/apps/indexer/gui/application/src/common/matcher/mod.rs
+++ b/application/apps/indexer/gui/application/src/common/matcher/mod.rs
@@ -1,0 +1,98 @@
+//! Shared text matchers for UI-side filtering and picker search.
+
+use std::ops::Range;
+
+use unicode_segmentation::UnicodeSegmentation;
+
+pub mod fuzzy_matcher;
+pub mod substring_matcher;
+
+/// Converts nucleo match indices into merged byte ranges for safe string slicing.
+fn nucleo_highlight_ranges(text: &str, indices: &mut Vec<u32>) -> Vec<Range<usize>> {
+    if indices.is_empty() {
+        return Vec::new();
+    }
+
+    indices.sort_unstable();
+    indices.dedup();
+
+    // Mirrors `Utf32Str::new`, which keeps raw bytes when grapheme heads are ASCII.
+    let uses_byte_indices = text.is_ascii()
+        || text
+            .graphemes(true)
+            .all(|grapheme| grapheme.chars().next().is_some_and(|ch| ch.is_ascii()));
+
+    let ranges = if uses_byte_indices {
+        byte_index_ranges(text, indices)
+    } else {
+        grapheme_index_ranges(text, indices)
+    };
+
+    merge_ranges(ranges)
+}
+
+/// Converts nucleo indices that already point into the original string bytes.
+fn byte_index_ranges(text: &str, indices: &[u32]) -> Vec<Range<usize>> {
+    let mut ranges = Vec::with_capacity(indices.len());
+
+    for &index in indices {
+        let start = index as usize;
+        if start >= text.len() {
+            continue;
+        }
+
+        if text.is_ascii() {
+            ranges.push(start..start + 1);
+        } else if let Some(range) = grapheme_range_containing(text, start) {
+            ranges.push(range);
+        }
+    }
+
+    ranges
+}
+
+/// Converts nucleo indices that refer to grapheme positions in the string.
+fn grapheme_index_ranges(text: &str, indices: &[u32]) -> Vec<Range<usize>> {
+    let mut ranges = Vec::with_capacity(indices.len());
+    let mut next_index = 0;
+
+    for (grapheme_index, (start, grapheme)) in text.grapheme_indices(true).enumerate() {
+        while next_index < indices.len() && (indices[next_index] as usize) < grapheme_index {
+            next_index += 1;
+        }
+        if next_index >= indices.len() {
+            break;
+        }
+        if (indices[next_index] as usize) == grapheme_index {
+            ranges.push(start..start + grapheme.len());
+            next_index += 1;
+        }
+    }
+
+    ranges
+}
+
+/// Returns the full grapheme range that contains `byte_index`.
+fn grapheme_range_containing(text: &str, byte_index: usize) -> Option<Range<usize>> {
+    text.grapheme_indices(true).find_map(|(start, grapheme)| {
+        let end = start + grapheme.len();
+        (start <= byte_index && byte_index < end).then_some(start..end)
+    })
+}
+
+/// Merges touching or overlapping ranges for compact rendering spans.
+fn merge_ranges(ranges: Vec<Range<usize>>) -> Vec<Range<usize>> {
+    let mut merged: Vec<Range<usize>> = Vec::with_capacity(ranges.len());
+
+    for range in ranges {
+        if let Some(last) = merged.last_mut()
+            && range.start <= last.end
+        {
+            last.end = last.end.max(range.end);
+        } else {
+            merged.push(range);
+        }
+    }
+
+    merged
+}

--- a/application/apps/indexer/gui/application/src/common/matcher/substring_matcher.rs
+++ b/application/apps/indexer/gui/application/src/common/matcher/substring_matcher.rs
@@ -9,7 +9,8 @@ use nucleo_matcher::{
     Matcher, Utf32Str,
     pattern::{Atom, AtomKind, CaseMatching, Normalization},
 };
-use unicode_segmentation::UnicodeSegmentation;
+
+use super::nucleo_highlight_ranges;
 
 /// Reusable case-insensitive literal substring matcher for UI text filtering.
 #[derive(Debug, Clone, Default)]
@@ -75,93 +76,12 @@ impl SubstringMatcher {
             &mut self.indices_buf,
         );
 
-        if matched.is_none() || self.indices_buf.is_empty() {
+        if matched.is_none() {
             return Vec::new();
         }
 
-        self.indices_buf.sort_unstable();
-        self.indices_buf.dedup();
-
-        // Mirrors `Utf32Str::new`, which keeps raw bytes when grapheme heads are ASCII.
-        let uses_byte_indices = text.is_ascii()
-            || text
-                .graphemes(true)
-                .all(|grapheme| grapheme.chars().next().is_some_and(|ch| ch.is_ascii()));
-
-        let ranges = if uses_byte_indices {
-            byte_index_ranges(text, &self.indices_buf)
-        } else {
-            grapheme_index_ranges(text, &self.indices_buf)
-        };
-
-        merge_ranges(ranges)
+        nucleo_highlight_ranges(text, &mut self.indices_buf)
     }
-}
-
-/// Converts nucleo indices that already point into the original string bytes.
-fn byte_index_ranges(text: &str, indices: &[u32]) -> Vec<Range<usize>> {
-    let mut ranges = Vec::with_capacity(indices.len());
-
-    for &index in indices {
-        let start = index as usize;
-        if start >= text.len() {
-            continue;
-        }
-
-        if text.is_ascii() {
-            ranges.push(start..start + 1);
-        } else if let Some(range) = grapheme_range_containing(text, start) {
-            ranges.push(range);
-        }
-    }
-
-    ranges
-}
-
-/// Converts nucleo indices that refer to grapheme positions in the string.
-fn grapheme_index_ranges(text: &str, indices: &[u32]) -> Vec<Range<usize>> {
-    let mut ranges = Vec::with_capacity(indices.len());
-    let mut next_index = 0;
-
-    for (grapheme_index, (start, grapheme)) in text.grapheme_indices(true).enumerate() {
-        while next_index < indices.len() && (indices[next_index] as usize) < grapheme_index {
-            next_index += 1;
-        }
-        if next_index >= indices.len() {
-            break;
-        }
-        if (indices[next_index] as usize) == grapheme_index {
-            ranges.push(start..start + grapheme.len());
-            next_index += 1;
-        }
-    }
-
-    ranges
-}
-
-/// Returns the full grapheme range that contains `byte_index`.
-fn grapheme_range_containing(text: &str, byte_index: usize) -> Option<Range<usize>> {
-    text.grapheme_indices(true).find_map(|(start, grapheme)| {
-        let end = start + grapheme.len();
-        (start <= byte_index && byte_index < end).then_some(start..end)
-    })
-}
-
-/// Merges touching or overlapping ranges for compact rendering spans.
-fn merge_ranges(ranges: Vec<Range<usize>>) -> Vec<Range<usize>> {
-    let mut merged: Vec<Range<usize>> = Vec::with_capacity(ranges.len());
-
-    for range in ranges {
-        if let Some(last) = merged.last_mut()
-            && range.start <= last.end
-        {
-            last.end = last.end.max(range.end);
-        } else {
-            merged.push(range);
-        }
-    }
-
-    merged
 }
 
 #[cfg(test)]

--- a/application/apps/indexer/gui/application/src/common/mod.rs
+++ b/application/apps/indexer/gui/application/src/common/mod.rs
@@ -4,6 +4,7 @@ pub mod comm_utls;
 pub mod fixed_queue;
 pub mod fonts;
 pub mod logging;
+pub mod matcher;
 pub mod phosphor;
 pub mod time;
 pub mod ui;

--- a/application/apps/indexer/gui/application/src/common/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/common/ui/mod.rs
@@ -1,6 +1,6 @@
 pub mod buttons;
 pub mod modal;
-pub mod substring_matcher;
+pub mod search_picker;
 pub mod tab_strip;
 pub mod visibility_tracker;
 

--- a/application/apps/indexer/gui/application/src/common/ui/search_picker.rs
+++ b/application/apps/indexer/gui/application/src/common/ui/search_picker.rs
@@ -1,0 +1,22 @@
+//! Shared text rendering for searchable picker overlays.
+
+use std::ops::Range;
+
+/// Text plus byte ranges to highlight while rendering a picker row.
+#[derive(Debug, Clone)]
+pub struct SearchPickerText {
+    /// Text to render in the picker row.
+    pub text: String,
+    /// Byte ranges to highlight inside `text`.
+    pub highlights: Vec<Range<usize>>,
+}
+
+impl SearchPickerText {
+    /// Creates picker text with caller-provided highlight byte ranges.
+    pub fn new(text: impl Into<String>, highlights: Vec<Range<usize>>) -> Self {
+        Self {
+            text: text.into(),
+            highlights,
+        }
+    }
+}

--- a/application/apps/indexer/gui/application/src/common/ui/substring_matcher.rs
+++ b/application/apps/indexer/gui/application/src/common/ui/substring_matcher.rs
@@ -3,12 +3,13 @@
 //! This wraps `nucleo-matcher` behind a tiny API suited for egui state.
 //! Queries are built explicitly on text changes and reused during row matching.
 
-use std::ops::Not;
+use std::ops::{Not, Range};
 
 use nucleo_matcher::{
     Matcher, Utf32Str,
     pattern::{Atom, AtomKind, CaseMatching, Normalization},
 };
+use unicode_segmentation::UnicodeSegmentation;
 
 /// Reusable case-insensitive literal substring matcher for UI text filtering.
 #[derive(Debug, Clone, Default)]
@@ -16,6 +17,8 @@ pub struct SubstringMatcher {
     matcher: Matcher,
     query: Option<Atom>,
     text_buf: Vec<char>,
+    /// Reused memory buffer for `Atom::indices`, which nucleo appends into.
+    indices_buf: Vec<u32>,
 }
 
 impl SubstringMatcher {
@@ -54,6 +57,111 @@ impl SubstringMatcher {
             .score(Utf32Str::new(text, &mut self.text_buf), &mut self.matcher)
             .is_some()
     }
+
+    /// Returns byte ranges for underlining the current query match inside `text`.
+    ///
+    /// Nucleo reports match positions as text indices, so this converts them to
+    /// byte ranges that can safely slice the original string. Empty queries and
+    /// non-matching text produce no highlight ranges.
+    pub fn highlight_ranges(&mut self, text: &str) -> Vec<Range<usize>> {
+        let Some(query) = self.query.as_ref() else {
+            return Vec::new();
+        };
+
+        self.indices_buf.clear();
+        let matched = query.indices(
+            Utf32Str::new(text, &mut self.text_buf),
+            &mut self.matcher,
+            &mut self.indices_buf,
+        );
+
+        if matched.is_none() || self.indices_buf.is_empty() {
+            return Vec::new();
+        }
+
+        self.indices_buf.sort_unstable();
+        self.indices_buf.dedup();
+
+        // Mirrors `Utf32Str::new`, which keeps raw bytes when grapheme heads are ASCII.
+        let uses_byte_indices = text.is_ascii()
+            || text
+                .graphemes(true)
+                .all(|grapheme| grapheme.chars().next().is_some_and(|ch| ch.is_ascii()));
+
+        let ranges = if uses_byte_indices {
+            byte_index_ranges(text, &self.indices_buf)
+        } else {
+            grapheme_index_ranges(text, &self.indices_buf)
+        };
+
+        merge_ranges(ranges)
+    }
+}
+
+/// Converts nucleo indices that already point into the original string bytes.
+fn byte_index_ranges(text: &str, indices: &[u32]) -> Vec<Range<usize>> {
+    let mut ranges = Vec::with_capacity(indices.len());
+
+    for &index in indices {
+        let start = index as usize;
+        if start >= text.len() {
+            continue;
+        }
+
+        if text.is_ascii() {
+            ranges.push(start..start + 1);
+        } else if let Some(range) = grapheme_range_containing(text, start) {
+            ranges.push(range);
+        }
+    }
+
+    ranges
+}
+
+/// Converts nucleo indices that refer to grapheme positions in the string.
+fn grapheme_index_ranges(text: &str, indices: &[u32]) -> Vec<Range<usize>> {
+    let mut ranges = Vec::with_capacity(indices.len());
+    let mut next_index = 0;
+
+    for (grapheme_index, (start, grapheme)) in text.grapheme_indices(true).enumerate() {
+        while next_index < indices.len() && (indices[next_index] as usize) < grapheme_index {
+            next_index += 1;
+        }
+        if next_index >= indices.len() {
+            break;
+        }
+        if (indices[next_index] as usize) == grapheme_index {
+            ranges.push(start..start + grapheme.len());
+            next_index += 1;
+        }
+    }
+
+    ranges
+}
+
+/// Returns the full grapheme range that contains `byte_index`.
+fn grapheme_range_containing(text: &str, byte_index: usize) -> Option<Range<usize>> {
+    text.grapheme_indices(true).find_map(|(start, grapheme)| {
+        let end = start + grapheme.len();
+        (start <= byte_index && byte_index < end).then_some(start..end)
+    })
+}
+
+/// Merges touching or overlapping ranges for compact rendering spans.
+fn merge_ranges(ranges: Vec<Range<usize>>) -> Vec<Range<usize>> {
+    let mut merged: Vec<Range<usize>> = Vec::with_capacity(ranges.len());
+
+    for range in ranges {
+        if let Some(last) = merged.last_mut()
+            && range.start <= last.end
+        {
+            last.end = last.end.max(range.end);
+        } else {
+            merged.push(range);
+        }
+    }
+
+    merged
 }
 
 #[cfg(test)]
@@ -78,6 +186,38 @@ mod tests {
         assert!(matcher.has_query());
         assert!(matcher.matches("status error"));
         assert!(!matcher.matches("warning"));
+    }
+
+    #[test]
+    fn highlights_ascii_substring_match() {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query("err");
+
+        assert_eq!(matcher.highlight_ranges("status error"), vec![7..10]);
+    }
+
+    #[test]
+    fn highlights_case_insensitive_match() {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query("err");
+
+        assert_eq!(matcher.highlight_ranges("ERR.log"), vec![0..3]);
+    }
+
+    #[test]
+    fn empty_query_has_no_highlights() {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query("");
+
+        assert!(matcher.highlight_ranges("status error").is_empty());
+    }
+
+    #[test]
+    fn non_matching_text_has_no_highlights() {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query("err");
+
+        assert!(matcher.highlight_ranges("warning").is_empty());
     }
 
     #[test]
@@ -106,6 +246,22 @@ mod tests {
 
         assert!(matcher.matches("xxÄyy"));
         assert!(!matcher.matches("xxyy"));
+    }
+
+    #[test]
+    fn highlights_unicode_case_insensitive_match() {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query("ä");
+
+        assert_eq!(matcher.highlight_ranges("xxÄyy"), vec![2..4]);
+    }
+
+    #[test]
+    fn highlights_full_grapheme_for_combining_text() {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query("e");
+
+        assert_eq!(matcher.highlight_ranges("e\u{301}clair"), vec![0..3]);
     }
 
     #[test]

--- a/application/apps/indexer/gui/application/src/host/common/ui_utls.rs
+++ b/application/apps/indexer/gui/application/src/host/common/ui_utls.rs
@@ -1,8 +1,8 @@
 use std::path::{Component, Path};
 
 use egui::{
-    Align, Color32, Frame, Label, Margin, RichText, TextBuffer, TextEdit, TextStyle, Ui, Vec2,
-    Widget as _,
+    Align, Color32, Frame, Label, Margin, Rect, RichText, TextBuffer, TextEdit, TextStyle, Ui,
+    Vec2, Widget as _,
 };
 
 /// Frame used for neutral grouped content blocks across application UI.
@@ -30,6 +30,17 @@ pub fn main_panel_group_frame(ui: &mut Ui) -> Frame {
         .fill(ui.style().visuals.faint_bg_color)
         .inner_margin(Margin::symmetric(12, 12))
         .outer_margin(Margin::symmetric(0, 4))
+}
+
+/// Returns whether the latest pointer click happened outside the provided rectangle.
+pub fn clicked_outside_rect(ui: &Ui, rect: Rect) -> bool {
+    ui.input(|input| {
+        input.pointer.any_click()
+            && input
+                .pointer
+                .interact_pos()
+                .is_some_and(|pos| !rect.contains(pos))
+    })
 }
 
 /// Show a validation message while preserving the vertical layout slot.

--- a/application/apps/indexer/gui/application/src/host/ui/command_palette/commands.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/command_palette/commands.rs
@@ -1,0 +1,367 @@
+//! Static command list and command-palette actions.
+
+use egui::{Theme, Ui};
+use stypes::FileFormat;
+use tokio::sync::mpsc::Sender;
+
+use crate::{
+    common::{matcher::fuzzy_matcher::FuzzyMatcher, ui::search_picker::SearchPickerText},
+    host::{
+        command::HostCommand,
+        common::{parsers::ParserNames, sources::StreamNames},
+        ui::{
+            UiActions, file_dialog_commands,
+            state::{self, HostState, modal::HostModal},
+        },
+    },
+};
+
+use super::CommandPaletteItem;
+
+/// Host-level action launched from a command-palette result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandAction {
+    GoHome,
+    OpenFiles,
+    OpenFilesWithPlugin,
+    OpenFolderFiles(FileFormat),
+    CloseCurrentTab,
+    NextTab,
+    PreviousTab,
+    OpenPluginManager,
+    ReloadPlugins,
+    ShowShortcuts,
+    ShowAbout,
+    SetTheme(Theme),
+    ToggleRightPanel,
+    ToggleBottomPanel,
+    ConnectionSetup {
+        stream: StreamNames,
+        parser: ParserNames,
+    },
+}
+
+/// Static command-palette entry.
+#[derive(Debug, Clone, Copy)]
+pub struct CommandDefinition {
+    /// Searchable command title shown in the palette.
+    pub title: &'static str,
+    /// Action executed when this command is selected.
+    pub action: CommandAction,
+}
+
+const COMMANDS: &[CommandDefinition] = &[
+    CommandDefinition {
+        title: "Go to Home",
+        action: CommandAction::GoHome,
+    },
+    CommandDefinition {
+        title: "Open File(s)",
+        action: CommandAction::OpenFiles,
+    },
+    CommandDefinition {
+        title: "Open File(s) with Plugin",
+        action: CommandAction::OpenFilesWithPlugin,
+    },
+    CommandDefinition {
+        title: "Open Text Files from Folder",
+        action: CommandAction::OpenFolderFiles(FileFormat::Text),
+    },
+    CommandDefinition {
+        title: "Open DLT Binary Files from Folder",
+        action: CommandAction::OpenFolderFiles(FileFormat::Binary),
+    },
+    CommandDefinition {
+        title: "Open PcapNG Files from Folder",
+        action: CommandAction::OpenFolderFiles(FileFormat::PcapNG),
+    },
+    CommandDefinition {
+        title: "Open Pcap Files from Folder",
+        action: CommandAction::OpenFolderFiles(FileFormat::PcapLegacy),
+    },
+    CommandDefinition {
+        title: "Close Current Tab",
+        action: CommandAction::CloseCurrentTab,
+    },
+    CommandDefinition {
+        title: "Next Tab",
+        action: CommandAction::NextTab,
+    },
+    CommandDefinition {
+        title: "Previous Tab",
+        action: CommandAction::PreviousTab,
+    },
+    CommandDefinition {
+        title: "Open Plugin Manager",
+        action: CommandAction::OpenPluginManager,
+    },
+    CommandDefinition {
+        title: "Reload Plugins",
+        action: CommandAction::ReloadPlugins,
+    },
+    CommandDefinition {
+        title: "Show Keyboard Shortcuts",
+        action: CommandAction::ShowShortcuts,
+    },
+    CommandDefinition {
+        title: "Show About",
+        action: CommandAction::ShowAbout,
+    },
+    CommandDefinition {
+        title: "Set Dark Theme",
+        action: CommandAction::SetTheme(Theme::Dark),
+    },
+    CommandDefinition {
+        title: "Set Light Theme",
+        action: CommandAction::SetTheme(Theme::Light),
+    },
+    CommandDefinition {
+        title: "Toggle Right Panel",
+        action: CommandAction::ToggleRightPanel,
+    },
+    CommandDefinition {
+        title: "Toggle Bottom Panel",
+        action: CommandAction::ToggleBottomPanel,
+    },
+    CommandDefinition {
+        title: "Terminal with Plain Text",
+        action: CommandAction::ConnectionSetup {
+            stream: StreamNames::Process,
+            parser: ParserNames::Text,
+        },
+    },
+    CommandDefinition {
+        title: "Serial Port with Plain Text",
+        action: CommandAction::ConnectionSetup {
+            stream: StreamNames::Serial,
+            parser: ParserNames::Text,
+        },
+    },
+    CommandDefinition {
+        title: "TCP with DLT",
+        action: CommandAction::ConnectionSetup {
+            stream: StreamNames::Tcp,
+            parser: ParserNames::Dlt,
+        },
+    },
+    CommandDefinition {
+        title: "UDP with DLT",
+        action: CommandAction::ConnectionSetup {
+            stream: StreamNames::Udp,
+            parser: ParserNames::Dlt,
+        },
+    },
+    CommandDefinition {
+        title: "Serial Port with DLT",
+        action: CommandAction::ConnectionSetup {
+            stream: StreamNames::Serial,
+            parser: ParserNames::Dlt,
+        },
+    },
+    CommandDefinition {
+        title: "TCP with SomeIP",
+        action: CommandAction::ConnectionSetup {
+            stream: StreamNames::Tcp,
+            parser: ParserNames::SomeIP,
+        },
+    },
+    CommandDefinition {
+        title: "UDP with SomeIP",
+        action: CommandAction::ConnectionSetup {
+            stream: StreamNames::Udp,
+            parser: ParserNames::SomeIP,
+        },
+    },
+    CommandDefinition {
+        title: "Serial Port with SomeIP",
+        action: CommandAction::ConnectionSetup {
+            stream: StreamNames::Serial,
+            parser: ParserNames::SomeIP,
+        },
+    },
+    CommandDefinition {
+        title: "Terminal with Plugin",
+        action: CommandAction::ConnectionSetup {
+            stream: StreamNames::Process,
+            parser: ParserNames::Plugins,
+        },
+    },
+    CommandDefinition {
+        title: "TCP with Plugin",
+        action: CommandAction::ConnectionSetup {
+            stream: StreamNames::Tcp,
+            parser: ParserNames::Plugins,
+        },
+    },
+    CommandDefinition {
+        title: "UDP with Plugin",
+        action: CommandAction::ConnectionSetup {
+            stream: StreamNames::Udp,
+            parser: ParserNames::Plugins,
+        },
+    },
+    CommandDefinition {
+        title: "Serial Port with Plugin",
+        action: CommandAction::ConnectionSetup {
+            stream: StreamNames::Serial,
+            parser: ParserNames::Plugins,
+        },
+    },
+];
+
+/// Rebuilds command-palette results from the static command list.
+pub fn recompute_results(matcher: &mut FuzzyMatcher) -> Vec<CommandPaletteItem> {
+    let mut matches: Vec<_> = COMMANDS
+        .iter()
+        .enumerate()
+        .filter_map(|(index, command)| {
+            matcher
+                .score(command.title)
+                .map(|score| (index, score, command))
+        })
+        .collect();
+
+    matches.sort_by(
+        |(left_index, left_score, _), (right_index, right_score, _)| {
+            right_score
+                .cmp(left_score)
+                .then_with(|| left_index.cmp(right_index))
+        },
+    );
+
+    matches
+        .into_iter()
+        .map(|(_, _, command)| CommandPaletteItem {
+            title: SearchPickerText::new(command.title, matcher.highlight_ranges(command.title)),
+            action: command.action,
+        })
+        .collect()
+}
+
+/// Executes a command-palette action and returns whether the palette should close.
+pub fn execute_action(
+    action: CommandAction,
+    cmd_tx: &Sender<HostCommand>,
+    state: &mut HostState,
+    actions: &mut UiActions,
+    ui: &Ui,
+) -> bool {
+    match action {
+        CommandAction::GoHome => {
+            state.activate_tab(state::HOME_TAB_IDX);
+            true
+        }
+        CommandAction::OpenFiles => {
+            file_dialog_commands::open_files_dialog(actions);
+            true
+        }
+        CommandAction::OpenFilesWithPlugin => {
+            file_dialog_commands::open_files_with_plugin_dialog(actions);
+            true
+        }
+        CommandAction::OpenFolderFiles(format) => {
+            file_dialog_commands::open_folder_dialog(actions, format);
+            true
+        }
+        CommandAction::CloseCurrentTab => {
+            state.close_active_tab(actions);
+            true
+        }
+        CommandAction::NextTab => {
+            state.activate_next_tab();
+            true
+        }
+        CommandAction::PreviousTab => {
+            state.activate_previous_tab();
+            true
+        }
+        CommandAction::OpenPluginManager => {
+            state.open_plugin_manager();
+            true
+        }
+        CommandAction::ReloadPlugins => {
+            actions.try_send_command(cmd_tx, HostCommand::ReloadPlugins)
+        }
+        CommandAction::ShowShortcuts => {
+            state.modals.open(HostModal::Shortcuts);
+            true
+        }
+        CommandAction::ShowAbout => {
+            state.modals.open(HostModal::About);
+            true
+        }
+        CommandAction::SetTheme(theme) => {
+            ui.ctx().set_theme(theme);
+            true
+        }
+        CommandAction::ToggleRightPanel => {
+            let visible = &mut state.preferences.panels_visibility.right;
+            *visible = !*visible;
+            true
+        }
+        CommandAction::ToggleBottomPanel => {
+            let visible = &mut state.preferences.panels_visibility.bottom;
+            *visible = !*visible;
+            true
+        }
+        CommandAction::ConnectionSetup { stream, parser } => actions.try_send_command(
+            cmd_tx,
+            HostCommand::ConnectionSessionSetup { stream, parser },
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_matcher(query: &str) -> FuzzyMatcher {
+        let mut matcher = FuzzyMatcher::default();
+        matcher.build_query(query);
+        matcher
+    }
+
+    fn result_actions(results: &[CommandPaletteItem]) -> Vec<CommandAction> {
+        results.iter().map(|item| item.action).collect()
+    }
+
+    #[test]
+    fn command_set_matches_initial_palette_scope() {
+        assert_eq!(COMMANDS.len(), 30);
+        assert!(COMMANDS.iter().any(|command| matches!(
+            command.action,
+            CommandAction::ConnectionSetup {
+                stream: StreamNames::Serial,
+                parser: ParserNames::Plugins,
+            }
+        )));
+    }
+
+    #[test]
+    fn empty_query_preserves_command_order() {
+        let mut matcher = build_matcher("");
+
+        let results = recompute_results(&mut matcher);
+
+        assert_eq!(results.len(), COMMANDS.len());
+        let expected: Vec<_> = COMMANDS[..3].iter().map(|command| command.action).collect();
+        assert_eq!(&result_actions(&results)[..3], expected.as_slice());
+        assert!(results.iter().all(|item| item.title.highlights.is_empty()));
+    }
+
+    #[test]
+    fn fuzzy_query_matches_titles_only_and_highlights_title() {
+        let mut matcher = build_matcher("pm");
+
+        let results = recompute_results(&mut matcher);
+
+        assert!(result_actions(&results).contains(&CommandAction::OpenPluginManager));
+        assert!(!result_actions(&results).contains(&CommandAction::ReloadPlugins));
+
+        let plugin_manager = results
+            .iter()
+            .find(|item| item.action == CommandAction::OpenPluginManager)
+            .expect("plugin manager command should match");
+        assert!(!plugin_manager.title.highlights.is_empty());
+    }
+}

--- a/application/apps/indexer/gui/application/src/host/ui/command_palette/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/command_palette/mod.rs
@@ -1,61 +1,41 @@
-//! Host-level Quick Open overlay for recent sessions and favorite files.
+//! Host-level Command Palette overlay for application commands.
 
-use std::{path::PathBuf, sync::Arc, time::Duration};
-
-use egui::{Align, Align2, Context, Key, Modifiers, ScrollArea, Ui, Window, vec2};
+use egui::{Align, Align2, Key, Modifiers, ScrollArea, Ui, Window, vec2};
 use tokio::sync::mpsc::Sender;
 
 use crate::{
-    common::{
-        action_throttle::ActionThrottle, matcher::substring_matcher::SubstringMatcher,
-        ui::search_picker::SearchPickerText,
-    },
+    common::{matcher::fuzzy_matcher::FuzzyMatcher, ui::search_picker::SearchPickerText},
     host::{
-        command::{HostCommand, OpenRecentSessionParam},
+        command::HostCommand,
         common::ui_utls::{clicked_outside_rect, sized_singleline_text_edit},
-        ui::storage::{HostStorage, recent::session::RecentSessionReopenMode},
+        ui::{UiActions, state::HostState},
     },
 };
 
-use super::UiActions;
+use commands::CommandAction;
 
+mod commands;
 mod row;
-mod search;
 
-const RESULT_LIMIT: usize = 100;
-
-/// Searchable launcher for recent sessions and favorite-folder files.
+/// Searchable launcher for global application commands.
 #[derive(Debug)]
-pub struct QuickOpen {
+pub struct CommandPalette {
     cmd_tx: Sender<HostCommand>,
     open: bool,
     query: String,
-    matcher: SubstringMatcher,
-    results: Vec<QuickOpenItem>,
-    /// Cached results need to be rebuilt from current storage.
-    needs_recompute: bool,
-    throttle: ActionThrottle,
+    matcher: FuzzyMatcher,
+    results: Vec<CommandPaletteItem>,
     selected_index: usize,
     /// True until the search field receives focus after opening.
     first_open_frame: bool,
     scroll_selected_into_view: bool,
 }
 
-/// Cached result item containing only display text and the data needed to open it.
-#[derive(Debug)]
-enum QuickOpenItem {
-    /// Recent-session match. The snapshot is looked up by key only when opened.
-    RecentSession {
-        source_key: Arc<str>,
-        title: SearchPickerText,
-        summary: SearchPickerText,
-    },
-    /// Favorite-file match from the current favorite-folder tree.
-    FavoriteFile {
-        path: PathBuf,
-        name: SearchPickerText,
-        path_text: SearchPickerText,
-    },
+/// Cached result item containing display text and the action to execute.
+#[derive(Debug, Clone)]
+struct CommandPaletteItem {
+    title: SearchPickerText,
+    action: CommandAction,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -64,17 +44,19 @@ enum SelectionDirection {
     Next,
 }
 
-impl QuickOpen {
-    /// Creates a closed Quick Open overlay that sends selected items to the host service.
+impl CommandPalette {
+    /// Creates a closed Command Palette overlay.
     pub fn new(cmd_tx: Sender<HostCommand>) -> Self {
+        let mut matcher = FuzzyMatcher::default();
+        matcher.build_query("");
+        let results = commands::recompute_results(&mut matcher);
+
         Self {
             cmd_tx,
             open: false,
             query: String::new(),
-            matcher: SubstringMatcher::default(),
-            results: Vec::new(),
-            needs_recompute: true,
-            throttle: ActionThrottle::new(Duration::from_millis(75)),
+            matcher,
+            results,
             selected_index: 0,
             first_open_frame: false,
             scroll_selected_into_view: false,
@@ -86,7 +68,7 @@ impl QuickOpen {
         self.open
     }
 
-    /// Opens the overlay and starts a fresh search session.
+    /// Opens the overlay and starts a fresh command search session.
     pub fn open(&mut self) {
         let Self {
             cmd_tx: _,
@@ -94,8 +76,6 @@ impl QuickOpen {
             query,
             matcher,
             results,
-            needs_recompute,
-            throttle,
             selected_index,
             first_open_frame,
             scroll_selected_into_view,
@@ -108,37 +88,31 @@ impl QuickOpen {
         *open = true;
         query.clear();
         matcher.build_query("");
-        results.clear();
-        *needs_recompute = true;
+        *results = commands::recompute_results(matcher);
         *selected_index = 0;
         *first_open_frame = true;
         *scroll_selected_into_view = false;
-        throttle.reset();
     }
 
-    /// Consumes Quick Open shortcuts before the active tab or search field can handle them.
-    pub fn handle_input(&mut self, ui: &Ui, storage: &HostStorage, actions: &mut UiActions) {
+    /// Consumes Command Palette keyboard input while the overlay is open.
+    pub fn handle_input(&mut self, ui: &Ui, state: &mut HostState, actions: &mut UiActions) {
         if !self.open {
             return;
         }
 
-        self.refresh_results(storage, ui.ctx());
-
         let mut should_close = false;
-        let mut open_index = None;
-        self.handle_keys(ui, &mut open_index, &mut should_close);
+        let mut execute_index = None;
+        self.handle_keys(ui, &mut execute_index, &mut should_close);
 
-        if let Some(index) = open_index {
-            self.open_result(index, storage, actions);
-        }
-
-        if should_close {
+        if let Some(index) = execute_index {
+            self.execute_result(index, state, actions, ui);
+        } else if should_close {
             self.close();
         }
     }
 
-    /// Renders the Quick Open overlay when it is open.
-    pub fn render(&mut self, parent_ui: &Ui, storage: &HostStorage, actions: &mut UiActions) {
+    /// Renders the Command Palette overlay when it is open.
+    pub fn render(&mut self, parent_ui: &Ui, state: &mut HostState, actions: &mut UiActions) {
         if !self.open {
             return;
         }
@@ -146,12 +120,12 @@ impl QuickOpen {
         const PANEL_WIDTH: f32 = 520.0;
         const PANEL_ANCHOR_HEIGHT: f32 = 440.0;
 
-        let mut open_index = None;
+        let mut execute_index = None;
         let screen_rect = parent_ui.ctx().content_rect();
         let panel_pos = screen_rect.center() + vec2(0.0, -80.0 - PANEL_ANCHOR_HEIGHT * 0.5);
 
-        let window_id = parent_ui.make_persistent_id("quick_open_window");
-        let window_response = Window::new("quick_open")
+        let window_id = parent_ui.make_persistent_id("command_palette_window");
+        let window_response = Window::new("command_palette")
             .id(window_id)
             .title_bar(false)
             .collapsible(false)
@@ -162,12 +136,10 @@ impl QuickOpen {
             .show(parent_ui.ctx(), |ui| {
                 ui.set_width(PANEL_WIDTH);
                 ui.vertical(|ui| {
-                    ui.heading("Quick Open");
+                    ui.heading("Command Palette");
                     ui.add_space(6.0);
 
-                    self.refresh_results(storage, ui.ctx());
-
-                    let search_id = ui.make_persistent_id("quick_open_search");
+                    let search_id = ui.make_persistent_id("command_palette_search");
                     let query_response = sized_singleline_text_edit(
                         ui,
                         &mut self.query,
@@ -175,7 +147,7 @@ impl QuickOpen {
                         7,
                     )
                     .id(search_id)
-                    .hint_text("Search recent sessions and favorite files")
+                    .hint_text("Search commands")
                     .lock_focus(true)
                     .show(ui)
                     .response;
@@ -187,25 +159,18 @@ impl QuickOpen {
 
                     if query_response.changed() {
                         self.matcher.build_query(&self.query);
-                        self.needs_recompute = true;
+                        self.results = commands::recompute_results(&mut self.matcher);
                         self.selected_index = 0;
                         self.scroll_selected_into_view = true;
-                        if self.query.is_empty() {
-                            self.throttle.reset();
-                        } else {
-                            self.throttle.delay_next();
-                        }
                     }
 
-                    self.refresh_results(storage, ui.ctx());
-
                     ui.add_space(8.0);
-                    self.render_results(ui, &mut open_index);
+                    self.render_results(ui, &mut execute_index);
                 });
             });
 
-        if let Some(index) = open_index {
-            self.open_result(index, storage, actions);
+        if let Some(index) = execute_index {
+            self.execute_result(index, state, actions, parent_ui);
         } else if window_response
             .as_ref()
             .is_some_and(|response| clicked_outside_rect(parent_ui, response.response.rect))
@@ -221,8 +186,6 @@ impl QuickOpen {
             query,
             matcher,
             results,
-            needs_recompute,
-            throttle: _,
             selected_index,
             first_open_frame,
             scroll_selected_into_view,
@@ -231,14 +194,13 @@ impl QuickOpen {
         *open = false;
         query.clear();
         matcher.build_query("");
-        results.clear();
-        *needs_recompute = true;
+        *results = commands::recompute_results(matcher);
         *selected_index = 0;
         *first_open_frame = false;
         *scroll_selected_into_view = false;
     }
 
-    fn handle_keys(&mut self, ui: &Ui, open_index: &mut Option<usize>, should_close: &mut bool) {
+    fn handle_keys(&mut self, ui: &Ui, execute_index: &mut Option<usize>, should_close: &mut bool) {
         if ui.input_mut(|input| input.consume_key(Modifiers::NONE, Key::Escape)) {
             *should_close = true;
             return;
@@ -269,7 +231,7 @@ impl QuickOpen {
                 || input.consume_key(Modifiers::CTRL, Key::M)
         }) && !self.results.is_empty()
         {
-            *open_index = Some(self.selected_index.min(self.results.len() - 1));
+            *execute_index = Some(self.selected_index.min(self.results.len() - 1));
         }
     }
 
@@ -289,31 +251,13 @@ impl QuickOpen {
         self.scroll_selected_into_view = true;
     }
 
-    fn refresh_results(&mut self, storage: &HostStorage, ctx: &Context) {
-        if !self.needs_recompute || !self.throttle.ready(Some(ctx)) {
-            return;
-        }
-
-        self.results = search::recompute_results(storage, &mut self.matcher);
-        self.needs_recompute = false;
-        self.clamp_selection();
-    }
-
-    fn clamp_selection(&mut self) {
-        if self.results.is_empty() {
-            self.selected_index = 0;
-        } else if self.selected_index >= self.results.len() {
-            self.selected_index = self.results.len() - 1;
-        }
-    }
-
-    fn render_results(&mut self, ui: &mut Ui, open_index: &mut Option<usize>) {
+    fn render_results(&mut self, ui: &mut Ui, execute_index: &mut Option<usize>) {
         ScrollArea::vertical()
-            .id_salt("quick_open_results")
+            .id_salt("command_palette_results")
             .max_height(360.0)
             .show(ui, |ui| {
                 if self.results.is_empty() {
-                    ui.weak("No matching recent sessions or favorite files.");
+                    ui.weak("No matching commands.");
                     return;
                 }
 
@@ -324,49 +268,47 @@ impl QuickOpen {
                         response.scroll_to_me(Some(Align::Center));
                     }
                     if response.clicked() {
-                        *open_index = Some(index);
+                        *execute_index = Some(index);
                     }
                 }
             });
         self.scroll_selected_into_view = false;
     }
 
-    fn open_result(&mut self, index: usize, storage: &HostStorage, actions: &mut UiActions) {
-        let Some(command) = self.open_command(index, storage) else {
+    fn execute_result(
+        &mut self,
+        index: usize,
+        state: &mut HostState,
+        actions: &mut UiActions,
+        ui: &Ui,
+    ) {
+        let Some(item) = self.results.get(index) else {
             return;
         };
 
-        if actions.try_send_command(&self.cmd_tx, command) {
+        if commands::execute_action(item.action, &self.cmd_tx, state, actions, ui) {
             self.close();
         }
     }
+}
 
-    fn open_command(&mut self, index: usize, storage: &HostStorage) -> Option<HostCommand> {
-        match self.results.get(index)? {
-            QuickOpenItem::RecentSession { source_key, .. } => {
-                let Some(snapshot) = storage
-                    .recent_sessions
-                    .sessions
-                    .iter()
-                    .find(|session| session.source_key.as_ref() == source_key.as_ref())
-                    .cloned()
-                else {
-                    self.close();
-                    return None;
-                };
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-                let params = OpenRecentSessionParam {
-                    snapshot,
-                    mode: RecentSessionReopenMode::RestoreSession,
-                    session_setup_id: None,
-                };
-                let command = HostCommand::OpenRecentSession(Box::new(params));
-                Some(command)
-            }
-            QuickOpenItem::FavoriteFile { path, .. } => {
-                let command = HostCommand::OpenFiles(vec![path.clone()]);
-                Some(command)
-            }
-        }
+    #[test]
+    fn open_resets_query_and_results() {
+        let (cmd_tx, _cmd_rx) = tokio::sync::mpsc::channel(1);
+        let mut palette = CommandPalette::new(cmd_tx);
+        palette.query = "plugin".to_owned();
+        palette.matcher.build_query(&palette.query);
+        palette.results = commands::recompute_results(&mut palette.matcher);
+
+        palette.open();
+
+        assert!(palette.is_open());
+        assert!(palette.query.is_empty());
+        assert!(palette.results.len() > 20);
+        assert_eq!(palette.selected_index, 0);
     }
 }

--- a/application/apps/indexer/gui/application/src/host/ui/command_palette/row.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/command_palette/row.rs
@@ -1,0 +1,132 @@
+//! Command Palette result row rendering.
+
+use egui::{
+    Align, CursorIcon, Direction, Label, Layout, Rect, Response, RichText, Sense, Stroke,
+    TextStyle, Theme, Ui, UiBuilder, Widget, text::LayoutJob, text::TextFormat, vec2,
+};
+
+use crate::{
+    common::{phosphor::icons, ui::search_picker::SearchPickerText},
+    host::common::parsers::ParserNames,
+};
+
+use super::{CommandAction, CommandPaletteItem};
+
+/// Renders one selectable Command Palette result row.
+pub fn render_result_row(ui: &mut Ui, item: &CommandPaletteItem, selected: bool) -> Response {
+    const ROW_HEIGHT: f32 = 36.0;
+    const ICON_COLUMN_WIDTH: f32 = 24.0;
+    const ICON_SIZE: f32 = 16.0;
+    const TITLE_FONT_SIZE: f32 = 14.0;
+
+    let (rect, response) =
+        ui.allocate_exact_size(vec2(ui.available_width(), ROW_HEIGHT), Sense::click());
+    let response = response.on_hover_cursor(CursorIcon::PointingHand);
+
+    let background = if selected {
+        Some(ui.visuals().selection.bg_fill)
+    } else if response.hovered() {
+        Some(ui.visuals().widgets.hovered.bg_fill)
+    } else {
+        None
+    };
+
+    if let Some(background) = background {
+        ui.painter().rect_filled(rect, 0.0, background);
+    }
+
+    let content_rect = rect.shrink2(vec2(8.0, 4.0));
+    let icon_rect = Rect::from_min_size(
+        content_rect.min,
+        vec2(ICON_COLUMN_WIDTH, content_rect.height()),
+    );
+    ui.scope_builder(
+        UiBuilder::new()
+            .max_rect(icon_rect)
+            .layout(Layout::centered_and_justified(Direction::LeftToRight)),
+        |ui| {
+            Label::new(RichText::new(action_icon(item.action)).size(ICON_SIZE)).ui(ui);
+        },
+    );
+
+    let text_rect = Rect::from_min_max(
+        content_rect.min + vec2(ICON_COLUMN_WIDTH, 0.0),
+        content_rect.max,
+    );
+    ui.scope_builder(
+        UiBuilder::new()
+            .max_rect(text_rect)
+            .layout(Layout::left_to_right(Align::Center)),
+        |ui| {
+            render_title(ui, &item.title, TITLE_FONT_SIZE);
+        },
+    );
+
+    response
+}
+
+fn render_title(ui: &mut Ui, title: &SearchPickerText, font_size: f32) {
+    if title.highlights.is_empty() {
+        Label::new(RichText::new(title.text.as_str()).size(font_size))
+            .truncate()
+            .ui(ui);
+        return;
+    }
+
+    let mut font_id = TextStyle::Body.resolve(ui.style());
+    font_id.size = font_size;
+    let color = ui.visuals().text_color();
+    let base_format = TextFormat {
+        font_id,
+        color,
+        ..Default::default()
+    };
+    let highlight_format = TextFormat {
+        underline: Stroke::new(1.0, color),
+        ..base_format.clone()
+    };
+
+    let mut job = LayoutJob::default();
+    let mut cursor = 0;
+    for range in &title.highlights {
+        if cursor < range.start {
+            job.append(&title.text[cursor..range.start], 0.0, base_format.clone());
+        }
+        job.append(
+            &title.text[range.start..range.end],
+            0.0,
+            highlight_format.clone(),
+        );
+        cursor = range.end;
+    }
+
+    if cursor < title.text.len() {
+        job.append(&title.text[cursor..], 0.0, base_format);
+    }
+
+    Label::new(job).truncate().ui(ui);
+}
+
+fn action_icon(action: CommandAction) -> &'static str {
+    match action {
+        CommandAction::GoHome => icons::regular::HOUSE,
+        CommandAction::OpenFiles | CommandAction::OpenFilesWithPlugin => icons::regular::FILES,
+        CommandAction::OpenFolderFiles(_) => icons::regular::FOLDER_OPEN,
+        CommandAction::CloseCurrentTab => icons::regular::X,
+        CommandAction::NextTab | CommandAction::PreviousTab => icons::regular::ARROWS_CLOCKWISE,
+        CommandAction::OpenPluginManager
+        | CommandAction::ReloadPlugins
+        | CommandAction::ConnectionSetup {
+            parser: ParserNames::Plugins,
+            ..
+        } => icons::regular::PLUG,
+        CommandAction::ShowShortcuts => icons::regular::KEYBOARD,
+        CommandAction::ShowAbout => icons::regular::INFO,
+        CommandAction::SetTheme(Theme::Dark) => icons::regular::MOON,
+        CommandAction::SetTheme(Theme::Light) => icons::regular::SUN,
+        CommandAction::ToggleRightPanel | CommandAction::ToggleBottomPanel => {
+            icons::regular::SIDEBAR
+        }
+        CommandAction::ConnectionSetup { .. } => icons::regular::TERMINAL,
+    }
+}

--- a/application/apps/indexer/gui/application/src/host/ui/file_dialog_commands.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/file_dialog_commands.rs
@@ -1,0 +1,129 @@
+//! File dialog commands shared by menus and shortcuts.
+
+use stypes::FileFormat;
+use tokio::sync::mpsc::Sender;
+
+use crate::host::{
+    command::HostCommand,
+    ui::actions::{FileDialogOptions, UiActions},
+};
+
+const OPEN_FILES_ID: &str = "menu_open_files";
+const OPEN_FILES_WITH_PLUGIN_ID: &str = "menu_open_files_with_plugin";
+const TEXT_FILES_FROM_DIR: &str = "menu_text_files";
+const BINARY_DLT_FILES_FROM_DIR: &str = "menu_binary_dlt_files";
+const PCAPNG_FILES_FROM_DIR: &str = "menu_pacpng_files";
+const PCAP_FILES_FROM_DIR: &str = "menu_pcap_files";
+
+/// Opens the generic multi-file picker.
+pub fn open_files_dialog(actions: &mut UiActions) {
+    actions
+        .file_dialog
+        .pick_files(OPEN_FILES_ID, FileDialogOptions::new().title("Open Files"));
+}
+
+/// Opens the multi-file picker for plugin-backed sessions.
+pub fn open_files_with_plugin_dialog(actions: &mut UiActions) {
+    actions.file_dialog.pick_files(
+        OPEN_FILES_WITH_PLUGIN_ID,
+        FileDialogOptions::new().title("Open Files with Plugin"),
+    );
+}
+
+/// Opens a folder picker for files with the requested format.
+pub fn open_folder_dialog(actions: &mut UiActions, format: FileFormat) {
+    actions.file_dialog.pick_folder(
+        id_from_file_format(format),
+        FileDialogOptions::new().title(folder_dialog_title(format)),
+    );
+}
+
+/// Sends host commands for completed file dialog selections.
+pub fn handle_dialog_output(actions: &mut UiActions, cmd_tx: &Sender<HostCommand>) {
+    if let Some((id, paths)) = actions.file_dialog.take_output_many(all_file_dialog_ids())
+        && !paths.is_empty()
+    {
+        if id == OPEN_FILES_ID {
+            actions.try_send_command(cmd_tx, HostCommand::OpenFiles(paths));
+            return;
+        }
+
+        if id == OPEN_FILES_WITH_PLUGIN_ID {
+            actions.try_send_command(cmd_tx, HostCommand::OpenFilesWithPlugin(paths));
+            return;
+        }
+
+        if let Some(target_format) = file_format_from_id(id) {
+            let dir_path = paths
+                .into_iter()
+                .next()
+                .expect("paths length is checked in parent if");
+            let cmd = HostCommand::OpenFromDirectory {
+                dir_path,
+                target_format,
+            };
+            actions.try_send_command(cmd_tx, cmd);
+            return;
+        }
+
+        panic!("File dialog: Not implemented dialog id {id}");
+    }
+}
+
+const fn all_file_dialog_ids() -> &'static [&'static str] {
+    // Reminder on adding new file formats.
+    match FileFormat::Text {
+        FileFormat::PcapNG => {}
+        FileFormat::PcapLegacy => {}
+        FileFormat::Text => {}
+        FileFormat::Binary => {}
+    }
+
+    &[
+        OPEN_FILES_ID,
+        OPEN_FILES_WITH_PLUGIN_ID,
+        TEXT_FILES_FROM_DIR,
+        BINARY_DLT_FILES_FROM_DIR,
+        PCAPNG_FILES_FROM_DIR,
+        PCAP_FILES_FROM_DIR,
+    ]
+}
+
+const fn id_from_file_format(format: FileFormat) -> &'static str {
+    match format {
+        FileFormat::PcapNG => PCAPNG_FILES_FROM_DIR,
+        FileFormat::PcapLegacy => PCAP_FILES_FROM_DIR,
+        FileFormat::Text => TEXT_FILES_FROM_DIR,
+        FileFormat::Binary => BINARY_DLT_FILES_FROM_DIR,
+    }
+}
+
+const fn folder_dialog_title(format: FileFormat) -> &'static str {
+    match format {
+        FileFormat::PcapNG => "Select Folder with PcapNG Files",
+        FileFormat::PcapLegacy => "Select Folder with Pcap Files",
+        FileFormat::Text => "Select Folder with Text Files",
+        // Binary is used here for DLT files to preserve existing behavior.
+        FileFormat::Binary => "Select Folder with DLT Files",
+    }
+}
+
+fn file_format_from_id(id: &str) -> Option<FileFormat> {
+    // Reminder on adding new file formats.
+    match FileFormat::Text {
+        FileFormat::PcapNG => {}
+        FileFormat::PcapLegacy => {}
+        FileFormat::Text => {}
+        FileFormat::Binary => {}
+    }
+
+    let format = match id {
+        TEXT_FILES_FROM_DIR => FileFormat::Text,
+        BINARY_DLT_FILES_FROM_DIR => FileFormat::Binary,
+        PCAPNG_FILES_FROM_DIR => FileFormat::PcapNG,
+        PCAP_FILES_FROM_DIR => FileFormat::PcapLegacy,
+        _ => return None,
+    };
+
+    Some(format)
+}

--- a/application/apps/indexer/gui/application/src/host/ui/home/file_explorer.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/file_explorer.rs
@@ -13,7 +13,7 @@ use egui::{
 use tokio::sync::mpsc::Sender;
 
 use crate::common::{
-    action_throttle::ActionThrottle, phosphor::icons, ui::substring_matcher::SubstringMatcher,
+    action_throttle::ActionThrottle, matcher::substring_matcher::SubstringMatcher, phosphor::icons,
 };
 use crate::host::common::ui_utls::{sized_singleline_text_edit, truncate_path_to_width};
 use crate::host::{
@@ -600,7 +600,7 @@ mod tests {
         FavoriteFolder, FileExplorerUi, FileTreeNode, FileTreeNodeKind, filter_favorite_folders,
     };
     use crate::{
-        common::ui::substring_matcher::SubstringMatcher,
+        common::matcher::substring_matcher::SubstringMatcher,
         host::ui::storage::{
             file_explorer::{FileExplorerData, FileExplorerStorage},
             types::LoadState,

--- a/application/apps/indexer/gui/application/src/host/ui/home/file_explorer.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/file_explorer.rs
@@ -3,7 +3,7 @@
 //! This module renders the home-screen file explorer, manages its transient UI
 //! state, and bridges user actions to the host/storage layers.
 
-use std::{hash::Hash, ops::Not, path::PathBuf};
+use std::{hash::Hash, ops::Not, path::PathBuf, time::Duration};
 
 use egui::{Align, Layout, TextStyle};
 use egui::{
@@ -12,7 +12,9 @@ use egui::{
 };
 use tokio::sync::mpsc::Sender;
 
-use crate::common::{phosphor::icons, ui::substring_matcher::SubstringMatcher};
+use crate::common::{
+    action_throttle::ActionThrottle, phosphor::icons, ui::substring_matcher::SubstringMatcher,
+};
 use crate::host::common::ui_utls::{sized_singleline_text_edit, truncate_path_to_width};
 use crate::host::{
     command::{HostCommand, ScanFavoriteFoldersParam},
@@ -43,6 +45,8 @@ pub struct FileExplorerUi {
     search_matcher: SubstringMatcher,
     /// Filtered favorite-tree snapshot derived from the latest storage revision.
     search_cache: FavoriteSearchCache,
+    /// Limits favorite-tree filtering while the user is typing.
+    search_throttle: ActionThrottle,
 }
 
 /// Cached favorite-file search results and their invalidation keys.
@@ -64,6 +68,7 @@ impl FileExplorerUi {
             search_query: String::new(),
             search_matcher: SubstringMatcher::default(),
             search_cache: FavoriteSearchCache::default(),
+            search_throttle: ActionThrottle::new(Duration::from_millis(100)),
         }
     }
 
@@ -171,8 +176,11 @@ impl FileExplorerUi {
                 .ui(ui);
 
                 if search_response.changed() {
-                    self.search_matcher.build_query(&self.search_query);
-                    self.search_cache.roots = None;
+                    if self.search_query.is_empty() {
+                        self.clear_search_cache(file_explorer.revision);
+                    } else {
+                        self.search_throttle.delay_next();
+                    }
                 }
             },
         );
@@ -189,7 +197,7 @@ impl FileExplorerUi {
             ui.add_space(6.0);
         }
 
-        self.refresh_search_cache(file_explorer);
+        self.refresh_search_cache(file_explorer, Some(ui.ctx()));
 
         egui::ScrollArea::vertical()
             .id_salt("favorite_folders_scroll")
@@ -205,6 +213,9 @@ impl FileExplorerUi {
                 };
 
                 let search_active = !self.search_query.is_empty();
+                let search_cache_current = self.search_cache.roots.is_some()
+                    && self.search_cache.query == self.search_query
+                    && self.search_cache.revision == file_explorer.revision;
 
                 let mut remove_path = None;
 
@@ -214,7 +225,7 @@ impl FileExplorerUi {
                     data.favorite_folders.as_slice()
                 };
 
-                if search_active && favorite_folders.is_empty() {
+                if search_active && search_cache_current && favorite_folders.is_empty() {
                     ui.label("No favorite files match the current search.");
                 }
 
@@ -413,18 +424,30 @@ impl FileExplorerUi {
 
     /// Refreshes the cached favorite-file search result when its invalidation keys change.
     ///
-    /// Empty search text clears the cache. Non-empty searches rebuild only when the query or
-    /// `FileExplorerStorage::revision` differs from the cached values.
-    fn refresh_search_cache(&mut self, file_explorer: &FileExplorerStorage) {
+    /// Empty search text clears the cache. Non-empty query changes are throttled, while
+    /// storage-only changes rebuild immediately.
+    fn refresh_search_cache(
+        &mut self,
+        file_explorer: &FileExplorerStorage,
+        ctx: Option<&egui::Context>,
+    ) {
         if self.search_query.is_empty() {
-            self.search_cache.roots = None;
+            if self.search_cache.roots.is_some() || !self.search_cache.query.is_empty() {
+                self.clear_search_cache(file_explorer.revision);
+            } else {
+                self.search_cache.revision = file_explorer.revision;
+            }
             return;
         }
 
-        if self.search_cache.roots.is_some()
-            && self.search_cache.query == self.search_query
-            && self.search_cache.revision == file_explorer.revision
-        {
+        let query_changed = self.search_cache.query != self.search_query;
+        let revision_changed = self.search_cache.revision != file_explorer.revision;
+        let missing_cache = self.search_cache.roots.is_none();
+        if !query_changed && !revision_changed && !missing_cache {
+            return;
+        }
+
+        if query_changed && !self.search_throttle.ready(ctx) {
             return;
         }
 
@@ -439,6 +462,27 @@ impl FileExplorerUi {
         self.search_cache.query.clone_from(&self.search_query);
         self.search_cache.revision = file_explorer.revision;
         self.search_cache.roots = Some(roots);
+    }
+
+    fn clear_search_cache(&mut self, revision: u64) {
+        let Self {
+            cmd_tx: _,
+            search_query: _,
+            search_matcher,
+            search_cache,
+            search_throttle,
+        } = self;
+        let FavoriteSearchCache {
+            query,
+            revision: cache_revision,
+            roots,
+        } = search_cache;
+
+        search_matcher.build_query("");
+        query.clear();
+        *cache_revision = revision;
+        *roots = None;
+        search_throttle.reset();
     }
 }
 
@@ -531,7 +575,9 @@ fn filter_tree_nodes(nodes: &[FileTreeNode], matcher: &mut SubstringMatcher) -> 
                     kind: FileTreeNodeKind::Folder(children),
                 })
             }
-            FileTreeNodeKind::File => matcher.matches(node.name.as_str()).then(|| node.clone()),
+            FileTreeNodeKind::File => matcher
+                .matches(&node.path.to_string_lossy())
+                .then(|| node.clone()),
         })
         .collect()
 }
@@ -636,9 +682,9 @@ mod tests {
                     ],
                 ),
                 folder_node(
-                    "/root/target-folder",
-                    "target-folder",
-                    vec![file_node("/root/target-folder/other.log", "other.log")],
+                    "/root/archive",
+                    "archive",
+                    vec![file_node("/root/archive/other.log", "other.log")],
                 ),
                 file_node("/root/top.log", "top.log"),
             ],
@@ -655,13 +701,37 @@ mod tests {
     }
 
     #[test]
+    fn search_matches_file_path_segments() {
+        let root = favorite_folder(
+            "/root",
+            vec![
+                folder_node(
+                    "/root/target-folder",
+                    "target-folder",
+                    vec![file_node("/root/target-folder/other.log", "other.log")],
+                ),
+                file_node("/root/top.log", "top.log"),
+            ],
+        );
+
+        let filtered = filter_favorite_folders(&[root], &mut build_matcher("target-folder"));
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(child_names(&filtered[0].children), vec!["target-folder"]);
+        assert_eq!(
+            child_names(folder_children(&filtered[0].children, "target-folder")),
+            vec!["other.log"]
+        );
+    }
+
+    #[test]
     fn search_omits_roots_without_matching_files() {
         let root = favorite_folder(
             "/root",
             vec![folder_node(
-                "/root/target-folder",
-                "target-folder",
-                vec![file_node("/root/target-folder/other.log", "other.log")],
+                "/root/archive",
+                "archive",
+                vec![file_node("/root/archive/other.log", "other.log")],
             )],
         );
 
@@ -681,7 +751,7 @@ mod tests {
             1,
         );
 
-        ui.refresh_search_cache(&storage);
+        ui.refresh_search_cache(&storage, None);
         assert!(ui.search_cache.roots.as_ref().is_some_and(Vec::is_empty));
 
         storage.state = LoadState::Ready(FileExplorerData {
@@ -692,7 +762,7 @@ mod tests {
         });
         storage.revision = 2;
 
-        ui.refresh_search_cache(&storage);
+        ui.refresh_search_cache(&storage, None);
 
         let roots = ui
             .search_cache

--- a/application/apps/indexer/gui/application/src/host/ui/home/recent.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/recent.rs
@@ -218,15 +218,11 @@ impl RecentSessionsUi {
     ) {
         if filter_has_focus {
             let select_direction = ui.input_mut(|input| {
-                if input.consume_key(Modifiers::NONE, Key::ArrowDown)
-                    || input.consume_key(Modifiers::CTRL, Key::N)
-                {
+                if input.consume_key(Modifiers::NONE, Key::ArrowDown) {
                     return Some(SelectionDirection::Next);
                 }
 
-                if input.consume_key(Modifiers::NONE, Key::ArrowUp)
-                    || input.consume_key(Modifiers::CTRL, Key::P)
-                {
+                if input.consume_key(Modifiers::NONE, Key::ArrowUp) {
                     return Some(SelectionDirection::Previous);
                 }
 

--- a/application/apps/indexer/gui/application/src/host/ui/home/recent.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/home/recent.rs
@@ -10,11 +10,13 @@ use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
 
 use crate::{
-    common::ui::{
-        buttons,
-        modal::{ModalSize, show_modal},
-        substring_matcher::SubstringMatcher,
-        visibility_tracker::VisibilityTracker,
+    common::{
+        matcher::substring_matcher::SubstringMatcher,
+        ui::{
+            buttons,
+            modal::{ModalSize, show_modal},
+            visibility_tracker::VisibilityTracker,
+        },
     },
     host::{
         command::{HostCommand, OpenRecentSessionParam},
@@ -440,7 +442,7 @@ mod tests {
 
     use super::{RecentSessionsUi, SelectionDirection, matches_recent_session_query};
     use crate::{
-        common::ui::substring_matcher::SubstringMatcher,
+        common::matcher::substring_matcher::SubstringMatcher,
         host::ui::storage::recent::{
             session::{RecentSessionSnapshot, RecentSessionSource},
             storage::RecentSessionsStorage,

--- a/application/apps/indexer/gui/application/src/host/ui/menu.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/menu.rs
@@ -8,7 +8,8 @@ use crate::{
         command::HostCommand,
         common::{app_style, parsers::ParserNames, sources::StreamNames},
         ui::{
-            actions::{FileDialogOptions, UiActions},
+            actions::UiActions,
+            file_dialog_commands,
             state::{HostState, modal::HostModal},
         },
     },
@@ -18,13 +19,6 @@ use crate::{
 pub struct MainMenuBar {
     cmd_tx: Sender<HostCommand>,
 }
-
-pub const OPEN_FILES_ID: &str = "menu_open_files";
-const OPEN_FILES_WITH_PLUGIN_ID: &str = "menu_open_files_with_plugin";
-const TEXT_FILES_FROM_DIR: &str = "menu_text_files";
-const BINARY_DLT_FILES_FROM_DIR: &str = "menu_binary_dlt_files";
-const PCAPNG_FILES_FROM_DIR: &str = "menu_pacpng_files";
-const PCAP_FILES_FROM_DIR: &str = "menu_pcap_files";
 
 impl MainMenuBar {
     pub fn new(cmd_tx: Sender<HostCommand>) -> Self {
@@ -66,51 +60,30 @@ impl MainMenuBar {
 
             ui.menu_button("File", |ui| {
                 if ui.button("Open File(s)").clicked() {
-                    actions
-                        .file_dialog
-                        .pick_files(OPEN_FILES_ID, FileDialogOptions::new().title("Open Files"));
+                    file_dialog_commands::open_files_dialog(actions);
                 }
 
                 ui.separator();
 
                 ui.menu_button("Select Files from Folder", |ui| {
                     if ui.button("Text").clicked() {
-                        actions.file_dialog.pick_folder(
-                            id_from_file_format(FileFormat::Text),
-                            FileDialogOptions::new().title("Select Folder with Text Files"),
-                        );
+                        file_dialog_commands::open_folder_dialog(actions, FileFormat::Text);
                     }
                     if ui.button("DLT Binary").clicked() {
-                        actions
-                            .file_dialog
-                            // NOTE: Binary is used here actually for DLT files to match the
-                            // behavior in the master branch.
-                            .pick_folder(
-                                id_from_file_format(FileFormat::Binary),
-                                FileDialogOptions::new().title("Select Folder with DLT Files"),
-                            );
+                        file_dialog_commands::open_folder_dialog(actions, FileFormat::Binary);
                     }
                     if ui.button("PcapNG").clicked() {
-                        actions.file_dialog.pick_folder(
-                            id_from_file_format(FileFormat::PcapNG),
-                            FileDialogOptions::new().title("Select Folder with PcapNG Files"),
-                        );
+                        file_dialog_commands::open_folder_dialog(actions, FileFormat::PcapNG);
                     }
                     if ui.button("Pcap").clicked() {
-                        actions.file_dialog.pick_folder(
-                            id_from_file_format(FileFormat::PcapLegacy),
-                            FileDialogOptions::new().title("Select Folder with Pcap Files"),
-                        );
+                        file_dialog_commands::open_folder_dialog(actions, FileFormat::PcapLegacy);
                     }
                 });
 
                 ui.separator();
 
                 if ui.button("Open File(s) with Plugin...").clicked() {
-                    actions.file_dialog.pick_files(
-                        OPEN_FILES_WITH_PLUGIN_ID,
-                        FileDialogOptions::new().title("Open Files with Plugin"),
-                    );
+                    file_dialog_commands::open_files_with_plugin_dialog(actions);
                 }
             });
 
@@ -150,54 +123,8 @@ impl MainMenuBar {
     }
 
     fn handle_file_dialog(&mut self, actions: &mut UiActions) {
-        if let Some((id, paths)) = actions.file_dialog.take_output_many(all_file_dialog_ids())
-            && !paths.is_empty()
-        {
-            if id == OPEN_FILES_ID {
-                actions.try_send_command(&self.cmd_tx, HostCommand::OpenFiles(paths));
-                return;
-            }
-
-            if id == OPEN_FILES_WITH_PLUGIN_ID {
-                actions.try_send_command(&self.cmd_tx, HostCommand::OpenFilesWithPlugin(paths));
-                return;
-            }
-
-            if let Some(target_format) = file_format_from_id(id) {
-                let dir_path = paths
-                    .into_iter()
-                    .next()
-                    .expect("paths length is checked in parent if");
-                let cmd = HostCommand::OpenFromDirectory {
-                    dir_path,
-                    target_format,
-                };
-                actions.try_send_command(&self.cmd_tx, cmd);
-                return;
-            }
-
-            panic!("Menu: Not implemented dialog id {id}");
-        }
+        file_dialog_commands::handle_dialog_output(actions, &self.cmd_tx);
     }
-}
-
-const fn all_file_dialog_ids() -> &'static [&'static str] {
-    // Reminder on adding new file formats.
-    match FileFormat::Text {
-        FileFormat::PcapNG => {}
-        FileFormat::PcapLegacy => {}
-        FileFormat::Text => {}
-        FileFormat::Binary => {}
-    }
-
-    &[
-        OPEN_FILES_ID,
-        OPEN_FILES_WITH_PLUGIN_ID,
-        TEXT_FILES_FROM_DIR,
-        BINARY_DLT_FILES_FROM_DIR,
-        PCAPNG_FILES_FROM_DIR,
-        PCAP_FILES_FROM_DIR,
-    ]
 }
 pub fn render_connections_menu(ui: &mut Ui, actions: &mut UiActions, cmd_tx: &Sender<HostCommand>) {
     if ui.button("DLT on UDP").clicked() {
@@ -275,33 +202,4 @@ pub fn render_connections_menu(ui: &mut Ui, actions: &mut UiActions, cmd_tx: &Se
             },
         );
     }
-}
-
-const fn id_from_file_format(format: FileFormat) -> &'static str {
-    match format {
-        FileFormat::PcapNG => PCAPNG_FILES_FROM_DIR,
-        FileFormat::PcapLegacy => PCAP_FILES_FROM_DIR,
-        FileFormat::Text => TEXT_FILES_FROM_DIR,
-        FileFormat::Binary => BINARY_DLT_FILES_FROM_DIR,
-    }
-}
-
-fn file_format_from_id(id: &str) -> Option<FileFormat> {
-    // Reminder on adding new file formats.
-    match FileFormat::Text {
-        FileFormat::PcapNG => {}
-        FileFormat::PcapLegacy => {}
-        FileFormat::Text => {}
-        FileFormat::Binary => {}
-    }
-
-    let format = match id {
-        TEXT_FILES_FROM_DIR => FileFormat::Text,
-        BINARY_DLT_FILES_FROM_DIR => FileFormat::Binary,
-        PCAPNG_FILES_FROM_DIR => FileFormat::PcapNG,
-        PCAP_FILES_FROM_DIR => FileFormat::PcapLegacy,
-        _ => return None,
-    };
-
-    Some(format)
 }

--- a/application/apps/indexer/gui/application/src/host/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/mod.rs
@@ -22,6 +22,7 @@ use crate::{
         message::HostMessage,
         service::HostService,
         ui::{
+            command_palette::CommandPalette,
             home::HomeView,
             notification::NotificationUi,
             quick_open::QuickOpen,
@@ -42,7 +43,9 @@ pub use actions::{HostAction, UiActions};
 
 pub mod actions;
 mod banners;
+mod command_palette;
 mod dnd_paths;
+mod file_dialog_commands;
 pub mod home;
 mod menu;
 mod modals;
@@ -67,6 +70,7 @@ pub struct Host {
     tabs: TabsUi,
     notifications: NotificationUi,
     quick_open: QuickOpen,
+    command_palette: CommandPalette,
     state: HostState,
     storage: HostStorage,
     ui_actions: UiActions,
@@ -102,6 +106,7 @@ impl Host {
                     senders: ui_comm.senders,
                     notifications: NotificationUi::default(),
                     quick_open: QuickOpen::new(cmd_tx.clone()),
+                    command_palette: CommandPalette::new(cmd_tx.clone()),
                     tabs: TabsUi::default(),
                     state,
                     storage: HostStorage::new(cmd_tx, recent_sessions),
@@ -252,6 +257,8 @@ impl Host {
 
         self.quick_open
             .render(ui, &self.storage, &mut self.ui_actions);
+        self.command_palette
+            .render(ui, &mut self.state, &mut self.ui_actions);
 
         CentralPanel::default()
             .frame(Frame::central_panel(ui.style()).inner_margin(0))
@@ -527,9 +534,12 @@ impl eframe::App for Host {
     }
 
     fn ui(&mut self, ui: &mut Ui, frame: &mut eframe::Frame) {
+        let overlay_was_open = self.quick_open.is_open() || self.command_palette.is_open();
         self.quick_open
             .handle_input(ui, &self.storage, &mut self.ui_actions);
-        if !self.quick_open.is_open() {
+        self.command_palette
+            .handle_input(ui, &mut self.state, &mut self.ui_actions);
+        if !overlay_was_open && !self.quick_open.is_open() && !self.command_palette.is_open() {
             shortcuts::handler::handle(self, ui.ctx());
         }
 

--- a/application/apps/indexer/gui/application/src/host/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/mod.rs
@@ -24,6 +24,7 @@ use crate::{
         ui::{
             home::HomeView,
             notification::NotificationUi,
+            quick_open::QuickOpen,
             session_setup::state::{
                 parsers::ParserConfig,
                 sources::{ByteSourceConfig, ProcessConfig, StreamConfig},
@@ -49,6 +50,7 @@ pub mod multi_setup;
 mod notification;
 mod persist;
 mod plugin_manager;
+mod quick_open;
 mod recent_session;
 pub mod registry;
 pub mod session_setup;
@@ -64,6 +66,7 @@ pub struct Host {
     menu: MainMenuBar,
     tabs: TabsUi,
     notifications: NotificationUi,
+    quick_open: QuickOpen,
     state: HostState,
     storage: HostStorage,
     ui_actions: UiActions,
@@ -98,6 +101,7 @@ impl Host {
                     receivers: ui_comm.receivers,
                     senders: ui_comm.senders,
                     notifications: NotificationUi::default(),
+                    quick_open: QuickOpen::new(cmd_tx.clone()),
                     tabs: TabsUi::default(),
                     state,
                     storage: HostStorage::new(cmd_tx, recent_sessions),
@@ -245,6 +249,9 @@ impl Host {
             .show_inside(ui, |ui| {
                 self.render_tabs(ui);
             });
+
+        self.quick_open
+            .render(ui, &self.storage, &mut self.ui_actions);
 
         CentralPanel::default()
             .frame(Frame::central_panel(ui.style()).inner_margin(0))
@@ -520,7 +527,11 @@ impl eframe::App for Host {
     }
 
     fn ui(&mut self, ui: &mut Ui, frame: &mut eframe::Frame) {
-        shortcuts::handler::handle(self, ui.ctx());
+        self.quick_open
+            .handle_input(ui, &self.storage, &mut self.ui_actions);
+        if !self.quick_open.is_open() {
+            shortcuts::handler::handle(self, ui.ctx());
+        }
 
         self.render_ui(ui, frame);
 

--- a/application/apps/indexer/gui/application/src/host/ui/quick_open/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/quick_open/mod.rs
@@ -2,13 +2,14 @@
 
 use std::{ops::Range, path::PathBuf, sync::Arc, time::Duration};
 
-use egui::{Align, Align2, Context, Key, Modifiers, ScrollArea, TextEdit, Ui, Window, vec2};
+use egui::{Align, Align2, Context, Key, Modifiers, Rect, ScrollArea, Ui, Window, vec2};
 use tokio::sync::mpsc::Sender;
 
 use crate::{
     common::{action_throttle::ActionThrottle, ui::substring_matcher::SubstringMatcher},
     host::{
         command::{HostCommand, OpenRecentSessionParam},
+        common::ui_utls::sized_singleline_text_edit,
         ui::storage::{HostStorage, recent::session::RecentSessionReopenMode},
     },
 };
@@ -162,7 +163,7 @@ impl QuickOpen {
         let panel_pos = screen_rect.center() + vec2(0.0, -80.0 - PANEL_ANCHOR_HEIGHT * 0.5);
 
         let window_id = parent_ui.make_persistent_id("quick_open_window");
-        Window::new("quick_open")
+        let window_response = Window::new("quick_open")
             .id(window_id)
             .title_bar(false)
             .collapsible(false)
@@ -179,13 +180,17 @@ impl QuickOpen {
                     self.refresh_results(storage, ui.ctx());
 
                     let search_id = ui.make_persistent_id("quick_open_search");
-                    let query_response = TextEdit::singleline(&mut self.query)
-                        .id(search_id)
-                        .hint_text("Search recent sessions and favorite files")
-                        .desired_width(f32::INFINITY)
-                        .lock_focus(true)
-                        .show(ui)
-                        .response;
+                    let query_response = sized_singleline_text_edit(
+                        ui,
+                        &mut self.query,
+                        vec2(ui.available_width(), 25.0),
+                        7,
+                    )
+                    .id(search_id)
+                    .hint_text("Search recent sessions and favorite files")
+                    .lock_focus(true)
+                    .show(ui)
+                    .response;
 
                     if self.first_open_frame {
                         query_response.request_focus();
@@ -197,6 +202,11 @@ impl QuickOpen {
                         self.needs_recompute = true;
                         self.selected_index = 0;
                         self.scroll_selected_into_view = true;
+                        if self.query.is_empty() {
+                            self.throttle.reset();
+                        } else {
+                            self.throttle.delay_next();
+                        }
                     }
 
                     self.refresh_results(storage, ui.ctx());
@@ -208,6 +218,11 @@ impl QuickOpen {
 
         if let Some(index) = open_index {
             self.open_result(index, storage, actions);
+        } else if window_response
+            .as_ref()
+            .is_some_and(|response| clicked_outside_window(parent_ui, response.response.rect))
+        {
+            self.close();
         }
     }
 
@@ -366,4 +381,14 @@ impl QuickOpen {
             }
         }
     }
+}
+
+fn clicked_outside_window(ui: &Ui, window_rect: Rect) -> bool {
+    ui.input(|input| {
+        input.pointer.any_click()
+            && input
+                .pointer
+                .interact_pos()
+                .is_some_and(|pos| !window_rect.contains(pos))
+    })
 }

--- a/application/apps/indexer/gui/application/src/host/ui/quick_open/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/quick_open/mod.rs
@@ -1,0 +1,369 @@
+//! Host-level Quick Open overlay for recent sessions and favorite files.
+
+use std::{ops::Range, path::PathBuf, sync::Arc, time::Duration};
+
+use egui::{Align, Align2, Context, Key, Modifiers, ScrollArea, TextEdit, Ui, Window, vec2};
+use tokio::sync::mpsc::Sender;
+
+use crate::{
+    common::{action_throttle::ActionThrottle, ui::substring_matcher::SubstringMatcher},
+    host::{
+        command::{HostCommand, OpenRecentSessionParam},
+        ui::storage::{HostStorage, recent::session::RecentSessionReopenMode},
+    },
+};
+
+use super::UiActions;
+
+mod row;
+mod search;
+
+const RESULT_LIMIT: usize = 100;
+
+/// Searchable launcher for recent sessions and favorite-folder files.
+#[derive(Debug)]
+pub struct QuickOpen {
+    cmd_tx: Sender<HostCommand>,
+    open: bool,
+    query: String,
+    matcher: SubstringMatcher,
+    results: Vec<QuickOpenItem>,
+    /// Cached results need to be rebuilt from current storage.
+    needs_recompute: bool,
+    throttle: ActionThrottle,
+    selected_index: usize,
+    /// True until the search field receives focus after opening.
+    first_open_frame: bool,
+    scroll_selected_into_view: bool,
+}
+
+/// Cached result item containing only display text and the data needed to open it.
+#[derive(Debug)]
+enum QuickOpenItem {
+    /// Recent-session match. The snapshot is looked up by key only when opened.
+    RecentSession {
+        source_key: Arc<str>,
+        title: HighlightedText,
+        summary: HighlightedText,
+    },
+    /// Favorite-file match from the current favorite-folder tree.
+    FavoriteFile {
+        path: PathBuf,
+        name: HighlightedText,
+        path_text: HighlightedText,
+    },
+}
+
+/// Display text plus cached matched-query byte ranges.
+#[derive(Debug)]
+struct HighlightedText {
+    text: String,
+    highlights: Vec<Range<usize>>,
+}
+
+impl HighlightedText {
+    fn new(text: String, matcher: &mut SubstringMatcher) -> Self {
+        let highlights = matcher.highlight_ranges(&text);
+
+        Self { text, highlights }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SelectionDirection {
+    Previous,
+    Next,
+}
+
+impl QuickOpen {
+    /// Creates a closed Quick Open overlay that sends selected items to the host service.
+    pub fn new(cmd_tx: Sender<HostCommand>) -> Self {
+        Self {
+            cmd_tx,
+            open: false,
+            query: String::new(),
+            matcher: SubstringMatcher::default(),
+            results: Vec::new(),
+            needs_recompute: true,
+            throttle: ActionThrottle::new(Duration::from_millis(75)),
+            selected_index: 0,
+            first_open_frame: false,
+            scroll_selected_into_view: false,
+        }
+    }
+
+    /// Returns whether the overlay is currently visible.
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    /// Opens the overlay and starts a fresh search session.
+    pub fn open(&mut self) {
+        let Self {
+            cmd_tx: _,
+            open,
+            query,
+            matcher,
+            results,
+            needs_recompute,
+            throttle,
+            selected_index,
+            first_open_frame,
+            scroll_selected_into_view,
+        } = self;
+
+        if *open {
+            return;
+        }
+
+        *open = true;
+        query.clear();
+        matcher.build_query("");
+        results.clear();
+        *needs_recompute = true;
+        *selected_index = 0;
+        *first_open_frame = true;
+        *scroll_selected_into_view = false;
+        throttle.reset();
+    }
+
+    /// Consumes Quick Open shortcuts before the active tab or search field can handle them.
+    pub fn handle_input(&mut self, ui: &Ui, storage: &HostStorage, actions: &mut UiActions) {
+        if !self.open {
+            return;
+        }
+
+        self.refresh_results(storage, ui.ctx());
+
+        let mut should_close = false;
+        let mut open_index = None;
+        self.handle_keys(ui, &mut open_index, &mut should_close);
+
+        if let Some(index) = open_index {
+            self.open_result(index, storage, actions);
+        }
+
+        if should_close {
+            self.close();
+        }
+    }
+
+    /// Renders the Quick Open overlay when it is open.
+    pub fn render(&mut self, parent_ui: &Ui, storage: &HostStorage, actions: &mut UiActions) {
+        if !self.open {
+            return;
+        }
+
+        const PANEL_WIDTH: f32 = 520.0;
+        const PANEL_ANCHOR_HEIGHT: f32 = 440.0;
+
+        let mut open_index = None;
+        let screen_rect = parent_ui.ctx().content_rect();
+        let panel_pos = screen_rect.center() + vec2(0.0, -80.0 - PANEL_ANCHOR_HEIGHT * 0.5);
+
+        let window_id = parent_ui.make_persistent_id("quick_open_window");
+        Window::new("quick_open")
+            .id(window_id)
+            .title_bar(false)
+            .collapsible(false)
+            .resizable(false)
+            .scroll(false)
+            .fixed_pos(panel_pos)
+            .pivot(Align2::CENTER_TOP)
+            .show(parent_ui.ctx(), |ui| {
+                ui.set_width(PANEL_WIDTH);
+                ui.vertical(|ui| {
+                    ui.heading("Quick Open");
+                    ui.add_space(6.0);
+
+                    self.refresh_results(storage, ui.ctx());
+
+                    let search_id = ui.make_persistent_id("quick_open_search");
+                    let query_response = TextEdit::singleline(&mut self.query)
+                        .id(search_id)
+                        .hint_text("Search recent sessions and favorite files")
+                        .desired_width(f32::INFINITY)
+                        .lock_focus(true)
+                        .show(ui)
+                        .response;
+
+                    if self.first_open_frame {
+                        query_response.request_focus();
+                        self.first_open_frame = false;
+                    }
+
+                    if query_response.changed() {
+                        self.matcher.build_query(&self.query);
+                        self.needs_recompute = true;
+                        self.selected_index = 0;
+                        self.scroll_selected_into_view = true;
+                    }
+
+                    self.refresh_results(storage, ui.ctx());
+
+                    ui.add_space(8.0);
+                    self.render_results(ui, &mut open_index);
+                });
+            });
+
+        if let Some(index) = open_index {
+            self.open_result(index, storage, actions);
+        }
+    }
+
+    fn close(&mut self) {
+        let Self {
+            cmd_tx: _,
+            open,
+            query,
+            matcher,
+            results,
+            needs_recompute,
+            throttle: _,
+            selected_index,
+            first_open_frame,
+            scroll_selected_into_view,
+        } = self;
+
+        *open = false;
+        query.clear();
+        matcher.build_query("");
+        results.clear();
+        *needs_recompute = true;
+        *selected_index = 0;
+        *first_open_frame = false;
+        *scroll_selected_into_view = false;
+    }
+
+    fn handle_keys(&mut self, ui: &Ui, open_index: &mut Option<usize>, should_close: &mut bool) {
+        if ui.input_mut(|input| input.consume_key(Modifiers::NONE, Key::Escape)) {
+            *should_close = true;
+            return;
+        }
+
+        let direction = ui.input_mut(|input| {
+            if input.consume_key(Modifiers::NONE, Key::ArrowDown)
+                || input.consume_key(Modifiers::CTRL, Key::N)
+            {
+                return Some(SelectionDirection::Next);
+            }
+
+            if input.consume_key(Modifiers::NONE, Key::ArrowUp)
+                || input.consume_key(Modifiers::CTRL, Key::P)
+            {
+                return Some(SelectionDirection::Previous);
+            }
+
+            None
+        });
+
+        if let Some(direction) = direction {
+            self.move_selection(direction);
+        }
+
+        if ui.input_mut(|input| {
+            input.consume_key(Modifiers::NONE, Key::Enter)
+                || input.consume_key(Modifiers::CTRL, Key::M)
+        }) && !self.results.is_empty()
+        {
+            *open_index = Some(self.selected_index.min(self.results.len() - 1));
+        }
+    }
+
+    fn move_selection(&mut self, direction: SelectionDirection) {
+        if self.results.is_empty() {
+            self.selected_index = 0;
+            return;
+        }
+
+        self.selected_index = match direction {
+            SelectionDirection::Previous => self
+                .selected_index
+                .checked_sub(1)
+                .unwrap_or(self.results.len() - 1),
+            SelectionDirection::Next => (self.selected_index + 1) % self.results.len(),
+        };
+        self.scroll_selected_into_view = true;
+    }
+
+    fn refresh_results(&mut self, storage: &HostStorage, ctx: &Context) {
+        if !self.needs_recompute || !self.throttle.ready(Some(ctx)) {
+            return;
+        }
+
+        self.results = search::recompute_results(storage, &mut self.matcher);
+        self.needs_recompute = false;
+        self.clamp_selection();
+    }
+
+    fn clamp_selection(&mut self) {
+        if self.results.is_empty() {
+            self.selected_index = 0;
+        } else if self.selected_index >= self.results.len() {
+            self.selected_index = self.results.len() - 1;
+        }
+    }
+
+    fn render_results(&mut self, ui: &mut Ui, open_index: &mut Option<usize>) {
+        ScrollArea::vertical()
+            .id_salt("quick_open_results")
+            .max_height(360.0)
+            .show(ui, |ui| {
+                if self.results.is_empty() {
+                    ui.weak("No matching recent sessions or favorite files.");
+                    return;
+                }
+
+                for (index, item) in self.results.iter().enumerate() {
+                    let selected = index == self.selected_index;
+                    let response = row::render_result_row(ui, item, selected);
+                    if selected && self.scroll_selected_into_view {
+                        response.scroll_to_me(Some(Align::Center));
+                    }
+                    if response.clicked() {
+                        *open_index = Some(index);
+                    }
+                }
+            });
+        self.scroll_selected_into_view = false;
+    }
+
+    fn open_result(&mut self, index: usize, storage: &HostStorage, actions: &mut UiActions) {
+        let Some(command) = self.open_command(index, storage) else {
+            return;
+        };
+
+        if actions.try_send_command(&self.cmd_tx, command) {
+            self.close();
+        }
+    }
+
+    fn open_command(&mut self, index: usize, storage: &HostStorage) -> Option<HostCommand> {
+        match self.results.get(index)? {
+            QuickOpenItem::RecentSession { source_key, .. } => {
+                let Some(snapshot) = storage
+                    .recent_sessions
+                    .sessions
+                    .iter()
+                    .find(|session| session.source_key.as_ref() == source_key.as_ref())
+                    .cloned()
+                else {
+                    self.close();
+                    return None;
+                };
+
+                let params = OpenRecentSessionParam {
+                    snapshot,
+                    mode: RecentSessionReopenMode::RestoreSession,
+                    session_setup_id: None,
+                };
+                let command = HostCommand::OpenRecentSession(Box::new(params));
+                Some(command)
+            }
+            QuickOpenItem::FavoriteFile { path, .. } => {
+                let command = HostCommand::OpenFiles(vec![path.clone()]);
+                Some(command)
+            }
+        }
+    }
+}

--- a/application/apps/indexer/gui/application/src/host/ui/quick_open/row.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/quick_open/row.rs
@@ -1,0 +1,137 @@
+//! Quick Open result row rendering.
+
+use egui::{
+    Align, CursorIcon, Direction, Label, Layout, Rect, Response, RichText, Sense, Stroke,
+    TextStyle, Ui, UiBuilder, Widget,
+    text::{LayoutJob, TextFormat},
+    vec2,
+};
+
+use crate::common::phosphor::icons;
+
+use super::{HighlightedText, QuickOpenItem};
+
+/// Renders one selectable Quick Open result row.
+pub fn render_result_row(ui: &mut Ui, item: &QuickOpenItem, selected: bool) -> Response {
+    const ROW_HEIGHT: f32 = 48.0;
+    const ICON_COLUMN_WIDTH: f32 = 24.0;
+    const ICON_SIZE: f32 = 16.0;
+
+    let (rect, response) =
+        ui.allocate_exact_size(vec2(ui.available_width(), ROW_HEIGHT), Sense::click());
+    let response = response.on_hover_cursor(CursorIcon::PointingHand);
+
+    let background = if selected {
+        Some(ui.visuals().selection.bg_fill)
+    } else if response.hovered() {
+        Some(ui.visuals().widgets.hovered.bg_fill)
+    } else {
+        None
+    };
+
+    if let Some(background) = background {
+        ui.painter().rect_filled(rect, 0.0, background);
+    }
+
+    let content_rect = rect.shrink2(vec2(8.0, 4.0));
+    let icon_rect = Rect::from_min_size(
+        content_rect.min,
+        vec2(ICON_COLUMN_WIDTH, content_rect.height()),
+    );
+    ui.scope_builder(
+        UiBuilder::new()
+            .max_rect(icon_rect)
+            .layout(Layout::centered_and_justified(Direction::LeftToRight)),
+        |ui| {
+            Label::new(RichText::new(item_icon(item)).size(ICON_SIZE)).ui(ui);
+        },
+    );
+
+    let text_rect = Rect::from_min_max(
+        content_rect.min + vec2(ICON_COLUMN_WIDTH, 0.0),
+        content_rect.max,
+    );
+    ui.scope_builder(
+        UiBuilder::new()
+            .max_rect(text_rect)
+            .layout(Layout::top_down(Align::Min)),
+        |ui| match item {
+            QuickOpenItem::RecentSession { title, summary, .. } => {
+                render_text_line(ui, title, true);
+                render_text_line(ui, summary, false);
+            }
+            QuickOpenItem::FavoriteFile {
+                name, path_text, ..
+            } => {
+                render_text_line(ui, name, true);
+                render_text_line(ui, path_text, false);
+            }
+        },
+    );
+
+    response
+}
+
+fn render_text_line(ui: &mut Ui, text: &HighlightedText, primary: bool) {
+    if text.highlights.is_empty() {
+        let content = if primary {
+            RichText::new(text.text.as_str()).strong()
+        } else {
+            RichText::new(text.text.as_str()).size(13.0)
+        };
+        Label::new(content).truncate().ui(ui);
+        return;
+    }
+
+    let job = highlighted_layout(ui, text, primary);
+    Label::new(job).truncate().ui(ui);
+}
+
+fn highlighted_layout(ui: &Ui, text: &HighlightedText, primary: bool) -> LayoutJob {
+    let mut font_id = TextStyle::Body.resolve(ui.style());
+    if !primary {
+        font_id.size = 13.0;
+    }
+
+    let color = if primary {
+        ui.visuals().strong_text_color()
+    } else {
+        ui.visuals().text_color()
+    };
+    let base_format = TextFormat {
+        font_id,
+        color,
+        ..Default::default()
+    };
+    let highlight_format = TextFormat {
+        underline: Stroke::new(1.25, color),
+        ..base_format.clone()
+    };
+
+    let mut job = LayoutJob::default();
+    let mut cursor = 0;
+    for range in &text.highlights {
+        if cursor < range.start {
+            job.append(&text.text[cursor..range.start], 0.0, base_format.clone());
+        }
+        job.append(
+            &text.text[range.start..range.end],
+            0.0,
+            highlight_format.clone(),
+        );
+        cursor = range.end;
+    }
+
+    if cursor < text.text.len() {
+        job.append(&text.text[cursor..], 0.0, base_format);
+    }
+
+    job
+}
+
+fn item_icon(item: &QuickOpenItem) -> &'static str {
+    match item {
+        QuickOpenItem::RecentSession { .. } => icons::regular::ARROW_COUNTER_CLOCKWISE,
+        QuickOpenItem::FavoriteFile { .. } => icons::regular::FILE,
+    }
+}

--- a/application/apps/indexer/gui/application/src/host/ui/quick_open/row.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/quick_open/row.rs
@@ -2,14 +2,12 @@
 
 use egui::{
     Align, CursorIcon, Direction, Label, Layout, Rect, Response, RichText, Sense, Stroke,
-    TextStyle, Ui, UiBuilder, Widget,
-    text::{LayoutJob, TextFormat},
-    vec2,
+    TextStyle, Ui, UiBuilder, Widget, text::LayoutJob, text::TextFormat, vec2,
 };
 
-use crate::common::phosphor::icons;
+use crate::common::{phosphor::icons, ui::search_picker::SearchPickerText};
 
-use super::{HighlightedText, QuickOpenItem};
+use super::QuickOpenItem;
 
 /// Renders one selectable Quick Open result row.
 pub fn render_result_row(ui: &mut Ui, item: &QuickOpenItem, selected: bool) -> Response {
@@ -72,7 +70,7 @@ pub fn render_result_row(ui: &mut Ui, item: &QuickOpenItem, selected: bool) -> R
     response
 }
 
-fn render_text_line(ui: &mut Ui, text: &HighlightedText, primary: bool) {
+fn render_text_line(ui: &mut Ui, text: &SearchPickerText, primary: bool) {
     if text.highlights.is_empty() {
         let content = if primary {
             RichText::new(text.text.as_str()).strong()
@@ -87,7 +85,7 @@ fn render_text_line(ui: &mut Ui, text: &HighlightedText, primary: bool) {
     Label::new(job).truncate().ui(ui);
 }
 
-fn highlighted_layout(ui: &Ui, text: &HighlightedText, primary: bool) -> LayoutJob {
+fn highlighted_layout(ui: &Ui, text: &SearchPickerText, primary: bool) -> LayoutJob {
     let mut font_id = TextStyle::Body.resolve(ui.style());
     if !primary {
         font_id.size = 13.0;

--- a/application/apps/indexer/gui/application/src/host/ui/quick_open/search.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/quick_open/search.rs
@@ -1,0 +1,344 @@
+//! Quick Open source matching and result list construction.
+
+use std::sync::Arc;
+
+use crate::{
+    common::ui::substring_matcher::SubstringMatcher,
+    host::ui::storage::{
+        HostStorage,
+        file_explorer::{FileTreeNode, FileTreeNodeKind},
+        recent::session::RecentSessionSnapshot,
+        types::LoadState,
+    },
+};
+
+use super::{HighlightedText, QuickOpenItem, RESULT_LIMIT};
+
+/// Rebuilds the capped Quick Open result list from current host storage.
+pub fn recompute_results(
+    storage: &HostStorage,
+    matcher: &mut SubstringMatcher,
+) -> Vec<QuickOpenItem> {
+    let mut results = Vec::with_capacity(RESULT_LIMIT);
+
+    append_recent_results(storage, matcher, &mut results);
+    if results.len() < RESULT_LIMIT {
+        append_favorite_results(storage, matcher, &mut results);
+    }
+
+    results
+}
+
+fn append_recent_results(
+    storage: &HostStorage,
+    matcher: &mut SubstringMatcher,
+    results: &mut Vec<QuickOpenItem>,
+) {
+    for session in &storage.recent_sessions.sessions {
+        if results.len() >= RESULT_LIMIT {
+            return;
+        }
+
+        if !matches_recent_session(matcher, session) {
+            continue;
+        }
+
+        results.push(QuickOpenItem::RecentSession {
+            source_key: Arc::clone(&session.source_key),
+            title: HighlightedText::new(session.title().to_owned(), matcher),
+            summary: HighlightedText::new(session.summary().to_owned(), matcher),
+        });
+    }
+}
+
+fn append_favorite_results(
+    storage: &HostStorage,
+    matcher: &mut SubstringMatcher,
+    results: &mut Vec<QuickOpenItem>,
+) {
+    let LoadState::Ready(data) = &storage.file_explorer.state else {
+        return;
+    };
+
+    for folder in &data.favorite_folders {
+        if append_favorite_nodes(&folder.children, matcher, results) {
+            return;
+        }
+    }
+}
+
+fn matches_recent_session(matcher: &mut SubstringMatcher, session: &RecentSessionSnapshot) -> bool {
+    matcher.matches(session.title()) || matcher.matches(session.summary())
+}
+
+fn append_favorite_nodes(
+    nodes: &[FileTreeNode],
+    matcher: &mut SubstringMatcher,
+    results: &mut Vec<QuickOpenItem>,
+) -> bool {
+    for node in nodes {
+        match &node.kind {
+            FileTreeNodeKind::Folder(children) => {
+                if append_favorite_nodes(children, matcher, results) {
+                    return true;
+                }
+            }
+            FileTreeNodeKind::File => {
+                let path_text = node.path.to_string_lossy().into_owned();
+                if matcher.matches(node.name.as_str()) || matcher.matches(&path_text) {
+                    results.push(QuickOpenItem::FavoriteFile {
+                        path: node.path.clone(),
+                        name: HighlightedText::new(node.name.clone(), matcher),
+                        path_text: HighlightedText::new(path_text, matcher),
+                    });
+
+                    if results.len() >= RESULT_LIMIT {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ops::Range, path::PathBuf};
+
+    use stypes::{FileFormat, ParserType};
+
+    use super::recompute_results;
+    use crate::{
+        common::ui::substring_matcher::SubstringMatcher,
+        host::ui::{
+            quick_open::{QuickOpenItem, RESULT_LIMIT},
+            storage::{
+                HostStorage,
+                file_explorer::{FavoriteFolder, FileExplorerData, FileTreeNode, FileTreeNodeKind},
+                recent::{
+                    session::{RecentSessionSnapshot, RecentSessionSource},
+                    storage::RecentSessionsStorage,
+                },
+                types::LoadState,
+            },
+        },
+    };
+
+    fn storage(
+        sessions: Vec<RecentSessionSnapshot>,
+        favorite_folders: Vec<FavoriteFolder>,
+    ) -> HostStorage {
+        let (cmd_tx, _cmd_rx) = tokio::sync::mpsc::channel(1);
+        let mut recent_sessions = RecentSessionsStorage::default();
+        recent_sessions.sessions = sessions;
+        let mut storage = HostStorage::new(cmd_tx, recent_sessions);
+        storage.file_explorer.state = LoadState::Ready(FileExplorerData { favorite_folders });
+        storage
+    }
+
+    fn recent(path: &str, parser: ParserType) -> RecentSessionSnapshot {
+        RecentSessionSnapshot::new(
+            1,
+            vec![RecentSessionSource::File {
+                format: FileFormat::Text,
+                path: PathBuf::from(path),
+            }],
+            parser,
+            Default::default(),
+        )
+    }
+
+    fn file(path: &str, name: &str) -> FileTreeNode {
+        FileTreeNode {
+            path: PathBuf::from(path),
+            name: name.into(),
+            kind: FileTreeNodeKind::File,
+        }
+    }
+
+    fn folder(path: &str, children: Vec<FileTreeNode>) -> FavoriteFolder {
+        FavoriteFolder {
+            path: PathBuf::from(path),
+            children,
+        }
+    }
+
+    fn build_matcher(query: &str) -> SubstringMatcher {
+        let mut matcher = SubstringMatcher::default();
+        matcher.build_query(query);
+        matcher
+    }
+
+    fn result_names(results: &[QuickOpenItem]) -> Vec<&str> {
+        results
+            .iter()
+            .map(|item| match item {
+                QuickOpenItem::RecentSession { title, .. } => title.text.as_str(),
+                QuickOpenItem::FavoriteFile { name, .. } => name.text.as_str(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn empty_query_keeps_recent_then_favorites_order() {
+        let storage = storage(
+            vec![
+                recent("/logs/first.log", ParserType::Text(())),
+                recent("/logs/second.log", ParserType::Text(())),
+            ],
+            vec![folder(
+                "/fav",
+                vec![file("/fav/a.log", "a.log"), file("/fav/b.log", "b.log")],
+            )],
+        );
+        let mut matcher = build_matcher("");
+
+        let results = recompute_results(&storage, &mut matcher);
+
+        assert_eq!(
+            result_names(&results),
+            vec!["first.log", "second.log", "a.log", "b.log"]
+        );
+    }
+
+    #[test]
+    fn query_matches_recent_summary_and_file_path() {
+        let storage = storage(
+            vec![recent("/logs/plain.log", ParserType::Text(()))],
+            vec![folder(
+                "/fav",
+                vec![file("/fav/errors/trace.bin", "trace.bin")],
+            )],
+        );
+
+        let mut matcher = build_matcher("plain");
+        let results = recompute_results(&storage, &mut matcher);
+        assert_eq!(result_names(&results), vec!["plain.log"]);
+
+        let mut matcher = build_matcher("errors");
+        let results = recompute_results(&storage, &mut matcher);
+        assert_eq!(result_names(&results), vec!["trace.bin"]);
+    }
+
+    #[test]
+    fn recent_title_match_is_highlighted() {
+        let storage = storage(
+            vec![recent("/logs/errors.log", ParserType::Text(()))],
+            Vec::new(),
+        );
+        let mut matcher = build_matcher("err");
+
+        let results = recompute_results(&storage, &mut matcher);
+
+        let QuickOpenItem::RecentSession { title, summary, .. } = &results[0] else {
+            panic!("expected recent-session result");
+        };
+        assert_eq!(title.highlights, vec![0..3]);
+        assert!(summary.highlights.is_empty());
+    }
+
+    #[test]
+    fn recent_summary_match_is_highlighted() {
+        let storage = storage(
+            vec![recent("/logs/errors.log", ParserType::Text(()))],
+            Vec::new(),
+        );
+        let mut matcher = build_matcher("plain");
+
+        let results = recompute_results(&storage, &mut matcher);
+
+        let QuickOpenItem::RecentSession { title, summary, .. } = &results[0] else {
+            panic!("expected recent-session result");
+        };
+        assert!(title.highlights.is_empty());
+        assert_eq!(
+            summary.highlights.as_slice(),
+            &[substring_range(&summary.text, "Plain")]
+        );
+    }
+
+    #[test]
+    fn favorite_name_and_path_matches_are_highlighted() {
+        let storage = storage(
+            Vec::new(),
+            vec![folder(
+                "/fav",
+                vec![file("/fav/errors/trace.bin", "trace.bin")],
+            )],
+        );
+
+        let mut matcher = build_matcher("trace");
+        let results = recompute_results(&storage, &mut matcher);
+        let QuickOpenItem::FavoriteFile {
+            name, path_text, ..
+        } = &results[0]
+        else {
+            panic!("expected favorite-file result");
+        };
+        assert_eq!(name.highlights, vec![0..5]);
+        assert_eq!(
+            path_text.highlights.as_slice(),
+            &[substring_range(&path_text.text, "trace")]
+        );
+
+        let mut matcher = build_matcher("errors");
+        let results = recompute_results(&storage, &mut matcher);
+        let QuickOpenItem::FavoriteFile {
+            name, path_text, ..
+        } = &results[0]
+        else {
+            panic!("expected favorite-file result");
+        };
+        assert!(name.highlights.is_empty());
+        assert_eq!(
+            path_text.highlights.as_slice(),
+            &[substring_range(&path_text.text, "errors")]
+        );
+    }
+
+    #[test]
+    fn empty_query_results_have_no_highlights() {
+        let storage = storage(
+            vec![recent("/logs/errors.log", ParserType::Text(()))],
+            vec![folder("/fav", vec![file("/fav/trace.bin", "trace.bin")])],
+        );
+        let mut matcher = build_matcher("");
+
+        let results = recompute_results(&storage, &mut matcher);
+
+        for result in &results {
+            match result {
+                QuickOpenItem::RecentSession { title, summary, .. } => {
+                    assert!(title.highlights.is_empty());
+                    assert!(summary.highlights.is_empty());
+                }
+                QuickOpenItem::FavoriteFile {
+                    name, path_text, ..
+                } => {
+                    assert!(name.highlights.is_empty());
+                    assert!(path_text.highlights.is_empty());
+                }
+            }
+        }
+    }
+
+    fn substring_range(text: &str, substring: &str) -> Range<usize> {
+        let start = text.find(substring).expect("substring should exist");
+        start..start + substring.len()
+    }
+
+    #[test]
+    fn result_cache_is_capped() {
+        let files = (0..(RESULT_LIMIT + 5))
+            .map(|idx| file(&format!("/fav/{idx}.log"), &format!("{idx}.log")))
+            .collect();
+        let storage = storage(Vec::new(), vec![folder("/fav", files)]);
+        let mut matcher = build_matcher("");
+
+        let results = recompute_results(&storage, &mut matcher);
+
+        assert_eq!(results.len(), RESULT_LIMIT);
+    }
+}

--- a/application/apps/indexer/gui/application/src/host/ui/quick_open/search.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/quick_open/search.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use crate::{
-    common::ui::substring_matcher::SubstringMatcher,
+    common::{matcher::substring_matcher::SubstringMatcher, ui::search_picker::SearchPickerText},
     host::ui::storage::{
         HostStorage,
         file_explorer::{FileTreeNode, FileTreeNodeKind},
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 
-use super::{HighlightedText, QuickOpenItem, RESULT_LIMIT};
+use super::{QuickOpenItem, RESULT_LIMIT};
 
 /// Rebuilds the capped Quick Open result list from current host storage.
 pub fn recompute_results(
@@ -45,10 +45,15 @@ fn append_recent_results(
 
         results.push(QuickOpenItem::RecentSession {
             source_key: Arc::clone(&session.source_key),
-            title: HighlightedText::new(session.title().to_owned(), matcher),
-            summary: HighlightedText::new(session.summary().to_owned(), matcher),
+            title: matched_text(session.title().to_owned(), matcher),
+            summary: matched_text(session.summary().to_owned(), matcher),
         });
     }
+}
+
+fn matched_text(text: String, matcher: &mut SubstringMatcher) -> SearchPickerText {
+    let highlights = matcher.highlight_ranges(&text);
+    SearchPickerText::new(text, highlights)
 }
 
 fn append_favorite_results(
@@ -88,8 +93,8 @@ fn append_favorite_nodes(
                 if matcher.matches(node.name.as_str()) || matcher.matches(&path_text) {
                     results.push(QuickOpenItem::FavoriteFile {
                         path: node.path.clone(),
-                        name: HighlightedText::new(node.name.clone(), matcher),
-                        path_text: HighlightedText::new(path_text, matcher),
+                        name: matched_text(node.name.clone(), matcher),
+                        path_text: matched_text(path_text, matcher),
                     });
 
                     if results.len() >= RESULT_LIMIT {
@@ -111,7 +116,7 @@ mod tests {
 
     use super::recompute_results;
     use crate::{
-        common::ui::substring_matcher::SubstringMatcher,
+        common::matcher::substring_matcher::SubstringMatcher,
         host::ui::{
             quick_open::{QuickOpenItem, RESULT_LIMIT},
             storage::{

--- a/application/apps/indexer/gui/application/src/host/ui/session_setup/state/parsers/dlt.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/session_setup/state/parsers/dlt.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 
 use super::FibexFileInfo;
 use crate::{
-    common::ui::substring_matcher::SubstringMatcher,
+    common::matcher::substring_matcher::SubstringMatcher,
     host::common::dlt_stats::{DltStatistics, LevelDistribution},
 };
 

--- a/application/apps/indexer/gui/application/src/host/ui/shortcuts/definitions.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/shortcuts/definitions.rs
@@ -22,6 +22,10 @@ static SHORTCUTS: AppShortcuts = AppShortcuts {
         &[KeyboardShortcut::new(Modifiers::COMMAND, Key::O)],
         "Open file(s)",
     ),
+    quick_open: Shortcut::new(
+        &[KeyboardShortcut::new(Modifiers::COMMAND, Key::P)],
+        "Quick Open",
+    ),
     close_tab: Shortcut::new(CLOSE_TAB_BINDINGS, "Close active tab"),
     previous_tab: Shortcut::new(
         &[KeyboardShortcut::new(
@@ -90,6 +94,8 @@ static SHORTCUTS: AppShortcuts = AppShortcuts {
 pub struct AppShortcuts {
     pub home_tab: Shortcut,
     pub open_files: Shortcut,
+    /// Opens the Quick Open launcher.
+    pub quick_open: Shortcut,
     pub close_tab: Shortcut,
     pub previous_tab: Shortcut,
     pub next_tab: Shortcut,
@@ -146,10 +152,11 @@ pub fn app_shortcuts() -> &'static AppShortcuts {
     &SHORTCUTS
 }
 
-pub fn app_shortcut_defs() -> [&'static Shortcut; 9] {
+pub fn app_shortcut_defs() -> [&'static Shortcut; 10] {
     let AppShortcuts {
         home_tab,
         open_files,
+        quick_open,
         close_tab,
         previous_tab,
         next_tab,
@@ -170,6 +177,7 @@ pub fn app_shortcut_defs() -> [&'static Shortcut; 9] {
     [
         home_tab,
         open_files,
+        quick_open,
         close_tab,
         toggle_right_panel,
         toggle_bottom_panel,

--- a/application/apps/indexer/gui/application/src/host/ui/shortcuts/definitions.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/shortcuts/definitions.rs
@@ -26,6 +26,13 @@ static SHORTCUTS: AppShortcuts = AppShortcuts {
         &[KeyboardShortcut::new(Modifiers::COMMAND, Key::P)],
         "Quick Open",
     ),
+    command_palette: Shortcut::new(
+        &[KeyboardShortcut::new(
+            Modifiers::COMMAND.plus(Modifiers::SHIFT),
+            Key::P,
+        )],
+        "Command Palette",
+    ),
     close_tab: Shortcut::new(CLOSE_TAB_BINDINGS, "Close active tab"),
     previous_tab: Shortcut::new(
         &[KeyboardShortcut::new(
@@ -96,6 +103,8 @@ pub struct AppShortcuts {
     pub open_files: Shortcut,
     /// Opens the Quick Open launcher.
     pub quick_open: Shortcut,
+    /// Opens the global command launcher.
+    pub command_palette: Shortcut,
     pub close_tab: Shortcut,
     pub previous_tab: Shortcut,
     pub next_tab: Shortcut,
@@ -152,11 +161,12 @@ pub fn app_shortcuts() -> &'static AppShortcuts {
     &SHORTCUTS
 }
 
-pub fn app_shortcut_defs() -> [&'static Shortcut; 10] {
+pub fn app_shortcut_defs() -> [&'static Shortcut; 11] {
     let AppShortcuts {
         home_tab,
         open_files,
         quick_open,
+        command_palette,
         close_tab,
         previous_tab,
         next_tab,
@@ -178,6 +188,7 @@ pub fn app_shortcut_defs() -> [&'static Shortcut; 10] {
         home_tab,
         open_files,
         quick_open,
+        command_palette,
         close_tab,
         toggle_right_panel,
         toggle_bottom_panel,

--- a/application/apps/indexer/gui/application/src/host/ui/shortcuts/handler.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/shortcuts/handler.rs
@@ -3,10 +3,8 @@
 use egui::{Context, Event};
 
 use crate::host::ui::{
-    Host, HostAction, UiActions,
-    actions::FileDialogOptions,
-    menu,
-    state::{self, HostState, modal::HostModal},
+    Host, file_dialog_commands,
+    state::{self, modal::HostModal},
     tabs::TabType,
 };
 
@@ -62,6 +60,7 @@ fn handle_app_shortcuts(host: &mut Host, ctx: &Context) -> bool {
         home_tab,
         open_files,
         quick_open: quick_open_shortcut,
+        command_palette: command_palette_shortcut,
         close_tab,
         previous_tab,
         next_tab,
@@ -83,6 +82,7 @@ fn handle_app_shortcuts(host: &mut Host, ctx: &Context) -> bool {
         state,
         ui_actions,
         quick_open,
+        command_palette,
         ..
     } = host;
 
@@ -96,16 +96,18 @@ fn handle_app_shortcuts(host: &mut Host, ctx: &Context) -> bool {
         return true;
     }
 
+    if consume_shortcut(ctx, command_palette_shortcut) {
+        command_palette.open();
+        return true;
+    }
+
     if consume_shortcut(ctx, open_files) {
-        ui_actions.file_dialog.pick_files(
-            menu::OPEN_FILES_ID,
-            FileDialogOptions::new().title("Open Files"),
-        );
+        file_dialog_commands::open_files_dialog(ui_actions);
         return true;
     }
 
     if consume_shortcut(ctx, close_tab) {
-        close_active_tab(state, ui_actions);
+        state.close_active_tab(ui_actions);
         return true;
     }
 
@@ -202,22 +204,4 @@ fn handle_active_tab_shortcuts(
     };
 
     session.handle_shortcuts(ui_actions, &mut state.preferences, ctx, last_key)
-}
-
-fn close_active_tab(state: &mut HostState, ui_actions: &mut UiActions) {
-    match state.active_tab().clone() {
-        TabType::Home => {}
-        TabType::Session(id) => ui_actions.add_host_action(HostAction::CloseSession(id)),
-        TabType::SessionSetup(id) => state
-            .session_setups
-            .get(&id)
-            .expect("Session setup from active tab must exist")
-            .close(ui_actions),
-        TabType::MultiFileSetup(id) => state
-            .multi_setups
-            .get(&id)
-            .expect("Multiple files setup from active tab must exist")
-            .close(ui_actions),
-        TabType::PluginManager => state.close_plugin_manager(),
-    }
 }

--- a/application/apps/indexer/gui/application/src/host/ui/shortcuts/handler.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/shortcuts/handler.rs
@@ -61,6 +61,7 @@ fn handle_app_shortcuts(host: &mut Host, ctx: &Context) -> bool {
     let AppShortcuts {
         home_tab,
         open_files,
+        quick_open: quick_open_shortcut,
         close_tab,
         previous_tab,
         next_tab,
@@ -79,11 +80,19 @@ fn handle_app_shortcuts(host: &mut Host, ctx: &Context) -> bool {
     } = app_shortcuts();
 
     let Host {
-        state, ui_actions, ..
+        state,
+        ui_actions,
+        quick_open,
+        ..
     } = host;
 
     if consume_shortcut(ctx, home_tab) {
         state.activate_tab(state::HOME_TAB_IDX);
+        return true;
+    }
+
+    if consume_shortcut(ctx, quick_open_shortcut) {
+        quick_open.open();
         return true;
     }
 

--- a/application/apps/indexer/gui/application/src/host/ui/state/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/state/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     host::{
         command::HostCommand,
         ui::{
-            HomeView, UiActions,
+            HomeView, HostAction, UiActions,
             multi_setup::{MultiFileSetup, state::MultiFileState},
             plugin_manager::PluginManagerView,
             registry::HostRegistry,
@@ -139,6 +139,25 @@ impl HostState {
 
         self.update_current_tab_on_close(tab_idx);
         self.tabs.remove(tab_idx);
+    }
+
+    /// Closes the active tab when it can be closed.
+    pub fn close_active_tab(&mut self, actions: &mut UiActions) {
+        match self.active_tab().clone() {
+            TabType::Home => {}
+            TabType::Session(id) => actions.add_host_action(HostAction::CloseSession(id)),
+            TabType::SessionSetup(id) => self
+                .session_setups
+                .get(&id)
+                .expect("Session setup from active tab must exist")
+                .close(actions),
+            TabType::MultiFileSetup(id) => self
+                .multi_setups
+                .get(&id)
+                .expect("Multiple files setup from active tab must exist")
+                .close(actions),
+            TabType::PluginManager => self.close_plugin_manager(),
+        }
     }
 
     /// Add session to state returning it's ID.

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/library/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/library/mod.rs
@@ -8,7 +8,8 @@ use uuid::Uuid;
 
 use crate::{
     common::{
-        phosphor::icons, ui::substring_matcher::SubstringMatcher, validation::ValidationEligibility,
+        matcher::substring_matcher::SubstringMatcher, phosphor::icons,
+        validation::ValidationEligibility,
     },
     host::ui::{UiActions, registry::filters::FilterRegistry},
     session::{

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/mod.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/mod.rs
@@ -6,8 +6,9 @@ use uuid::Uuid;
 
 use crate::{
     common::{
+        matcher::substring_matcher::SubstringMatcher,
         phosphor::icons,
-        ui::{buttons, substring_matcher::SubstringMatcher, visibility_tracker::VisibilityTracker},
+        ui::{buttons, visibility_tracker::VisibilityTracker},
     },
     host::{
         command::{ExportPresetsParam, HostCommand},

--- a/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/query.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/bottom_panel/presets/query.rs
@@ -3,7 +3,7 @@
 use rustc_hash::FxHashSet;
 use uuid::Uuid;
 
-use crate::common::ui::substring_matcher::SubstringMatcher;
+use crate::common::matcher::substring_matcher::SubstringMatcher;
 
 use super::{HostRegistry, Preset, PresetQueryState};
 

--- a/application/apps/indexer/gui/application/src/session/ui/shared/export/modal.rs
+++ b/application/apps/indexer/gui/application/src/session/ui/shared/export/modal.rs
@@ -171,7 +171,9 @@ mod tests {
         }
 
         fn prepare_log(&self, element: &mut GrabbedElement) -> Vec<Range<usize>> {
-            vec![0..element.content.len()]
+            let rng = 0..element.content.len();
+
+            vec![rng]
         }
     }
 


### PR DESCRIPTION
This PR provides:

* Quick Open picker with `ctrl/cmd + p` to open recent session and files from favorite folders
* Command palette with `ctrl/mmd + shift + p` to run UI commands with keyboard using fuzzy finder
* Apply throttle to search in file explorer   