### PR TITLE
Restore recent sessions from legacy Chipmunk 3

### DIFF
--- a/crates/app/src/host/service/storage/mod.rs
+++ b/crates/app/src/host/service/storage/mod.rs
@@ -99,14 +99,18 @@ fn save_storage(data: &StorageSaveData) -> Result<(), StorageError> {
 
 /// Resolves the shared storage root under the Chipmunk home directory.
 fn storage_path() -> Result<PathBuf, StorageError> {
-    let home_dir = session_core::paths::get_home_dir().map_err(|err| StorageError {
+    let home_dir = chipmunk_home_dir()?;
+
+    storage_path_from_home(&home_dir)
+}
+
+fn chipmunk_home_dir() -> Result<PathBuf, StorageError> {
+    session_core::paths::get_home_dir().map_err(|err| StorageError {
         kind: StorageErrorKind::Path,
         message: err
             .message
             .unwrap_or_else(|| "Failed to resolve Chipmunk home directory.".into()),
-    })?;
-
-    storage_path_from_home(&home_dir)
+    })
 }
 
 /// Ensures the shared storage root exists for the provided home directory.

--- a/crates/app/src/host/service/storage/recent/legacy/actions.rs
+++ b/crates/app/src/host/service/storage/recent/legacy/actions.rs
@@ -1,0 +1,706 @@
+//! Legacy recent-action source and parser conversion.
+
+use std::{
+    ops::Not,
+    path::{Path, PathBuf},
+};
+
+use serde_json::{Map, Value, from_value};
+
+use stypes::{
+    DltParserSettings, FileFormat, MulticastInfo, ParserType, PluginParserGeneralSettings,
+    PluginParserSettings, ProcessTransportConfig, SerialTransportConfig, SomeIpParserSettings,
+    TCPTransportConfig, Transport, UDPTransportConfig,
+};
+
+use crate::host::{
+    common::parsers::ParserNames,
+    ui::storage::recent::session::{RecentSessionSnapshot, RecentSessionSource},
+};
+
+/// Normalized source shape for conservative recent-action/history matching.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MatchSource {
+    /// One or more normalized file paths.
+    Files(Vec<String>),
+    /// Process command source identity.
+    Process {
+        /// Process command line.
+        command: String,
+        /// Optional working directory.
+        cwd: Option<String>,
+    },
+    /// TCP stream source identity.
+    Tcp {
+        /// TCP bind address.
+        bind_addr: String,
+    },
+    /// UDP stream source identity.
+    Udp {
+        /// UDP bind address.
+        bind_addr: String,
+    },
+    /// Serial stream source identity.
+    Serial {
+        /// Optional serial port path.
+        path: Option<String>,
+    },
+}
+
+/// Converts one legacy recent-action payload into a native recent-session snapshot.
+pub fn parse_recent_action(content: &Value) -> Result<RecentSessionSnapshot, String> {
+    let observe = content
+        .get("observe")
+        .ok_or_else(|| String::from("missing observe payload"))?;
+    let origin = observe
+        .get("origin")
+        .ok_or_else(|| String::from("missing origin"))?;
+    let parser = observe
+        .get("parser")
+        .ok_or_else(|| String::from("missing parser"))?;
+
+    let sources = parse_sources(origin)?;
+    if sources.is_empty() {
+        return Err(String::from("empty sources"));
+    }
+
+    let parser = parse_parser(parser)?;
+
+    let last_opened = content
+        .pointer("/stat/last")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| String::from("missing timestamp"))?
+        / 1000;
+    Ok(RecentSessionSnapshot::new(
+        last_opened,
+        sources,
+        parser,
+        Default::default(),
+    ))
+}
+
+/// Converts a legacy origin object into ordered native recent-session sources.
+pub fn parse_sources(origin: &Value) -> Result<Vec<RecentSessionSource>, String> {
+    let (variant, payload) =
+        single_variant(origin).ok_or_else(|| String::from("invalid origin"))?;
+
+    match variant {
+        "File" => parse_file_source(payload).map(|source| vec![source]),
+        "Concat" => payload
+            .as_array()
+            .ok_or_else(|| String::from("invalid concat source"))?
+            .iter()
+            .map(parse_file_source)
+            .collect(),
+        "Stream" => parse_stream_source(payload).map(|source| vec![source]),
+        other => Err(format!("unsupported origin {other}")),
+    }
+}
+
+fn parse_file_source(payload: &Value) -> Result<RecentSessionSource, String> {
+    let (format, path) = if let Some(items) = payload.as_array() {
+        let format = items
+            .get(1)
+            .and_then(Value::as_str)
+            .ok_or_else(|| String::from("missing file format"))?;
+        let path = items
+            .get(2)
+            .and_then(Value::as_str)
+            .ok_or_else(|| String::from("missing file path"))?;
+        (parse_file_format(format)?, PathBuf::from(path))
+    } else if let Some(object) = payload.as_object() {
+        let format = string_field(object, &["format", "file_format", "f"])
+            .ok_or_else(|| String::from("missing file format"))?;
+        let path = path_from_object(object).ok_or_else(|| String::from("missing file path"))?;
+        (parse_file_format(format)?, path)
+    } else {
+        return Err(String::from("invalid file source"));
+    };
+
+    Ok(RecentSessionSource::File { format, path })
+}
+
+fn parse_file_format(format: &str) -> Result<FileFormat, String> {
+    match format {
+        "PcapNG" => Ok(FileFormat::PcapNG),
+        "PcapLegacy" => Ok(FileFormat::PcapLegacy),
+        "Text" => Ok(FileFormat::Text),
+        "Binary" => Ok(FileFormat::Binary),
+        "ParserPlugin" => Err(String::from("ParserPlugin file sources are not supported")),
+        other => Err(format!("unsupported file format {other}")),
+    }
+}
+
+fn parse_stream_source(payload: &Value) -> Result<RecentSessionSource, String> {
+    if let Some((variant, config)) = single_variant(payload) {
+        return parse_stream_variant(variant, config);
+    }
+
+    if let Some(items) = payload.as_array() {
+        if let Some((variant, config)) = items.iter().find_map(single_variant) {
+            return parse_stream_variant(variant, config);
+        }
+        if let (Some(kind), Some(config)) = (items.get(1).and_then(Value::as_str), items.get(2)) {
+            return parse_stream_variant(kind, config);
+        }
+    }
+
+    if let Some(object) = payload.as_object()
+        && let Some(kind) = string_field(object, &["kind", "type", "transport"])
+    {
+        return parse_stream_variant(kind, payload);
+    }
+
+    Err(String::from("invalid stream source"))
+}
+
+fn parse_stream_variant(variant: &str, payload: &Value) -> Result<RecentSessionSource, String> {
+    let payload = stream_config_payload(payload);
+    let transport = match variant {
+        "Process" => Transport::Process(parse_process_config(payload)?),
+        "TCP" => Transport::TCP(TCPTransportConfig {
+            bind_addr: parse_bind_addr(payload)?,
+        }),
+        "UDP" => Transport::UDP(UDPTransportConfig {
+            bind_addr: parse_bind_addr(payload)?,
+            multicast: parse_multicast(payload),
+        }),
+        "Serial" => Transport::Serial(parse_serial_config(payload)?),
+        other => return Err(format!("unsupported stream source {other}")),
+    };
+
+    Ok(RecentSessionSource::Stream { transport })
+}
+
+fn stream_config_payload(payload: &Value) -> &Value {
+    payload
+        .as_array()
+        .and_then(|items| items.get(1))
+        .unwrap_or(payload)
+}
+
+fn parse_process_config(payload: &Value) -> Result<ProcessTransportConfig, String> {
+    if let Some(command) = payload.as_str() {
+        return Ok(ProcessTransportConfig {
+            cwd: PathBuf::new(),
+            command: command.to_owned(),
+            shell: None,
+        });
+    }
+
+    let object = payload
+        .as_object()
+        .ok_or_else(|| String::from("invalid process source"))?;
+    let command = string_field(object, &["command", "cmd"])
+        .ok_or_else(|| String::from("missing process command"))?
+        .to_owned();
+    let cwd = string_field(object, &["cwd", "working_dir", "workdir"])
+        .map(PathBuf::from)
+        .unwrap_or_default();
+
+    Ok(ProcessTransportConfig {
+        cwd,
+        command,
+        shell: None,
+    })
+}
+
+fn parse_bind_addr(payload: &Value) -> Result<String, String> {
+    if let Some(bind_addr) = payload.as_str() {
+        return Ok(bind_addr.to_owned());
+    }
+
+    let object = payload
+        .as_object()
+        .ok_or_else(|| String::from("invalid network source"))?;
+    string_field(
+        object,
+        &["bind_addr", "bindAddr", "bind", "addr", "address"],
+    )
+    .map(str::to_owned)
+    .ok_or_else(|| String::from("missing bind address"))
+}
+
+fn parse_multicast(payload: &Value) -> Vec<MulticastInfo> {
+    let Some(object) = payload.as_object() else {
+        return Vec::new();
+    };
+
+    object
+        .get("multicast")
+        .or_else(|| object.get("multicast_addr"))
+        .or_else(|| object.get("multicastAddr"))
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| {
+                    if let Some(multiaddr) = item.as_str() {
+                        return Some(MulticastInfo {
+                            multiaddr: multiaddr.to_owned(),
+                            interface: None,
+                        });
+                    }
+
+                    let item = item.as_object()?;
+                    let multiaddr = string_field(item, &["multiaddr", "multi_addr", "addr"])?;
+                    let interface = string_field(item, &["interface", "iface"]).map(str::to_owned);
+                    Some(MulticastInfo {
+                        multiaddr: multiaddr.to_owned(),
+                        interface,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_serial_config(payload: &Value) -> Result<SerialTransportConfig, String> {
+    if let Some(path) = payload.as_str() {
+        return Ok(default_serial_config(path.to_owned()));
+    }
+
+    let object = payload
+        .as_object()
+        .ok_or_else(|| String::from("invalid serial source"))?;
+    let path = string_field(object, &["path", "port"])
+        .ok_or_else(|| String::from("missing serial path"))?
+        .to_owned();
+
+    Ok(SerialTransportConfig {
+        path,
+        baud_rate: u32_field(object, &["baud_rate", "baudRate"]).unwrap_or(9600),
+        data_bits: u8_field(object, &["data_bits", "dataBits"]).unwrap_or(8),
+        flow_control: u8_field(object, &["flow_control", "flowControl"]).unwrap_or(0),
+        parity: u8_field(object, &["parity"]).unwrap_or(0),
+        stop_bits: u8_field(object, &["stop_bits", "stopBits"]).unwrap_or(1),
+        send_data_delay: u8_field(object, &["send_data_delay", "sendDataDelay"]).unwrap_or(0),
+        exclusive: bool_field(object, &["exclusive"]).unwrap_or(false),
+    })
+}
+
+fn default_serial_config(path: String) -> SerialTransportConfig {
+    SerialTransportConfig {
+        path,
+        baud_rate: 9600,
+        data_bits: 8,
+        flow_control: 0,
+        parity: 0,
+        stop_bits: 1,
+        send_data_delay: 0,
+        exclusive: false,
+    }
+}
+
+fn parse_parser(parser: &Value) -> Result<ParserType, String> {
+    let (variant, payload) =
+        single_variant(parser).ok_or_else(|| String::from("invalid parser"))?;
+
+    match variant {
+        "Text" => Ok(ParserType::Text(())),
+        "Dlt" => Ok(ParserType::Dlt(parse_dlt_settings(payload))),
+        "SomeIp" => Ok(ParserType::SomeIp(parse_someip_settings(payload))),
+        "Plugin" => parse_plugin_settings(payload).map(ParserType::Plugin),
+        other => Err(format!("unsupported parser {other}")),
+    }
+}
+
+/// Extracts the parser kind used for history matching.
+pub fn parse_parser_name(parser: &Value) -> Option<ParserNames> {
+    if let Some(name) = parser.as_str() {
+        return parser_name_from_name(name);
+    }
+
+    single_variant(parser).and_then(|(variant, _)| parser_name_from_name(variant))
+}
+
+fn parser_name_from_name(name: &str) -> Option<ParserNames> {
+    match name {
+        "Text" => Some(ParserNames::Text),
+        "Dlt" => Some(ParserNames::Dlt),
+        "SomeIp" => Some(ParserNames::SomeIP),
+        "Plugin" => Some(ParserNames::Plugins),
+        _ => None,
+    }
+}
+
+fn parse_dlt_settings(payload: &Value) -> DltParserSettings {
+    let Some(object) = payload.as_object() else {
+        return DltParserSettings::default();
+    };
+
+    DltParserSettings {
+        filter_config: object
+            .get("filter_config")
+            .and_then(|value| from_value(value.clone()).ok()),
+        fibex_file_paths: string_vec_field(object, &["fibex_file_paths", "fibexFilePaths"]),
+        with_storage_header: bool_field(object, &["with_storage_header", "withStorageHeader"])
+            .unwrap_or(DltParserSettings::default().with_storage_header),
+        tz: string_field(object, &["tz"]).map(str::to_owned),
+        fibex_metadata: None,
+    }
+}
+
+fn parse_someip_settings(payload: &Value) -> SomeIpParserSettings {
+    let fibex_file_paths = payload
+        .as_object()
+        .and_then(|object| string_vec_field(object, &["fibex_file_paths", "fibexFilePaths"]));
+
+    SomeIpParserSettings { fibex_file_paths }
+}
+
+fn parse_plugin_settings(payload: &Value) -> Result<PluginParserSettings, String> {
+    let object = payload
+        .as_object()
+        .ok_or_else(|| String::from("invalid plugin parser settings"))?;
+    let plugin_path = string_field(object, &["plugin_path", "pluginPath", "path"])
+        .ok_or_else(|| String::from("missing plugin path"))?;
+    let plugin_configs = object
+        .get("plugin_configs")
+        .or_else(|| object.get("pluginConfigs"))
+        .and_then(|value| from_value(value.clone()).ok())
+        .unwrap_or_default();
+
+    let settings = PluginParserSettings {
+        plugin_path: PathBuf::from(plugin_path),
+        general_settings: PluginParserGeneralSettings::default(),
+        plugin_configs,
+    };
+
+    Ok(settings)
+}
+
+/// Converts a legacy stream descriptor into the normalized matching shape.
+pub fn parse_stream_match(value: &Value) -> Option<MatchSource> {
+    let stream = value.get("Stream").unwrap_or(value);
+    let (variant, payload) = single_variant(stream).unwrap_or_else(|| {
+        let kind = stream
+            .as_object()
+            .and_then(|object| string_field(object, &["kind", "type", "transport"]))
+            .unwrap_or("");
+        (kind, stream)
+    });
+
+    let payload = stream_config_payload(payload);
+    match variant {
+        "Process" => {
+            let transport = parse_process_config(payload).ok()?;
+            Some(MatchSource::Process {
+                command: transport.command,
+                cwd: path_to_match_string(&transport.cwd),
+            })
+        }
+        "TCP" => parse_bind_addr(payload)
+            .ok()
+            .map(|bind_addr| MatchSource::Tcp { bind_addr }),
+        "UDP" => parse_bind_addr(payload)
+            .ok()
+            .map(|bind_addr| MatchSource::Udp { bind_addr }),
+        "Serial" => parse_serial_config(payload)
+            .ok()
+            .map(|config| MatchSource::Serial {
+                path: Some(config.path),
+            }),
+        _ => None,
+    }
+}
+
+/// Converts native sources into the normalized matching shape.
+pub fn match_source_from_sources(sources: &[RecentSessionSource]) -> Option<MatchSource> {
+    match sources.first()? {
+        RecentSessionSource::File { .. } => sources
+            .iter()
+            .map(|source| match source {
+                RecentSessionSource::File { path, .. } => Some(normalize_path(path)),
+                RecentSessionSource::Stream { .. } => None,
+            })
+            .collect::<Option<Vec<_>>>()
+            .map(MatchSource::Files),
+        RecentSessionSource::Stream { transport } if sources.len() == 1 => match transport {
+            Transport::Process(config) => Some(MatchSource::Process {
+                command: config.command.clone(),
+                cwd: path_to_match_string(&config.cwd),
+            }),
+            Transport::TCP(config) => Some(MatchSource::Tcp {
+                bind_addr: config.bind_addr.clone(),
+            }),
+            Transport::UDP(config) => Some(MatchSource::Udp {
+                bind_addr: config.bind_addr.clone(),
+            }),
+            Transport::Serial(config) => Some(MatchSource::Serial {
+                path: Some(config.path.clone()),
+            }),
+        },
+        RecentSessionSource::Stream { .. } => None,
+    }
+}
+
+/// Returns whether the source shape can safely retain imported bookmarks.
+pub fn supports_bookmarks(sources: &[RecentSessionSource]) -> bool {
+    matches!(sources.first(), Some(RecentSessionSource::File { .. }))
+}
+
+fn single_variant(value: &Value) -> Option<(&str, &Value)> {
+    let object = value.as_object()?;
+    if object.len() != 1 {
+        return None;
+    }
+
+    object
+        .iter()
+        .next()
+        .map(|(key, value)| (key.as_str(), value))
+}
+
+/// Reconstructs a legacy path from direct or parent/name fields.
+pub fn path_from_object(object: &Map<String, Value>) -> Option<PathBuf> {
+    if let Some(path) = string_field(object, &["path", "file", "filename"]) {
+        return Some(PathBuf::from(path));
+    }
+
+    let name = string_field(object, &["n", "name"])?;
+    let parent = string_field(object, &["p", "parent", "parent_path"]);
+    Some(match parent {
+        Some(parent) if !parent.is_empty() => PathBuf::from(parent).join(name),
+        _ => PathBuf::from(name),
+    })
+}
+
+/// Normalizes paths only for case-insensitive legacy matching.
+pub fn normalize_path(path: &Path) -> String {
+    path.to_string_lossy().to_lowercase()
+}
+
+fn path_to_match_string(path: &Path) -> Option<String> {
+    path.as_os_str()
+        .is_empty()
+        .not()
+        .then(|| path.to_string_lossy().into_owned())
+}
+
+fn string_field<'a>(object: &'a Map<String, Value>, keys: &[&str]) -> Option<&'a str> {
+    keys.iter()
+        .find_map(|key| object.get(*key).and_then(Value::as_str))
+}
+
+fn string_vec_field(object: &Map<String, Value>, keys: &[&str]) -> Option<Vec<String>> {
+    keys.iter()
+        .find_map(|key| object.get(*key))
+        .and_then(|value| {
+            value.as_array().map(|items| {
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_owned)
+                    .collect::<Vec<_>>()
+            })
+        })
+}
+
+fn bool_field(object: &Map<String, Value>, keys: &[&str]) -> Option<bool> {
+    keys.iter()
+        .find_map(|key| object.get(*key))
+        .and_then(|value| bool_from_value(Some(value)))
+}
+
+/// Reads legacy boolean flags that may be stored as booleans or numeric values.
+pub fn bool_from_value(value: Option<&Value>) -> Option<bool> {
+    value.and_then(|value| match value {
+        Value::Bool(value) => Some(*value),
+        Value::Number(value) => value.as_u64().map(|value| value != 0),
+        _ => None,
+    })
+}
+
+fn u32_field(object: &Map<String, Value>, keys: &[&str]) -> Option<u32> {
+    keys.iter()
+        .find_map(|key| object.get(*key))
+        .and_then(Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+}
+
+fn u8_field(object: &Map<String, Value>, keys: &[&str]) -> Option<u8> {
+    keys.iter()
+        .find_map(|key| object.get(*key))
+        .and_then(Value::as_u64)
+        .and_then(|value| u8::try_from(value).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+    use stypes::{FileFormat, ParserType, Transport};
+
+    use super::*;
+
+    fn action(origin: Value, parser: Value) -> Value {
+        json!({
+            "stat": { "last": 1_700_000_123_456_u64 },
+            "observe": {
+                "origin": origin,
+                "parser": parser,
+            }
+        })
+    }
+
+    fn text_parser() -> Value {
+        json!({ "Text": null })
+    }
+
+    #[test]
+    fn imports_file_text_action() {
+        let snapshot = parse_recent_action(&action(
+            json!({ "File": ["source-id", "Text", "/logs/app.log"] }),
+            text_parser(),
+        ))
+        .expect("file action should import");
+
+        assert_eq!(snapshot.last_opened, 1_700_000_123);
+        assert!(matches!(snapshot.parser, ParserType::Text(())));
+        assert!(matches!(
+            &snapshot.sources()[0],
+            RecentSessionSource::File { format: FileFormat::Text, path }
+                if path == &PathBuf::from("/logs/app.log")
+        ));
+    }
+
+    #[test]
+    fn imports_concat_preserving_order() {
+        let snapshot = parse_recent_action(&action(
+            json!({
+                "Concat": [
+                    ["first", "Text", "/logs/first.log"],
+                    ["second", "Binary", "/logs/second.bin"]
+                ]
+            }),
+            text_parser(),
+        ))
+        .expect("concat action should import");
+
+        let paths = snapshot
+            .sources()
+            .iter()
+            .map(|source| match source {
+                RecentSessionSource::File { path, .. } => path.clone(),
+                RecentSessionSource::Stream { .. } => panic!("expected file source"),
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("/logs/first.log"),
+                PathBuf::from("/logs/second.bin")
+            ]
+        );
+    }
+
+    #[test]
+    fn imports_stream_actions() {
+        let process = parse_recent_action(&action(
+            json!({ "Stream": { "Process": { "command": "journalctl -f", "cwd": "/tmp" } } }),
+            text_parser(),
+        ))
+        .expect("process action should import");
+        let tcp = parse_recent_action(&action(
+            json!({ "Stream": { "TCP": { "bind_addr": "127.0.0.1:5000" } } }),
+            text_parser(),
+        ))
+        .expect("tcp action should import");
+        let udp = parse_recent_action(&action(
+            json!({
+                "Stream": {
+                    "UDP": {
+                        "bind_addr": "0.0.0.0:5001",
+                        "multicast": [{ "multiaddr": "239.0.0.1", "interface": "eth0" }]
+                    }
+                }
+            }),
+            text_parser(),
+        ))
+        .expect("udp action should import");
+        let serial = parse_recent_action(&action(
+            json!({ "Stream": { "Serial": { "path": "/dev/ttyUSB0", "baud_rate": 115200 } } }),
+            text_parser(),
+        ))
+        .expect("serial action should import");
+
+        assert!(matches!(
+            &process.sources()[0],
+            RecentSessionSource::Stream { transport: Transport::Process(config) }
+                if config.command == "journalctl -f" && config.cwd.as_path() == Path::new("/tmp")
+        ));
+        assert!(matches!(
+            &tcp.sources()[0],
+            RecentSessionSource::Stream { transport: Transport::TCP(config) }
+                if config.bind_addr == "127.0.0.1:5000"
+        ));
+        assert!(matches!(
+            &udp.sources()[0],
+            RecentSessionSource::Stream { transport: Transport::UDP(config) }
+                if config.bind_addr == "0.0.0.0:5001"
+                    && config.multicast.len() == 1
+                    && config.multicast[0].multiaddr == "239.0.0.1"
+                    && config.multicast[0].interface.as_deref() == Some("eth0")
+        ));
+        assert!(matches!(
+            &serial.sources()[0],
+            RecentSessionSource::Stream { transport: Transport::Serial(config) }
+                if config.path == "/dev/ttyUSB0" && config.baud_rate == 115200
+        ));
+    }
+
+    #[test]
+    fn imports_parser_settings() {
+        let dlt = parse_recent_action(&action(
+            json!({ "File": ["source-id", "PcapNG", "/logs/trace.pcapng"] }),
+            json!({ "Dlt": { "fibex_file_paths": ["/fibex/a.xml"], "with_storage_header": false, "tz": "UTC" } }),
+        ))
+        .expect("dlt parser should import");
+        let someip = parse_recent_action(&action(
+            json!({ "File": ["source-id", "PcapNG", "/logs/someip.pcapng"] }),
+            json!({ "SomeIp": { "fibex_file_paths": ["/fibex/someip.xml"] } }),
+        ))
+        .expect("someip parser should import");
+        let plugin = parse_recent_action(&action(
+            json!({ "File": ["source-id", "Text", "/logs/plugin.log"] }),
+            json!({ "Plugin": { "plugin_path": "/plugins/parser.wasm", "plugin_configs": [] } }),
+        ))
+        .expect("plugin parser should import");
+
+        assert!(matches!(
+            dlt.parser,
+            ParserType::Dlt(settings)
+                if settings.fibex_file_paths == Some(vec![String::from("/fibex/a.xml")])
+                    && !settings.with_storage_header
+                    && settings.tz.as_deref() == Some("UTC")
+                    && settings.fibex_metadata.is_none()
+        ));
+        assert!(matches!(
+            someip.parser,
+            ParserType::SomeIp(settings)
+                if settings.fibex_file_paths == Some(vec![String::from("/fibex/someip.xml")])
+        ));
+        assert!(matches!(
+            plugin.parser,
+            ParserType::Plugin(settings)
+                if settings.plugin_path.as_path() == Path::new("/plugins/parser.wasm")
+                    && settings.general_settings.placeholder.is_empty()
+                    && settings.plugin_configs.is_empty()
+        ));
+    }
+
+    #[test]
+    fn skips_unsupported_and_malformed_actions() {
+        assert!(
+            parse_recent_action(&action(
+                json!({ "File": ["source-id", "ParserPlugin", "/logs/plugin.bin"] }),
+                text_parser(),
+            ))
+            .is_err()
+        );
+        assert!(parse_recent_action(&json!({ "stat": { "last": 12 } })).is_err());
+    }
+}

--- a/crates/app/src/host/service/storage/recent/legacy/history.rs
+++ b/crates/app/src/host/service/storage/recent/legacy/history.rs
@@ -1,0 +1,646 @@
+//! Legacy history definition, collection, and state import.
+
+use std::{collections::HashSet, path::Path};
+
+use log::warn;
+use serde_json::{Map, Value};
+
+use processor::search::filter::SearchFilter;
+
+use crate::host::{
+    common::parsers::ParserNames,
+    ui::storage::recent::session::{
+        RecentSessionSource, RecentSessionStateSnapshot, SearchFilterSnapshot,
+    },
+};
+
+use super::{
+    LegacyStorageEntry,
+    actions::{
+        MatchSource, bool_from_value, match_source_from_sources, normalize_path, parse_parser_name,
+        parse_sources, parse_stream_match, path_from_object, supports_bookmarks,
+    },
+    history_collections_path, history_definitions_path, load_optional_entries,
+};
+
+/// Parsed legacy history data used to attach saved state to imported actions.
+#[derive(Debug, Default)]
+pub struct LegacyHistory {
+    definitions: Vec<HistoryDefinition>,
+    collections: Vec<HistoryCollection>,
+}
+
+/// Restorable legacy session identity: source shape plus parser kind.
+#[derive(Debug)]
+struct HistoryDefinition {
+    uuid: String,
+    source: MatchSource,
+    parser: ParserNames,
+}
+
+/// Legacy saved state linked to one or more history definitions.
+#[derive(Debug)]
+struct HistoryCollection {
+    relation_ids: HashSet<String>,
+    last_used: u64,
+    state: RecentSessionStateSnapshot,
+    skipped_entries: usize,
+}
+
+/// Returns usable history definitions, skipping malformed or unsupported entries.
+fn parse_history_definitions(entries: Vec<LegacyStorageEntry>) -> Vec<HistoryDefinition> {
+    let mut definitions = Vec::new();
+
+    for entry in entries {
+        let content = match entry.content_json() {
+            Ok(content) => content,
+            Err(err) => {
+                warn!("Skipping malformed legacy history definition content: {err}");
+                continue;
+            }
+        };
+
+        let Some(definition) = parse_history_definition(&entry.uuid, &content) else {
+            warn!(
+                "Skipping unsupported legacy history definition {}",
+                entry.uuid
+            );
+            continue;
+        };
+        definitions.push(definition);
+    }
+
+    definitions
+}
+
+/// Parses one history definition, returning `None` when source or parser identity is unsupported.
+fn parse_history_definition(uuid: &str, content: &Value) -> Option<HistoryDefinition> {
+    let origin = content
+        .pointer("/observe/origin")
+        .or_else(|| content.get("origin"))
+        .or_else(|| content.get("source"));
+    let source = origin
+        .and_then(|origin| parse_sources(origin).ok())
+        .as_deref()
+        .and_then(match_source_from_sources)
+        .or_else(|| parse_definition_source(content))?;
+
+    let parser = content
+        .pointer("/observe/parser")
+        .or_else(|| content.get("parser"))
+        .or_else(|| content.get("parser_kind"))
+        .or_else(|| content.get("parserKind"))
+        .and_then(parse_parser_name)?;
+
+    let definition = HistoryDefinition {
+        uuid: uuid.to_owned(),
+        source,
+        parser,
+    };
+
+    Some(definition)
+}
+
+/// Extracts a matchable source from a definition, returning `None` for unsupported shapes.
+fn parse_definition_source(content: &Value) -> Option<MatchSource> {
+    if let Some(object) = content.as_object() {
+        if let Some(path) = path_from_object(object) {
+            let path = normalize_path(&path);
+            return Some(MatchSource::Files(vec![path]));
+        }
+
+        if let Some(files) = object
+            .get("files")
+            .or_else(|| object.get("Concat"))
+            .and_then(Value::as_array)
+        {
+            let paths = files
+                .iter()
+                .filter_map(parse_definition_path)
+                .collect::<Vec<_>>();
+            if !paths.is_empty() {
+                return Some(MatchSource::Files(paths));
+            }
+        }
+    }
+
+    parse_stream_match(content)
+}
+
+/// Extracts one normalized definition path, returning `None` when no path is present.
+fn parse_definition_path(value: &Value) -> Option<String> {
+    if let Some(path) = value.as_str() {
+        return Some(path.to_lowercase());
+    }
+
+    value
+        .as_object()
+        .and_then(path_from_object)
+        .map(|path| normalize_path(&path))
+}
+
+/// Returns usable history collections, skipping malformed or unsupported entries.
+fn parse_history_collections(entries: Vec<LegacyStorageEntry>) -> Vec<HistoryCollection> {
+    let mut collections = Vec::new();
+
+    for entry in entries {
+        let content = match entry.content_json() {
+            Ok(content) => content,
+            Err(err) => {
+                warn!("Skipping malformed legacy history collection content: {err}");
+                continue;
+            }
+        };
+
+        let Some(collection) = parse_history_collection(&content) else {
+            warn!(
+                "Skipping unsupported legacy history collection {}",
+                entry.uuid
+            );
+            continue;
+        };
+        collections.push(collection);
+    }
+
+    collections
+}
+
+/// Parses one history collection, returning `None` when it has no related definitions.
+fn parse_history_collection(content: &Value) -> Option<HistoryCollection> {
+    let relation_ids = relation_ids(content);
+    if relation_ids.is_empty() {
+        return None;
+    }
+
+    let last_used = content.get("l").and_then(Value::as_u64).unwrap_or(0);
+    let mut state = RecentSessionStateSnapshot::default();
+    let skipped_entries = content
+        .get("e")
+        .map(|entries| parse_collection_entries(entries, &mut state))
+        .unwrap_or(0);
+
+    Some(HistoryCollection {
+        relation_ids,
+        last_used,
+        state,
+        skipped_entries,
+    })
+}
+
+/// Returns all definition relation ids found in a history collection.
+fn relation_ids(content: &Value) -> HashSet<String> {
+    let mut ids = HashSet::new();
+    let Some(object) = content.as_object() else {
+        return ids;
+    };
+
+    for key in [
+        "d",
+        "definitions",
+        "definition_uuids",
+        "definitionUuids",
+        "relations",
+        "r",
+    ] {
+        if let Some(values) = object.get(key).and_then(Value::as_array) {
+            ids.extend(values.iter().filter_map(Value::as_str).map(str::to_owned));
+        }
+    }
+
+    for key in [
+        "origin_definition_uuid",
+        "originDefinitionUuid",
+        "origin_definition",
+        "originDefinition",
+        "definition",
+        "o",
+    ] {
+        if let Some(value) = object.get(key) {
+            if let Some(id) = value.as_str() {
+                ids.insert(id.to_owned());
+            } else if let Some(id) = value.get("uuid").and_then(Value::as_str) {
+                ids.insert(id.to_owned());
+            }
+        }
+    }
+
+    ids
+}
+
+/// Imports collection entries into state and returns the number of skipped entries.
+fn parse_collection_entries(entries: &Value, state: &mut RecentSessionStateSnapshot) -> usize {
+    if let Some(object) = entries.as_object() {
+        return parse_collection_entry_object(object, state);
+    }
+
+    let Some(items) = entries.as_array() else {
+        return 1;
+    };
+
+    items
+        .iter()
+        .map(|item| {
+            if let Some(object) = item.as_object() {
+                parse_collection_entry_object(object, state)
+            } else {
+                1
+            }
+        })
+        .sum()
+}
+
+/// Imports one collection entry object into state and returns the number of skipped values.
+fn parse_collection_entry_object(
+    object: &Map<String, Value>,
+    state: &mut RecentSessionStateSnapshot,
+) -> usize {
+    let mut skipped = 0usize;
+
+    let entry_type = object.get("type").and_then(Value::as_str);
+    for (key, value) in object {
+        match key.as_str() {
+            "filters" => skipped += parse_filters(value, true, &mut state.filters),
+            "charts" => skipped += parse_charts(value, true, &mut state.search_values),
+            "bookmark" | "bookmarks" => skipped += parse_bookmarks(value, &mut state.bookmarks),
+            "disabled" => skipped += parse_disabled(value, state),
+            "type" => {}
+            _ => match entry_type {
+                Some("filters") => skipped += parse_filters(value, true, &mut state.filters),
+                Some("charts") => skipped += parse_charts(value, true, &mut state.search_values),
+                Some("bookmark") => skipped += parse_bookmarks(value, &mut state.bookmarks),
+                _ => {}
+            },
+        }
+    }
+
+    skipped
+}
+
+/// Imports filter entries into `output` and returns the number of skipped entries.
+fn parse_filters(
+    value: &Value,
+    default_enabled: bool,
+    output: &mut Vec<SearchFilterSnapshot>,
+) -> usize {
+    parse_one_or_many(value, |item| parse_filter(item, default_enabled), output)
+}
+
+/// Imports chart search-value entries into `output` and returns the number of skipped entries.
+fn parse_charts(
+    value: &Value,
+    default_enabled: bool,
+    output: &mut Vec<SearchFilterSnapshot>,
+) -> usize {
+    parse_one_or_many(value, |item| parse_chart(item, default_enabled), output)
+}
+
+/// Parses either one legacy entry or an array, returning the number of skipped items.
+fn parse_one_or_many<T>(
+    value: &Value,
+    mut parse: impl FnMut(&Value) -> Option<T>,
+    output: &mut Vec<T>,
+) -> usize {
+    if let Some(items) = value.as_array() {
+        let initial_len = output.len();
+        output.extend(items.iter().filter_map(&mut parse));
+        items.len() - (output.len() - initial_len)
+    } else if let Some(item) = parse(value) {
+        output.push(item);
+        0
+    } else {
+        1
+    }
+}
+
+/// Parses one filter snapshot, returning `None` when filter text is missing.
+fn parse_filter(value: &Value, default_enabled: bool) -> Option<SearchFilterSnapshot> {
+    let filter_value = value.get("filter").unwrap_or(value);
+    let text = if let Some(text) = filter_value.as_str() {
+        text
+    } else {
+        filter_value
+            .get("filter")
+            .or_else(|| filter_value.get("text"))
+            .and_then(Value::as_str)?
+    };
+
+    let reg = bool_from_value(filter_value.get("reg")).unwrap_or(false);
+    let word = bool_from_value(filter_value.get("word")).unwrap_or(false);
+    let cases = bool_from_value(filter_value.get("cases")).unwrap_or(false);
+    let enabled = bool_from_value(value.get("active"))
+        .or_else(|| bool_from_value(filter_value.get("active")))
+        .unwrap_or(default_enabled);
+
+    let snapshot = SearchFilterSnapshot {
+        filter: SearchFilter::plain(text)
+            .regex(reg)
+            .word(word)
+            .ignore_case(!cases),
+        enabled,
+    };
+
+    Some(snapshot)
+}
+
+/// Parses one chart search-value snapshot, returning `None` when filter text is missing.
+fn parse_chart(value: &Value, default_enabled: bool) -> Option<SearchFilterSnapshot> {
+    let chart_value = value.get("chart").unwrap_or(value);
+    let text = chart_value
+        .get("filter")
+        .or_else(|| chart_value.get("text"))
+        .and_then(Value::as_str)
+        .or_else(|| chart_value.as_str())?;
+    let enabled = bool_from_value(value.get("active"))
+        .or_else(|| bool_from_value(chart_value.get("active")))
+        .unwrap_or(default_enabled);
+
+    let snapshot = SearchFilterSnapshot {
+        filter: SearchFilter::plain(text).regex(true).ignore_case(true),
+        enabled,
+    };
+
+    Some(snapshot)
+}
+
+/// Imports bookmark positions into `output` and returns the number of skipped entries.
+fn parse_bookmarks(value: &Value, output: &mut Vec<u64>) -> usize {
+    parse_one_or_many(
+        value,
+        |item| {
+            item.as_u64()
+                .or_else(|| item.get("position").and_then(Value::as_u64))
+        },
+        output,
+    )
+}
+
+/// Imports disabled filters or charts into state and returns the number of skipped entries.
+fn parse_disabled(value: &Value, state: &mut RecentSessionStateSnapshot) -> usize {
+    if let Some(items) = value.as_array() {
+        return items.iter().map(|item| parse_disabled(item, state)).sum();
+    }
+
+    let Some(object) = value.as_object() else {
+        return 1;
+    };
+
+    let mut skipped = 0usize;
+    if let Some(filters) = object.get("filters").or_else(|| object.get("filter")) {
+        let first_added = state.filters.len();
+        skipped += parse_filters(filters, false, &mut state.filters);
+        for filter in &mut state.filters[first_added..] {
+            filter.enabled = false;
+        }
+    }
+    if let Some(charts) = object.get("charts").or_else(|| object.get("chart")) {
+        let first_added = state.search_values.len();
+        skipped += parse_charts(charts, false, &mut state.search_values);
+        for chart in &mut state.search_values[first_added..] {
+            chart.enabled = false;
+        }
+    }
+
+    if skipped == 0
+        && !object.contains_key("filters")
+        && !object.contains_key("filter")
+        && !object.contains_key("charts")
+        && !object.contains_key("chart")
+    {
+        skipped = 1;
+    }
+
+    skipped
+}
+
+impl LegacyHistory {
+    /// Loads optional legacy history files and returns usable parsed state.
+    pub fn load(home_dir: &Path) -> Self {
+        let definitions_path = history_definitions_path(home_dir);
+        let definitions = match load_optional_entries(&definitions_path) {
+            Ok(entries) => parse_history_definitions(entries),
+            Err(err) => {
+                warn!("Skipping malformed legacy history definitions: {err}");
+                Vec::new()
+            }
+        };
+
+        let collections_path = history_collections_path(home_dir);
+        let collections = match load_optional_entries(&collections_path) {
+            Ok(entries) => parse_history_collections(entries),
+            Err(err) => {
+                warn!("Skipping malformed legacy history collections: {err}");
+                Vec::new()
+            }
+        };
+
+        let skipped_entries = collections
+            .iter()
+            .map(|collection| collection.skipped_entries)
+            .sum::<usize>();
+        if skipped_entries > 0 {
+            warn!("Skipped {skipped_entries} malformed legacy history entries");
+        }
+
+        Self {
+            definitions,
+            collections,
+        }
+    }
+
+    /// Finds the newest matching collection state, or `None` when no definition matches.
+    pub fn state_for(
+        &self,
+        sources: &[RecentSessionSource],
+        parser: ParserNames,
+    ) -> Option<RecentSessionStateSnapshot> {
+        let source = match_source_from_sources(sources)?;
+        let definition_ids = self
+            .definitions
+            .iter()
+            .filter(|definition| definition.parser == parser && definition.source == source)
+            .map(|definition| definition.uuid.as_str())
+            .collect::<HashSet<_>>();
+
+        if definition_ids.is_empty() {
+            return None;
+        }
+
+        self.collections
+            .iter()
+            .filter(|collection| {
+                collection
+                    .relation_ids
+                    .iter()
+                    .any(|id| definition_ids.contains(id.as_str()))
+            })
+            .max_by_key(|collection| collection.last_used)
+            .map(|collection| {
+                let mut state = collection.state.clone();
+                if !supports_bookmarks(sources) {
+                    state.bookmarks.clear();
+                }
+                state
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use serde_json::json;
+    use stypes::{FileFormat, TCPTransportConfig, Transport};
+
+    use super::*;
+
+    /// Verifies that matching history returns the newest related collection state.
+    #[test]
+    fn maps_history_state_from_newest_matching_collection() {
+        let sources = vec![RecentSessionSource::File {
+            format: FileFormat::Text,
+            path: PathBuf::from("/LOGS/App.log"),
+        }];
+        let history = LegacyHistory {
+            definitions: vec![HistoryDefinition {
+                uuid: String::from("definition-id"),
+                source: MatchSource::Files(vec![String::from("/logs/app.log")]),
+                parser: ParserNames::Text,
+            }],
+            collections: vec![
+                HistoryCollection {
+                    relation_ids: HashSet::from([String::from("definition-id")]),
+                    last_used: 1,
+                    state: RecentSessionStateSnapshot {
+                        filters: vec![SearchFilterSnapshot {
+                            filter: SearchFilter::plain("old"),
+                            enabled: true,
+                        }],
+                        ..Default::default()
+                    },
+                    skipped_entries: 0,
+                },
+                HistoryCollection {
+                    relation_ids: HashSet::from([String::from("definition-id")]),
+                    last_used: 2,
+                    state: parsed_state(json!({
+                        "filters": [{ "filter": { "filter": "level=(warn|error)", "reg": true, "word": true, "cases": true } }],
+                        "charts": [{ "filter": "cpu=(\\d+)" }],
+                        "disabled": [
+                            { "filter": { "filter": "disabled filter", "active": true } },
+                            { "chart": { "filter": "disabled chart", "active": true } }
+                        ],
+                        "bookmark": [{ "position": 42 }]
+                    })),
+                    skipped_entries: 0,
+                },
+            ],
+        };
+
+        let state = history
+            .state_for(&sources, ParserNames::Text)
+            .expect("history should match");
+
+        assert_eq!(state.filters.len(), 2);
+        let imported_filter = state
+            .filters
+            .iter()
+            .find(|filter| filter.filter.value == "level=(warn|error)")
+            .expect("enabled filter should be imported");
+        assert!(imported_filter.filter.is_regex());
+        assert!(imported_filter.filter.is_word());
+        assert!(!imported_filter.filter.is_ignore_case());
+        assert!(imported_filter.enabled);
+        let disabled_filter = state
+            .filters
+            .iter()
+            .find(|filter| filter.filter.value == "disabled filter")
+            .expect("disabled filter should be imported");
+        assert!(!disabled_filter.enabled);
+
+        assert_eq!(state.search_values.len(), 2);
+        let imported_chart = state
+            .search_values
+            .iter()
+            .find(|chart| chart.filter.value == "cpu=(\\d+)")
+            .expect("enabled chart should be imported");
+        assert!(imported_chart.filter.is_regex());
+        assert!(imported_chart.filter.is_ignore_case());
+        assert!(imported_chart.enabled);
+        let disabled_chart = state
+            .search_values
+            .iter()
+            .find(|chart| chart.filter.value == "disabled chart")
+            .expect("disabled chart should be imported");
+        assert!(!disabled_chart.enabled);
+        assert_eq!(state.bookmarks, vec![42]);
+    }
+
+    /// Verifies that stream history returns state with bookmarks removed.
+    #[test]
+    fn does_not_attach_bookmarks_to_stream_history() {
+        let sources = vec![RecentSessionSource::Stream {
+            transport: Transport::TCP(TCPTransportConfig {
+                bind_addr: String::from("127.0.0.1:5000"),
+            }),
+        }];
+        let history = LegacyHistory {
+            definitions: vec![HistoryDefinition {
+                uuid: String::from("definition-id"),
+                source: MatchSource::Tcp {
+                    bind_addr: String::from("127.0.0.1:5000"),
+                },
+                parser: ParserNames::Text,
+            }],
+            collections: vec![HistoryCollection {
+                relation_ids: HashSet::from([String::from("definition-id")]),
+                last_used: 1,
+                state: RecentSessionStateSnapshot {
+                    bookmarks: vec![7],
+                    ..Default::default()
+                },
+                skipped_entries: 0,
+            }],
+        };
+
+        let state = history
+            .state_for(&sources, ParserNames::Text)
+            .expect("history should match");
+
+        assert!(state.bookmarks.is_empty());
+    }
+
+    /// Verifies that unmatched history returns no state.
+    #[test]
+    fn leaves_history_empty_without_matching_definition() {
+        let history = LegacyHistory {
+            definitions: vec![HistoryDefinition {
+                uuid: String::from("definition-id"),
+                source: MatchSource::Files(vec![String::from("/logs/other.log")]),
+                parser: ParserNames::Text,
+            }],
+            collections: vec![HistoryCollection {
+                relation_ids: HashSet::from([String::from("definition-id")]),
+                last_used: 1,
+                state: RecentSessionStateSnapshot {
+                    bookmarks: vec![7],
+                    ..Default::default()
+                },
+                skipped_entries: 0,
+            }],
+        };
+        let sources = vec![RecentSessionSource::File {
+            format: FileFormat::Text,
+            path: PathBuf::from("/logs/app.log"),
+        }];
+
+        assert!(history.state_for(&sources, ParserNames::Text).is_none());
+    }
+
+    /// Parses test entries into state and asserts that no entries were skipped.
+    fn parsed_state(entries: Value) -> RecentSessionStateSnapshot {
+        let mut state = RecentSessionStateSnapshot::default();
+        let skipped = parse_collection_entries(&entries, &mut state);
+        assert_eq!(skipped, 0);
+        state
+    }
+}

--- a/crates/app/src/host/service/storage/recent/legacy/mod.rs
+++ b/crates/app/src/host/service/storage/recent/legacy/mod.rs
@@ -1,0 +1,223 @@
+//! Legacy Chipmunk 3 recent-session import paths, marker helpers, and parsers.
+//!
+//! # NOTE:
+//!
+//! This can be removed after multiple Chipmunk 4 releases when users have already
+//! moved to the new version.
+//!
+//! At that point it would make sense to remove the old storage folder.
+
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use log::{info, warn};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::host::{
+    common::parsers::ParserNames,
+    ui::storage::recent::{session::RecentSessionSnapshot, storage::RecentSessionsStorage},
+};
+
+use self::{actions::parse_recent_action, history::LegacyHistory};
+
+mod actions;
+mod history;
+
+const LEGACY_STORAGE_DIR: &str = "storage";
+const LEGACY_RECENT_ACTIONS_FILE: &str = "user_recent_actions.storage";
+const LEGACY_HISTORY_DEFINITIONS_FILE: &str = "history_definitions_storage.storage";
+const LEGACY_HISTORY_COLLECTIONS_FILE: &str = "history_collections_storage.storage";
+const IMPORT_MARKER_FILE: &str = "recent_imported_chipmunk_4";
+
+/// Wrapper entry used by Chipmunk 3 `.storage` JSON arrays.
+#[derive(Debug, Deserialize)]
+struct LegacyStorageEntry {
+    uuid: String,
+    content: Value,
+}
+
+/// Accumulates imported snapshots and aggregate import counters.
+struct ImportAccumulator {
+    history: LegacyHistory,
+    snapshots: Vec<RecentSessionSnapshot>,
+    skipped: usize,
+    history_matches: usize,
+}
+
+/// Finished legacy import result ready for native persistence.
+struct ImportSummary {
+    storage: RecentSessionsStorage,
+    skipped: usize,
+    history_matches: usize,
+}
+
+/// Returns the legacy Chipmunk 3 storage directory path.
+pub fn storage_path(home_dir: &Path) -> PathBuf {
+    home_dir.join(LEGACY_STORAGE_DIR)
+}
+
+/// Returns the legacy recent-actions storage file path.
+pub fn recent_actions_path(home_dir: &Path) -> PathBuf {
+    storage_path(home_dir).join(LEGACY_RECENT_ACTIONS_FILE)
+}
+
+fn history_definitions_path(home_dir: &Path) -> PathBuf {
+    storage_path(home_dir).join(LEGACY_HISTORY_DEFINITIONS_FILE)
+}
+
+fn history_collections_path(home_dir: &Path) -> PathBuf {
+    storage_path(home_dir).join(LEGACY_HISTORY_COLLECTIONS_FILE)
+}
+
+/// Returns the legacy import marker file path.
+pub fn marker_path(home_dir: &Path) -> PathBuf {
+    storage_path(home_dir).join(IMPORT_MARKER_FILE)
+}
+
+/// Returns whether the legacy recent-actions file exists.
+pub fn recent_actions_exists(home_dir: &Path) -> bool {
+    recent_actions_path(home_dir).exists()
+}
+
+/// Returns whether the legacy import marker exists.
+pub fn marker_exists(home_dir: &Path) -> bool {
+    marker_path(home_dir).exists()
+}
+
+/// Creates the legacy import marker only when the legacy storage directory exists.
+pub fn create_marker(home_dir: &Path) -> io::Result<bool> {
+    if !storage_path(home_dir).exists() {
+        return Ok(false);
+    }
+
+    let marker_path = marker_path(home_dir);
+    if marker_path.exists() {
+        return Ok(false);
+    }
+
+    fs::write(
+        marker_path,
+        "Chipmunk 4 has already checked this Chipmunk 3 storage for recent sessions.\n",
+    )?;
+    Ok(true)
+}
+
+/// Imports Chipmunk 3 recent actions into the native recent-session model.
+pub fn import_recent_sessions(home_dir: &Path) -> Result<RecentSessionsStorage, String> {
+    info!("Legacy recent-session import started");
+
+    let recent_actions_file = recent_actions_path(home_dir);
+    let entries = load_storage_entries(&recent_actions_file)?;
+    let mut accumulator = ImportAccumulator::new(home_dir);
+    for entry in &entries {
+        accumulator.import_entry(entry);
+    }
+
+    let import = accumulator.finish();
+    info!(
+        "Legacy recent-session import completed: action entries read={}, sessions imported={}, entries skipped={}, history collections matched={}",
+        entries.len(),
+        import.storage.sessions.len(),
+        import.skipped,
+        import.history_matches
+    );
+
+    Ok(import.storage)
+}
+
+fn load_storage_entries(path: &Path) -> Result<Vec<LegacyStorageEntry>, String> {
+    let raw = fs::read_to_string(path).map_err(|err| {
+        format!(
+            "Failed to read legacy recent-actions storage '{}': {err}",
+            path.display()
+        )
+    })?;
+
+    serde_json::from_str(&raw).map_err(|err| {
+        format!(
+            "Failed to parse legacy recent-actions storage '{}': {err}",
+            path.display()
+        )
+    })
+}
+
+fn load_optional_entries(path: &Path) -> Result<Vec<LegacyStorageEntry>, String> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let raw = fs::read_to_string(path)
+        .map_err(|err| format!("Failed to read '{}': {err}", path.display()))?;
+
+    serde_json::from_str(&raw).map_err(|err| format!("Failed to parse '{}': {err}", path.display()))
+}
+
+impl ImportAccumulator {
+    fn new(home_dir: &Path) -> Self {
+        Self {
+            history: LegacyHistory::load(home_dir),
+            snapshots: Vec::new(),
+            skipped: 0,
+            history_matches: 0,
+        }
+    }
+
+    fn import_entry(&mut self, entry: &LegacyStorageEntry) {
+        let content = match entry.content_json() {
+            Ok(content) => content,
+            Err(err) => {
+                self.skipped += 1;
+                warn!("Skipping malformed legacy recent-action content: {err}");
+                return;
+            }
+        };
+
+        let mut snapshot = match parse_recent_action(&content) {
+            Ok(snapshot) => snapshot,
+            Err(err) => {
+                self.skipped += 1;
+                warn!(
+                    "Skipping unsupported legacy recent-action {}: {err}",
+                    entry.uuid
+                );
+                return;
+            }
+        };
+
+        let parser_name = ParserNames::from(&snapshot.parser);
+        if let Some(state) = self.history.state_for(snapshot.sources(), parser_name) {
+            snapshot.state = state;
+            snapshot.rebuild_cache();
+            self.history_matches += 1;
+        }
+
+        self.snapshots.push(snapshot);
+    }
+
+    fn finish(mut self) -> ImportSummary {
+        self.snapshots.sort_by_key(|snapshot| snapshot.last_opened);
+
+        let mut storage = RecentSessionsStorage::default();
+        for snapshot in self.snapshots {
+            storage.register_session(snapshot);
+        }
+
+        ImportSummary {
+            storage,
+            skipped: self.skipped,
+            history_matches: self.history_matches,
+        }
+    }
+}
+
+impl LegacyStorageEntry {
+    fn content_json(&self) -> Result<Value, String> {
+        match &self.content {
+            Value::String(content) => serde_json::from_str(content).map_err(|err| err.to_string()),
+            content => Ok(content.clone()),
+        }
+    }
+}

--- a/crates/app/src/host/service/storage/recent/mod.rs
+++ b/crates/app/src/host/service/storage/recent/mod.rs
@@ -6,11 +6,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use log::warn;
+use log::{info, warn};
 
 use stypes::Transport;
 
-use super::storage_path;
+use super::{chipmunk_home_dir, storage_path_from_home};
 use crate::{
     host::{
         command::OpenRecentSessionParam,
@@ -30,6 +30,8 @@ use crate::{
     },
     session::InitSessionError,
 };
+
+mod legacy;
 
 const RECENT_SESSIONS_FILE: &str = "recent_sessions.json";
 
@@ -59,8 +61,86 @@ pub enum RecentSessionOpenRequest {
 
 /// Loads and normalizes recent sessions.
 pub fn load_sessions() -> Result<RecentSessionsStorage, StorageError> {
-    let path = get_path()?;
-    load_and_normalize(&path)
+    let home_dir = chipmunk_home_dir()?;
+    load_sessions_from_home(&home_dir)
+}
+
+fn load_sessions_from_home(home_dir: &Path) -> Result<RecentSessionsStorage, StorageError> {
+    let native_path = get_path_from_home(home_dir)?;
+
+    run_legacy_import_hook(home_dir, &native_path);
+    create_legacy_marker(home_dir, &native_path);
+
+    load_and_normalize(&native_path)
+}
+
+fn get_path_from_home(home_dir: &Path) -> Result<PathBuf, StorageError> {
+    storage_path_from_home(home_dir).map(|storage_dir| storage_dir.join(RECENT_SESSIONS_FILE))
+}
+
+/// Import recent session from legacy Chipmunk 3 on first time Chipmunk 4 is used.
+fn run_legacy_import_hook(home_dir: &Path, native_path: &Path) {
+    if native_path.exists()
+        || legacy::marker_exists(home_dir)
+        || !legacy::recent_actions_exists(home_dir)
+    {
+        return;
+    }
+
+    let imported_storage = match legacy::import_recent_sessions(home_dir) {
+        Ok(storage) => storage,
+        Err(err) => {
+            warn!("Legacy recent-session import failed: {err}");
+            RecentSessionsStorage::default()
+        }
+    };
+
+    if let Err(err) = save_to_path(native_path, &imported_storage) {
+        warn!(
+            "Failed to create native recent-sessions storage at {} after legacy import: {err}",
+            native_path.display()
+        );
+    }
+}
+
+/// Create marker file in Chipmunk 3 legacy storage to mark the storage as
+/// already used to import legacy recent sessions into Chipmunk 4.
+///
+/// # Note:
+///
+/// We leave the marker in legacy Chipmunk to ensure that we will not re-import from
+/// legacy again in case users removed Chipmunk 4 storage directory.
+fn create_legacy_marker(home_dir: &Path, native_path: &Path) {
+    if !native_path.exists() {
+        return;
+    }
+
+    match legacy::create_marker(home_dir) {
+        Ok(true) => info!(
+            "Created legacy recent-session import marker at {}",
+            legacy::marker_path(home_dir).display()
+        ),
+        Ok(false) => {}
+        Err(err) => warn!(
+            "Failed to create legacy recent-session import marker at {}: {err}",
+            legacy::marker_path(home_dir).display()
+        ),
+    }
+}
+
+fn load_and_normalize(path: &Path) -> Result<RecentSessionsStorage, StorageError> {
+    let mut storage = RecentSessionsStorage::load(path)?;
+
+    if normalize_recent_sessions(&mut storage.sessions)
+        && let Err(err) = save_to_path(path, &storage)
+    {
+        warn!(
+            "Failed to persist normalized recent-sessions storage to {}: {err}",
+            path.display()
+        );
+    }
+
+    Ok(storage)
 }
 
 pub fn resolve_open_request(
@@ -153,21 +233,6 @@ fn open_recent_session_clean(
     }
 }
 
-fn load_and_normalize(path: &Path) -> Result<RecentSessionsStorage, StorageError> {
-    let mut storage = RecentSessionsStorage::load(path)?;
-
-    if normalize_recent_sessions(&mut storage.sessions)
-        && let Err(err) = save_to_path(path, &storage)
-    {
-        warn!(
-            "Failed to persist normalized recent-sessions storage to {}: {err}",
-            path.display()
-        );
-    }
-
-    Ok(storage)
-}
-
 fn normalize_recent_sessions(sessions: &mut Vec<RecentSessionSnapshot>) -> bool {
     let invalid_removed = sanitize_recent_sessions(sessions);
     let reordered = sort_recent_sessions(sessions);
@@ -238,14 +303,15 @@ fn save_to_path(path: &Path, data: &RecentSessionsStorage) -> Result<(), Storage
 }
 
 fn get_path() -> Result<PathBuf, StorageError> {
-    storage_path().map(|storage_dir| storage_dir.join(RECENT_SESSIONS_FILE))
+    let home_dir = chipmunk_home_dir()?;
+    get_path_from_home(&home_dir)
 }
 
 #[cfg(test)]
 mod tests {
     use std::{
         fs,
-        path::PathBuf,
+        path::{Path, PathBuf},
         time::{SystemTime, UNIX_EPOCH},
     };
 
@@ -272,7 +338,7 @@ mod tests {
 
     use super::*;
 
-    fn test_home_dir() -> std::path::PathBuf {
+    fn test_home_dir() -> PathBuf {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system time must be after unix epoch")
@@ -282,20 +348,17 @@ mod tests {
         path
     }
 
-    fn path_from_home(home_dir: &std::path::Path) -> Result<std::path::PathBuf, StorageError> {
+    fn path_from_home(home_dir: &Path) -> Result<PathBuf, StorageError> {
         let storage_dir = storage_path_from_home(home_dir)?;
         Ok(storage_dir.join(RECENT_SESSIONS_FILE))
     }
 
-    fn save_to_home(
-        home_dir: &std::path::Path,
-        data: &RecentSessionsStorage,
-    ) -> Result<(), StorageError> {
+    fn save_to_home(home_dir: &Path, data: &RecentSessionsStorage) -> Result<(), StorageError> {
         let path = path_from_home(home_dir)?;
         save_to_path(&path, data)
     }
 
-    fn write_sessions_to_home(home_dir: &std::path::Path, sessions: Vec<RecentSessionSnapshot>) {
+    fn write_sessions_to_home(home_dir: &Path, sessions: Vec<RecentSessionSnapshot>) {
         let path = path_from_home(home_dir).expect("path should resolve");
         let json = serde_json::json!({ "sessions": sessions });
         fs::write(
@@ -303,6 +366,87 @@ mod tests {
             serde_json::to_vec_pretty(&json).expect("json should serialize"),
         )
         .expect("sessions should be written");
+    }
+
+    fn create_legacy_storage(home_dir: &Path) {
+        fs::create_dir_all(legacy::storage_path(home_dir))
+            .expect("legacy storage dir should be created");
+    }
+
+    fn create_legacy_recent_actions(home_dir: &Path) {
+        write_legacy_recent_actions(home_dir, Vec::new());
+    }
+
+    fn write_legacy_recent_actions(home_dir: &Path, contents: Vec<serde_json::Value>) {
+        create_legacy_storage(home_dir);
+        let entries = contents
+            .into_iter()
+            .enumerate()
+            .map(|(index, content)| {
+                serde_json::json!({
+                    "uuid": format!("entry-{index}"),
+                    "content": content.to_string(),
+                })
+            })
+            .collect::<Vec<_>>();
+        fs::write(
+            legacy::recent_actions_path(home_dir),
+            serde_json::to_vec(&entries).expect("legacy entries should serialize"),
+        )
+        .expect("legacy recent actions should be written");
+    }
+
+    fn write_legacy_history_definitions(home_dir: &Path, contents: Vec<(&str, serde_json::Value)>) {
+        let path = legacy::storage_path(home_dir).join("history_definitions_storage.storage");
+        write_legacy_storage_entries(home_dir, &path, contents);
+    }
+
+    fn write_legacy_history_collections(home_dir: &Path, contents: Vec<(&str, serde_json::Value)>) {
+        let path = legacy::storage_path(home_dir).join("history_collections_storage.storage");
+        write_legacy_storage_entries(home_dir, &path, contents);
+    }
+
+    fn write_legacy_storage_entries(
+        home_dir: &Path,
+        path: &Path,
+        contents: Vec<(&str, serde_json::Value)>,
+    ) {
+        create_legacy_storage(home_dir);
+        let entries = contents
+            .into_iter()
+            .map(|(uuid, content)| {
+                serde_json::json!({
+                    "uuid": uuid,
+                    "content": content.to_string(),
+                })
+            })
+            .collect::<Vec<_>>();
+        fs::write(
+            path,
+            serde_json::to_vec(&entries).expect("legacy entries should serialize"),
+        )
+        .expect("legacy storage entries should be written");
+    }
+
+    fn legacy_file_action(
+        last: u64,
+        format: &str,
+        path: &Path,
+        parser: serde_json::Value,
+    ) -> serde_json::Value {
+        let path = path.to_string_lossy();
+        serde_json::json!({
+            "stat": { "last": last },
+            "observe": {
+                "origin": { "File": ["source-id", format, path] },
+                "parser": parser,
+            }
+        })
+    }
+
+    fn write_legacy_marker(home_dir: &Path) {
+        create_legacy_storage(home_dir);
+        fs::write(legacy::marker_path(home_dir), "").expect("legacy marker should be written");
     }
 
     fn snapshot_from_observe_options(options: ObserveOptions) -> RecentSessionSnapshot {
@@ -369,6 +513,246 @@ mod tests {
         let err = RecentSessionsStorage::load(&path).expect_err("invalid json should fail");
 
         assert_eq!(err.kind, StorageErrorKind::Parse);
+        let _ = fs::remove_dir_all(home_dir);
+    }
+
+    #[test]
+    fn load_sessions_marks_existing_native_file() {
+        let home_dir = test_home_dir();
+        save_to_home(&home_dir, &RecentSessionsStorage::default()).expect("save should succeed");
+        create_legacy_storage(&home_dir);
+
+        load_sessions_from_home(&home_dir).expect("load should succeed");
+
+        assert!(legacy::marker_path(&home_dir).exists());
+        let _ = fs::remove_dir_all(home_dir);
+    }
+
+    #[test]
+    fn load_sessions_does_not_create_missing_legacy_storage_for_marker() {
+        let home_dir = test_home_dir();
+        save_to_home(&home_dir, &RecentSessionsStorage::default()).expect("save should succeed");
+
+        load_sessions_from_home(&home_dir).expect("load should succeed");
+
+        assert!(!legacy::storage_path(&home_dir).exists());
+        assert!(!legacy::marker_path(&home_dir).exists());
+        let _ = fs::remove_dir_all(home_dir);
+    }
+
+    #[test]
+    fn legacy_import_hook_creates_empty_native_file_and_marker() {
+        let home_dir = test_home_dir();
+        let native_path = path_from_home(&home_dir).expect("path should resolve");
+        create_legacy_recent_actions(&home_dir);
+
+        let loaded = load_sessions_from_home(&home_dir).expect("load should succeed");
+
+        assert!(loaded.sessions.is_empty());
+        assert!(native_path.exists());
+        assert!(legacy::marker_path(&home_dir).exists());
+        let saved = RecentSessionsStorage::load(&native_path).expect("created storage should load");
+        assert!(saved.sessions.is_empty());
+        let _ = fs::remove_dir_all(home_dir);
+    }
+
+    #[test]
+    fn legacy_import_hook_writes_imported_native_file() {
+        let home_dir = test_home_dir();
+        let native_path = path_from_home(&home_dir).expect("path should resolve");
+        let source_path = home_dir.join("legacy.log");
+        fs::write(&source_path, "test").expect("source should exist for normalization");
+        write_legacy_recent_actions(
+            &home_dir,
+            vec![legacy_file_action(
+                1_700_000_123_456,
+                "Text",
+                &source_path,
+                serde_json::json!({ "Text": null }),
+            )],
+        );
+
+        let loaded = load_sessions_from_home(&home_dir).expect("load should succeed");
+
+        assert_eq!(loaded.sessions.len(), 1);
+        assert_eq!(loaded.sessions[0].last_opened, 1_700_000_123);
+        assert!(matches!(loaded.sessions[0].parser, ParserType::Text(())));
+        assert!(native_path.exists());
+        assert!(legacy::marker_path(&home_dir).exists());
+        let _ = fs::remove_dir_all(home_dir);
+    }
+
+    #[test]
+    fn legacy_import_failure_still_creates_empty_native_file() {
+        let home_dir = test_home_dir();
+        let native_path = path_from_home(&home_dir).expect("path should resolve");
+        create_legacy_storage(&home_dir);
+        fs::write(legacy::recent_actions_path(&home_dir), "{not-json")
+            .expect("malformed legacy actions should be written");
+
+        let loaded = load_sessions_from_home(&home_dir).expect("load should succeed");
+
+        assert!(loaded.sessions.is_empty());
+        assert!(native_path.exists());
+        assert!(legacy::marker_path(&home_dir).exists());
+        let saved = RecentSessionsStorage::load(&native_path).expect("created storage should load");
+        assert!(saved.sessions.is_empty());
+        let _ = fs::remove_dir_all(home_dir);
+    }
+
+    #[test]
+    fn legacy_import_restores_matching_history_state() {
+        let home_dir = test_home_dir();
+        let source_path = home_dir.join("legacy-with-history.log");
+        fs::write(&source_path, "test").expect("source should exist for normalization");
+        write_legacy_recent_actions(
+            &home_dir,
+            vec![legacy_file_action(
+                1_700_000_123_456,
+                "Text",
+                &source_path,
+                serde_json::json!({ "Text": null }),
+            )],
+        );
+
+        let source_path = source_path.to_string_lossy();
+        write_legacy_history_definitions(
+            &home_dir,
+            vec![(
+                "definition-id",
+                serde_json::json!({
+                    "observe": {
+                        "origin": { "File": ["source-id", "Text", source_path] },
+                        "parser": { "Text": null },
+                    }
+                }),
+            )],
+        );
+        write_legacy_history_collections(
+            &home_dir,
+            vec![(
+                "collection-id",
+                serde_json::json!({
+                    "d": ["definition-id"],
+                    "l": 2,
+                    "e": {
+                        "filters": [{
+                            "filter": {
+                                "filter": "level=(warn|error)",
+                                "reg": true,
+                                "word": true,
+                                "cases": true,
+                            }
+                        }],
+                        "charts": [{ "filter": "cpu=(\\d+)" }],
+                        "bookmark": [{ "position": 42 }],
+                    }
+                }),
+            )],
+        );
+
+        let loaded = load_sessions_from_home(&home_dir).expect("load should succeed");
+
+        assert_eq!(loaded.sessions.len(), 1);
+        let state = &loaded.sessions[0].state;
+        assert_eq!(state.filters.len(), 1);
+        let filter = &state.filters[0];
+        assert_eq!(filter.filter.value, "level=(warn|error)");
+        assert!(filter.filter.is_regex());
+        assert!(filter.filter.is_word());
+        assert!(!filter.filter.is_ignore_case());
+        assert!(filter.enabled);
+        assert_eq!(state.search_values.len(), 1);
+        let chart = &state.search_values[0];
+        assert_eq!(chart.filter.value, "cpu=(\\d+)");
+        assert!(chart.filter.is_regex());
+        assert!(chart.filter.is_ignore_case());
+        assert!(chart.enabled);
+        assert_eq!(state.bookmarks, vec![42]);
+        let _ = fs::remove_dir_all(home_dir);
+    }
+
+    #[test]
+    fn legacy_import_deduplicates_by_newest_source() {
+        let home_dir = test_home_dir();
+        let source_path = home_dir.join("duplicate.log");
+        fs::write(&source_path, "test").expect("source should exist for normalization");
+        write_legacy_recent_actions(
+            &home_dir,
+            vec![
+                legacy_file_action(
+                    1_000,
+                    "Text",
+                    &source_path,
+                    serde_json::json!({ "Text": null }),
+                ),
+                legacy_file_action(
+                    2_000,
+                    "Text",
+                    &source_path,
+                    serde_json::json!({ "SomeIp": { "fibex_file_paths": ["/fibex/a.xml"] } }),
+                ),
+            ],
+        );
+
+        let loaded = load_sessions_from_home(&home_dir).expect("load should succeed");
+
+        assert_eq!(loaded.sessions.len(), 1);
+        assert_eq!(loaded.sessions[0].last_opened, 2);
+        assert!(matches!(loaded.sessions[0].parser, ParserType::SomeIp(..)));
+        let _ = fs::remove_dir_all(home_dir);
+    }
+
+    #[test]
+    fn legacy_imported_missing_file_is_dropped_by_normalization() {
+        let home_dir = test_home_dir();
+        let native_path = path_from_home(&home_dir).expect("path should resolve");
+        let missing_path = home_dir.join("missing.log");
+        write_legacy_recent_actions(
+            &home_dir,
+            vec![legacy_file_action(
+                1_000,
+                "Text",
+                &missing_path,
+                serde_json::json!({ "Text": null }),
+            )],
+        );
+
+        let loaded = load_sessions_from_home(&home_dir).expect("load should succeed");
+
+        assert!(loaded.sessions.is_empty());
+        let saved =
+            RecentSessionsStorage::load(&native_path).expect("normalized storage should load");
+        assert!(saved.sessions.is_empty());
+        let _ = fs::remove_dir_all(home_dir);
+    }
+
+    #[test]
+    fn legacy_import_hook_skips_when_marker_exists() {
+        let home_dir = test_home_dir();
+        let native_path = path_from_home(&home_dir).expect("path should resolve");
+        create_legacy_recent_actions(&home_dir);
+        write_legacy_marker(&home_dir);
+
+        let loaded =
+            load_sessions_from_home(&home_dir).expect("missing native file should default");
+
+        assert!(loaded.sessions.is_empty());
+        assert!(!native_path.exists());
+        let _ = fs::remove_dir_all(home_dir);
+    }
+
+    #[test]
+    fn load_sessions_marks_malformed_native_before_parse_error() {
+        let home_dir = test_home_dir();
+        let native_path = path_from_home(&home_dir).expect("path should resolve");
+        fs::write(&native_path, "{not-json").expect("invalid json should be written");
+        create_legacy_storage(&home_dir);
+
+        let err = load_sessions_from_home(&home_dir).expect_err("invalid json should fail");
+
+        assert_eq!(err.kind, StorageErrorKind::Parse);
+        assert!(legacy::marker_path(&home_dir).exists());
         let _ = fs::remove_dir_all(home_dir);
     }
 


### PR DESCRIPTION
* Restore recent sessions from Chipmunk 3 legacy storage directory into Chipmunk 4 storage.
* Restore process will run once only if we don't have recent sessions in Chipmunk 4 while we have recent session for Chipmunk 3.
* A marker file will be created inside chipmunk 3 storage once we have any recent sessions in Chipmunk 4 to ensure the restore won't run again in the future.
* This implementation should eventually removed once we are sure that we don't have any users who haven't migrated to Chipmunk 4