### PR TITLE
Native: Show Changelog after app update

### DIFF
--- a/application/apps/indexer/gui/application/src/host/message.rs
+++ b/application/apps/indexer/gui/application/src/host/message.rs
@@ -44,6 +44,8 @@ pub enum HostMessage {
     PresetsExported { path: PathBuf, count: usize },
     /// A newer application version is available.
     AppVersionUpdate(Box<AppVersionUpdate>),
+    /// Release notes for the first launch after an application update.
+    AppChangelog(Box<AppChangelog>),
     /// Storage-related async events.
     Storage(StorageEvent),
     /// Plugin manager state published by the host service.
@@ -68,10 +70,17 @@ pub struct PresetsImported {
 pub struct AppVersionUpdate {
     /// Newer version returned by the release source.
     pub latest_version: Version,
-    /// Release notes associated with the newer version.
-    //TODO AAZ:
-    #[allow(unused)]
-    pub release_notes: Option<String>,
+    /// Release page URL.
+    pub release_url: String,
+}
+
+/// Message payload for release notes shown after an application update.
+#[derive(Debug)]
+pub struct AppChangelog {
+    /// Version whose release notes are being shown.
+    pub version: Version,
+    /// Markdown release notes.
+    pub release_notes: String,
     /// Release page URL.
     pub release_url: String,
 }

--- a/application/apps/indexer/gui/application/src/host/service/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/service/mod.rs
@@ -118,7 +118,11 @@ impl HostService {
                 };
 
                 Self::spawn_startup_cleanup();
-                release_info::spawn_update_check(host.communication.senders.clone());
+                let previous_version = storage::app_version::sync_current_version();
+                release_info::spawn_update_check(
+                    host.communication.senders.clone(),
+                    previous_version,
+                );
                 host.run().await;
             });
         });

--- a/application/apps/indexer/gui/application/src/host/service/release_info.rs
+++ b/application/apps/indexer/gui/application/src/host/service/release_info.rs
@@ -7,7 +7,7 @@ use crate::{
     common::app_info,
     host::{
         communication::ServiceSenders,
-        message::{AppVersionUpdate, HostMessage},
+        message::{AppChangelog, AppVersionUpdate, HostMessage},
     },
 };
 
@@ -24,12 +24,12 @@ struct ReleaseInfo {
     draft: bool,
 }
 
-/// Spawns a background check for a newer GitHub release in the current major series.
-pub fn spawn_update_check(senders: ServiceSenders) {
-    tokio::spawn(check_for_updates(senders));
+/// Spawns a background check for release metadata in the current major series.
+pub fn spawn_update_check(senders: ServiceSenders, previous_version: Option<Version>) {
+    tokio::spawn(check_for_updates(senders, previous_version));
 }
 
-async fn check_for_updates(senders: ServiceSenders) {
+async fn check_for_updates(senders: ServiceSenders, previous_version: Option<Version>) {
     let releases = match fetch_release_info().await {
         Ok(releases) => releases,
         Err(err) => {
@@ -40,8 +40,12 @@ async fn check_for_updates(senders: ServiceSenders) {
 
     let current_version = app_info::current_version();
 
+    if previous_version.is_some_and(|previous_version| previous_version < *current_version) {
+        send_current_changelog(&senders, &releases, current_version).await;
+    }
+
     let Some((latest_version, release)) =
-        latest_current_major_release(releases, current_version.major)
+        latest_current_major_release(&releases, current_version.major)
     else {
         info!(
             "No release found for the current major version in the latest \
@@ -60,8 +64,7 @@ async fn check_for_updates(senders: ServiceSenders) {
 
     let update = AppVersionUpdate {
         latest_version,
-        release_notes: release.body,
-        release_url: release.html_url,
+        release_url: release.html_url.clone(),
     };
 
     senders
@@ -73,13 +76,50 @@ fn parse_version(version: &str) -> Result<Version, semver::Error> {
     Version::parse(version.trim_start_matches('v'))
 }
 
+/// Sends release notes for the currently running version after an app update.
+async fn send_current_changelog(
+    senders: &ServiceSenders,
+    releases: &[ReleaseInfo],
+    current_version: &Version,
+) {
+    let Some(release) = current_release(releases, current_version) else {
+        return;
+    };
+
+    let Some(release_notes) = release.body.as_ref().filter(|body| !body.trim().is_empty()) else {
+        return;
+    };
+
+    let changelog = AppChangelog {
+        version: current_version.clone(),
+        release_notes: release_notes.clone(),
+        release_url: release.html_url.clone(),
+    };
+
+    senders
+        .send_message(HostMessage::AppChangelog(Box::new(changelog)))
+        .await;
+}
+
+fn current_release<'a>(
+    releases: &'a [ReleaseInfo],
+    current_version: &Version,
+) -> Option<&'a ReleaseInfo> {
+    releases.iter().find(|release| {
+        !release.draft
+            && parse_version(&release.tag_name)
+                .ok()
+                .is_some_and(|version| version == *current_version)
+    })
+}
+
 /// Returns the newest non-draft release that parses as the current major version.
 fn latest_current_major_release(
-    releases: Vec<ReleaseInfo>,
+    releases: &[ReleaseInfo],
     current_major: u64,
-) -> Option<(Version, ReleaseInfo)> {
+) -> Option<(Version, &ReleaseInfo)> {
     let mut matching_releases = releases
-        .into_iter()
+        .iter()
         .filter_map(|release| {
             if release.draft {
                 return None;
@@ -156,18 +196,27 @@ mod tests {
 
     #[test]
     fn latest_current_major_release_sorts_versions() {
-        let latest = latest_current_major_release(
-            vec![
-                release("4.0.0-alpha.1"),
-                release("5.0.0-alpha.1"),
-                release("4.0.0-beta.1"),
-                release("4.0.0-beta.2"),
-            ],
-            4,
-        )
-        .expect("current major release should be found");
+        let releases = vec![
+            release("4.0.0-alpha.1"),
+            release("5.0.0-alpha.1"),
+            release("4.0.0-beta.1"),
+            release("4.0.0-beta.2"),
+        ];
+        let latest = latest_current_major_release(&releases, 4)
+            .expect("current major release should be found");
 
         assert_eq!(latest.0, parse_version("4.0.0-beta.2").unwrap());
         assert_eq!(latest.1.tag_name, "4.0.0-beta.2");
+    }
+
+    #[test]
+    fn current_release_matches_exact_version() {
+        let releases = vec![release("4.0.0-alpha.1"), release("4.0.0-beta.1")];
+        let current_version = parse_version("4.0.0-beta.1").unwrap();
+
+        let current = current_release(&releases, &current_version)
+            .expect("exact current version release should be found");
+
+        assert_eq!(current.tag_name, "4.0.0-beta.1");
     }
 }

--- a/application/apps/indexer/gui/application/src/host/service/storage/app_version.rs
+++ b/application/apps/indexer/gui/application/src/host/service/storage/app_version.rs
@@ -1,0 +1,99 @@
+//! App-version storage used to detect first launch after an update.
+
+use std::{
+    fs::{self, File},
+    io::{BufReader, ErrorKind},
+    path::{Path, PathBuf},
+};
+
+use log::warn;
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+use crate::common::app_info;
+
+use super::storage_path;
+
+const APP_VERSION_FILE: &str = "app_version.json";
+
+/// Persisted file shape; a named struct keeps the JSON field explicit.
+#[derive(Debug, Deserialize, Serialize)]
+struct PersistedAppVersion {
+    last_seen_app_version: String,
+}
+
+/// Stores the current app version and returns the previously persisted version, if valid.
+pub fn sync_current_version() -> Option<Version> {
+    let path = match app_version_path() {
+        Ok(path) => path,
+        Err(err) => {
+            warn!("Failed to resolve app-version storage path: {err}");
+            return None;
+        }
+    };
+
+    let previous_version = match read_previous_version(&path) {
+        Ok(previous_version) => previous_version,
+        Err(err) => {
+            warn!(
+                "Failed to read app-version storage from {}: {err}. Recreating the file.",
+                path.display()
+            );
+            remove_invalid_file(&path);
+            None
+        }
+    };
+
+    if let Err(err) = write_current_version(&path, app_info::current_version()) {
+        warn!(
+            "Failed to write app-version storage to {}: {err}",
+            path.display()
+        );
+    }
+
+    previous_version
+}
+
+fn read_previous_version(path: &Path) -> Result<Option<Version>, String> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.to_string()),
+    };
+
+    let persisted: PersistedAppVersion = serde_json::from_reader(BufReader::new(file))
+        .map_err(|err| format!("failed to deserialize app-version storage: {err}"))?;
+
+    let version = Version::parse(&persisted.last_seen_app_version)
+        .map_err(|err| format!("failed to parse stored app version: {err}"))?;
+
+    Ok(Some(version))
+}
+
+fn write_current_version(path: &Path, current_version: &Version) -> Result<(), String> {
+    let persisted = PersistedAppVersion {
+        last_seen_app_version: current_version.to_string(),
+    };
+
+    let content = serde_json::to_string_pretty(&persisted)
+        .map_err(|err| format!("failed to serialize app-version storage: {err}"))?;
+
+    fs::write(path, content).map_err(|err| err.to_string())
+}
+
+fn remove_invalid_file(path: &Path) {
+    if let Err(err) = fs::remove_file(path)
+        && err.kind() != ErrorKind::NotFound
+    {
+        warn!(
+            "Failed to remove invalid app-version storage file {}: {err}",
+            path.display()
+        );
+    }
+}
+
+fn app_version_path() -> Result<PathBuf, String> {
+    storage_path()
+        .map(|storage_dir| storage_dir.join(APP_VERSION_FILE))
+        .map_err(|err| err.to_string())
+}

--- a/application/apps/indexer/gui/application/src/host/service/storage/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/service/storage/mod.rs
@@ -16,6 +16,7 @@ use crate::host::{
     ui::storage::types::{StorageError, StorageErrorKind, StorageEvent, StorageSaveData},
 };
 
+pub mod app_version;
 mod file_explorer;
 pub mod recent;
 

--- a/application/apps/indexer/gui/application/src/host/ui/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/mod.rs
@@ -225,6 +225,11 @@ impl Host {
             HostMessage::AppVersionUpdate(update) => {
                 self.state.app_info.set_update_info(*update);
             }
+            HostMessage::AppChangelog(changelog) => {
+                if self.state.modals.open(HostModal::Changelog) {
+                    self.state.app_info.set_changelog(*changelog);
+                }
+            }
             HostMessage::Storage(event) => self.storage.handle_event(event, &mut self.ui_actions),
             HostMessage::PluginsStateChanged(plugins) => self.state.set_plugins_state(*plugins),
             HostMessage::PluginReadmeLoaded(response) => {
@@ -287,6 +292,12 @@ impl Host {
             HostModal::Shortcuts => {
                 if shortcuts::modal::render_modal(ui) {
                     self.state.modals.close();
+                }
+            }
+            HostModal::Changelog => {
+                if modals::changelog::render_modal(&mut self.state.app_info, ui) {
+                    self.state.modals.close();
+                    self.state.app_info.clear_changelog();
                 }
             }
             HostModal::Confirmation(dialog) => {

--- a/application/apps/indexer/gui/application/src/host/ui/modals/changelog.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/modals/changelog.rs
@@ -1,0 +1,75 @@
+//! Changelog dialog rendering.
+
+use egui::{Align, Button, Layout, OpenUrl, ScrollArea, Ui, Widget, vec2};
+use egui_commonmark::CommonMarkViewer;
+
+use crate::{
+    common::ui::modal::{ModalSize, ResponsiveModalSize, show_modal},
+    host::ui::state::info::AppInfoState,
+};
+
+/// Renders the changelog dialog and returns true when it should close.
+pub fn render_modal(info_state: &mut AppInfoState, parent_ui: &Ui) -> bool {
+    let mut open_release_url = None;
+
+    let Some((changelog, markdown_cache)) = info_state.changelog_parts() else {
+        return true;
+    };
+
+    let title = format!("What's new in {}", changelog.version);
+
+    let modal = show_modal(
+        parent_ui,
+        "app_changelog",
+        ModalSize::Responsive(ResponsiveModalSize {
+            width_ratio: 0.65,
+            height_ratio: 0.75,
+            min_size: vec2(420.0, 320.0),
+            max_size: vec2(900.0, 700.0),
+            window_padding: vec2(40.0, 40.0),
+        }),
+        |ui, size| {
+            ui.heading(title);
+            ui.add_space(4.0);
+            ui.separator();
+
+            let notes_height = (size.y - 95.0).max(120.0);
+            ScrollArea::vertical()
+                .auto_shrink([false, false])
+                .max_height(notes_height)
+                .show(ui, |ui| {
+                    CommonMarkViewer::new().show(ui, markdown_cache, &changelog.release_notes);
+                });
+
+            ui.separator();
+            ui.allocate_ui_with_layout(
+                vec2(ui.available_width(), 25.0),
+                Layout::right_to_left(Align::Center),
+                |ui| {
+                    let action_button_size = vec2(100.0, 25.0);
+                    if Button::new("Close")
+                        .min_size(action_button_size)
+                        .ui(ui)
+                        .clicked()
+                    {
+                        ui.close();
+                    }
+
+                    if Button::new("Open release")
+                        .min_size(action_button_size)
+                        .ui(ui)
+                        .clicked()
+                    {
+                        open_release_url = Some(changelog.release_url.clone());
+                    }
+                },
+            );
+        },
+    );
+
+    if let Some(open_release_url) = open_release_url {
+        parent_ui.ctx().open_url(OpenUrl::new_tab(open_release_url));
+    }
+
+    modal.should_close()
+}

--- a/application/apps/indexer/gui/application/src/host/ui/modals/mod.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/modals/mod.rs
@@ -1,4 +1,5 @@
 //! Host-specific modal dialog renderers.
 
 pub mod about;
+pub mod changelog;
 pub mod confirmation;

--- a/application/apps/indexer/gui/application/src/host/ui/state/info.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/state/info.rs
@@ -1,11 +1,15 @@
 //! UI state for application metadata and update presentation.
 
-use crate::host::message::AppVersionUpdate;
+use egui_commonmark::CommonMarkCache;
+
+use crate::host::message::{AppChangelog, AppVersionUpdate};
 
 /// UI state for application information.
 #[derive(Debug, Default)]
 pub struct AppInfoState {
     update_info: Option<AppVersionUpdate>,
+    changelog: Option<AppChangelog>,
+    changelog_markdown_cache: CommonMarkCache,
     pub show_update_banner: bool,
 }
 
@@ -19,5 +23,30 @@ impl AppInfoState {
     pub fn set_update_info(&mut self, update_info: AppVersionUpdate) {
         self.update_info = Some(update_info);
         self.show_update_banner = true;
+    }
+
+    /// Stores release notes for the changelog modal.
+    pub fn set_changelog(&mut self, changelog: AppChangelog) {
+        self.changelog = Some(changelog);
+        self.changelog_markdown_cache = CommonMarkCache::default();
+    }
+
+    /// Returns changelog content and markdown cache for rendering.
+    pub fn changelog_parts(&mut self) -> Option<(&AppChangelog, &mut CommonMarkCache)> {
+        let Self {
+            changelog,
+            changelog_markdown_cache,
+            ..
+        } = self;
+
+        changelog
+            .as_ref()
+            .map(|changelog| (changelog, changelog_markdown_cache))
+    }
+
+    /// Clears changelog modal state.
+    pub fn clear_changelog(&mut self) {
+        self.changelog = None;
+        self.changelog_markdown_cache = CommonMarkCache::default();
     }
 }

--- a/application/apps/indexer/gui/application/src/host/ui/state/modal.rs
+++ b/application/apps/indexer/gui/application/src/host/ui/state/modal.rs
@@ -14,6 +14,8 @@ pub enum HostModal {
     About,
     /// Keyboard shortcuts overview.
     Shortcuts,
+    /// Release notes for the first launch after an application update.
+    Changelog,
     /// Caller-owned confirmation dialog with a pollable answer.
     Confirmation(ConfirmationDialog),
 }


### PR DESCRIPTION
* Render Body of the latest release where we but normally the changelogs on first time the app is opened after getting updated.
* Write down the latest shown version in app storage