### PR TITLE
Ensure session files cleanup on application close

### DIFF
--- a/crates/app/src/host/ui/mod.rs
+++ b/crates/app/src/host/ui/mod.rs
@@ -571,6 +571,11 @@ impl eframe::App for Host {
 
     fn on_exit(&mut self) {
         trace!("App Shutdown requested.");
+
+        const SESSION_SHUTDOWN_GRACE: Duration =
+            Duration::from_millis(session_core::session::SHUTDOWN_TIMEOUT_IN_MS + 500);
+        self.tabs
+            .close_sessions_for_shutdown(SESSION_SHUTDOWN_GRACE);
         self.storage.wait_until_save(&mut self.ui_actions);
 
         let (confirm_tx, confirm_rx) = std::sync::mpsc::channel();

--- a/crates/app/src/host/ui/tabs/mod.rs
+++ b/crates/app/src/host/ui/tabs/mod.rs
@@ -2,6 +2,8 @@
 
 mod render;
 
+use std::time::{Duration, Instant};
+
 use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
 
@@ -184,6 +186,35 @@ impl HostTabs {
         self.active_idx = self.tabs.len() - 1;
     }
 
+    /// Gracefully closes all live session services during application shutdown.
+    pub fn close_sessions_for_shutdown(&mut self, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        let mut confirmations = Vec::new();
+        let mut failed = 0;
+
+        for tab in &mut self.tabs {
+            let HostTab::Session(session) = tab else {
+                continue;
+            };
+
+            match session.request_shutdown_with_ack() {
+                Some(confirmation) => confirmations.push(confirmation),
+                None => failed += 1,
+            }
+        }
+
+        for confirmation in confirmations {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() || confirmation.recv_timeout(remaining).is_err() {
+                failed += 1;
+            }
+        }
+
+        if failed > 0 {
+            log::warn!("{failed} session(s) did not confirm shutdown cleanup");
+        }
+    }
+
     /// Requests close behavior for the active tab.
     pub fn close_active_tab(
         &mut self,
@@ -261,7 +292,7 @@ impl HostTabs {
         let HostTab::Session(session) = tab else {
             return;
         };
-        session.on_close_session(actions);
+        session.request_tab_close(actions);
     }
 
     /// Removes the setup tab identified by `setup_id`.

--- a/crates/app/src/session/command.rs
+++ b/crates/app/src/session/command.rs
@@ -125,7 +125,10 @@ pub enum SessionCommand {
     /// Cancel the running operation with the given id.
     CancelOperation { id: Uuid },
     /// Gracefully terminate the session service.
-    CloseSession,
+    CloseSession {
+        /// Notifies synchronous shutdown callers after service-owned cleanup finished.
+        confirm_tx: Option<Sender<()>>,
+    },
 }
 
 #[derive(Debug)]

--- a/crates/app/src/session/service/mod.rs
+++ b/crates/app/src/session/service/mod.rs
@@ -2,7 +2,7 @@ use std::{
     fs,
     ops::ControlFlow,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, mpsc::Sender as StdSender},
 };
 
 use image::ImageError;
@@ -66,6 +66,8 @@ pub struct SessionService {
     tracker: OperationTracker,
     /// Temp sources owned and cleaned up when this service closes.
     owned_temp_sources: Vec<PathBuf>,
+    /// Optional shutdown confirmation sent after service-owned cleanup runs.
+    shutdown_ack: Option<StdSender<()>>,
 }
 
 /// Inputs required to start one running session service.
@@ -195,6 +197,7 @@ impl SessionService {
             callback_rx,
             tracker: OperationTracker::default(),
             owned_temp_sources,
+            shutdown_ack: None,
         };
 
         tokio::spawn(async move {
@@ -231,7 +234,13 @@ impl SessionService {
 
         loop {
             select! {
-                Some(cmd) = self.cmd_rx.recv() => {
+                cmd = self.cmd_rx.recv() => {
+                    let Some(cmd) = cmd else {
+                        log::trace!("Session command channel closed for {}", self.session_id());
+                        self.stop_session().await;
+                        break;
+                    };
+
                     match self.handle_command(cmd).await {
                         Ok(ControlFlow::Break(())) => break,
                         Ok(ControlFlow::Continue(())) => {},
@@ -241,14 +250,17 @@ impl SessionService {
                         }
                     }
                 },
-                // Callback receiver won't be dropped when session is dropped.
-                Some(event) = self.callback_rx.recv() => {
+                event = self.callback_rx.recv() => {
+                    let Some(event) = event else {
+                        log::trace!("Session callback channel closed for {}", self.session_id());
+                        break;
+                    };
+
                     if let Err(error)= self.handle_callbacks(event).await {
                         log::error!("Error while handling session callback event: {error:?}");
                         self.send_error(error).await;
                     }
                 }
-                else => { break; }
             }
         }
 
@@ -259,6 +271,16 @@ impl SessionService {
         let notifi = AppNotification::SessionError(error);
 
         self.senders.send_notification(notifi).await;
+    }
+
+    async fn stop_session(&self) -> bool {
+        match self.session.stop(Uuid::new_v4()).await {
+            Ok(()) => true,
+            Err(err) => {
+                log::error!("Stopping session failed. {err:?}");
+                false
+            }
+        }
     }
 
     async fn handle_command(
@@ -568,12 +590,11 @@ impl SessionService {
             SessionCommand::CancelOperation { id } => {
                 self.session.abort(Uuid::new_v4(), id)?;
             }
-            SessionCommand::CloseSession => {
+            SessionCommand::CloseSession { confirm_tx } => {
                 // Session UI can be already dropped at this point, therefore
                 // we don't need to send errors to UI in this case.
-
-                if let Err(err) = self.session.stop(Uuid::new_v4()).await {
-                    log::error!("Stopping session failed. {err:?}");
+                if self.stop_session().await {
+                    self.shutdown_ack = confirm_tx;
                 }
 
                 return Ok(ControlFlow::Break(()));
@@ -817,6 +838,10 @@ impl Drop for SessionService {
 
         if let Some(operation) = self.tracker.search_results_tab.take() {
             cleanup_temp_source(&operation.destination);
+        }
+
+        if let Some(confirm_tx) = self.shutdown_ack.take() {
+            let _ = confirm_tx.send(());
         }
     }
 }

--- a/crates/app/src/session/ui/mod.rs
+++ b/crates/app/src/session/ui/mod.rs
@@ -1,8 +1,11 @@
-use std::{rc::Rc, sync::Arc};
+use std::{
+    rc::Rc,
+    sync::{Arc, mpsc::Receiver as StdReceiver},
+};
 
 use egui::{CentralPanel, Context, Frame, Margin, Panel, Ui};
 use log::warn;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::{Sender, error::TrySendError};
 
 use crate::{
     common::ui::{
@@ -454,8 +457,41 @@ impl Session {
             .take_state_update(&self.shared, registry)
     }
 
-    pub fn on_close_session(&self, actions: &mut UiActions) {
-        actions.try_send_command(&self.cmd_tx, SessionCommand::CloseSession);
+    /// Requests normal tab close without waiting for cleanup confirmation.
+    pub fn request_tab_close(&self, actions: &mut UiActions) {
+        actions.try_send_command(
+            &self.cmd_tx,
+            SessionCommand::CloseSession { confirm_tx: None },
+        );
+    }
+
+    /// Requests service shutdown from the synchronous eframe shutdown path.
+    pub fn request_shutdown_with_ack(&mut self) -> Option<StdReceiver<()>> {
+        self.receivers.message_rx.close();
+        while self.receivers.message_rx.try_recv().is_ok() {}
+
+        let (confirm_tx, confirm_rx) = std::sync::mpsc::channel();
+        let command = SessionCommand::CloseSession {
+            confirm_tx: Some(confirm_tx),
+        };
+
+        match self.cmd_tx.try_send(command) {
+            Ok(()) => Some(confirm_rx),
+            Err(TrySendError::Closed(_)) => {
+                warn!(
+                    "Session shutdown command channel is closed for {}",
+                    self.shared.get_id()
+                );
+                None
+            }
+            Err(TrySendError::Full(_)) => {
+                warn!(
+                    "Session shutdown command channel is full for {}",
+                    self.shared.get_id()
+                );
+                None
+            }
+        }
     }
 
     pub fn handle_shortcuts(

--- a/crates/core/session/src/session.rs
+++ b/crates/core/session/src/session.rs
@@ -344,10 +344,22 @@ impl Session {
         destroyed: Option<&CancellationToken>,
         destroying: &CancellationToken,
     ) -> Result<(), stypes::ComputationError> {
+        // Mark shutdown before sending End so racing callers can wait on the same completion.
         destroying.cancel();
-        tx_operations
-            .send(Operation::new(operation_id, operations::OperationKind::End))
-            .map_err(|e| stypes::ComputationError::Communication(e.to_string()))?;
+
+        let stop_signal =
+            tx_operations.send(Operation::new(operation_id, operations::OperationKind::End));
+
+        if let Err(error) = stop_signal {
+            if let Some(destroyed) = destroyed {
+                // The operations loop may already be closing; wait for cleanup confirmation.
+                destroyed.cancelled().await;
+                return Ok(());
+            }
+
+            return Err(stypes::ComputationError::Communication(error.to_string()));
+        }
+
         if let Some(destroyed) = destroyed {
             destroyed.cancelled().await;
         }
@@ -356,6 +368,12 @@ impl Session {
 
     pub async fn stop(&self, operation_id: Uuid) -> Result<(), stypes::ComputationError> {
         if self.destroyed.is_cancelled() {
+            return Ok(());
+        }
+
+        if self.destroying.is_cancelled() {
+            // Shutdown was already requested by another caller; still await cleanup.
+            self.destroyed.cancelled().await;
             return Ok(());
         }
 

--- a/crates/core/session/src/session.rs
+++ b/crates/core/session/src/session.rs
@@ -355,6 +355,10 @@ impl Session {
     }
 
     pub async fn stop(&self, operation_id: Uuid) -> Result<(), stypes::ComputationError> {
+        if self.destroyed.is_cancelled() {
+            return Ok(());
+        }
+
         Session::send_stop_signal(
             operation_id,
             &self.tx_operations,
@@ -594,5 +598,23 @@ impl Session {
         self.tracker
             .shutdown_with_error()
             .map_err(stypes::ComputationError::NativeError)
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        // This is fallback mechanism to ensure even dropping session without calling stop
+        // will still destroy the session and call the cleanup functions.
+        if self.destroyed.is_cancelled() {
+            return;
+        }
+
+        // Drop cannot await the shutdown token; send the same request as `Self::stop()`
+        // but don't wait for await callbacks.
+        self.destroying.cancel();
+        let _ = self.tx_operations.send(Operation::new(
+            Uuid::new_v4(),
+            operations::OperationKind::End,
+        ));
     }
 }

--- a/crates/core/session/src/state/session_file.rs
+++ b/crates/core/session/src/state/session_file.rs
@@ -285,7 +285,7 @@ impl SessionFile {
 
         debug!("cleaning up files: {filename:?}");
         if filename.exists() {
-            std::fs::remove_file(&filename).map_err(|e| stypes::NativeError {
+            std::fs::remove_file(filename).map_err(|e| stypes::NativeError {
                 severity: stypes::Severity::ERROR,
                 kind: stypes::NativeErrorKind::Io,
                 message: Some(format!(

--- a/crates/core/session/src/state/session_file.rs
+++ b/crates/core/session/src/state/session_file.rs
@@ -273,29 +273,28 @@ impl SessionFile {
             })
     }
 
-    /// Cleans up the temporary generated files and for the session on its attachments if exist
-    /// for none-linked sessions.
+    /// Cleans up temporary generated files and attachments for non-linked sessions.
     pub fn cleanup(&mut self) -> Result<(), stypes::NativeError> {
-        if self.writer.is_none() {
-            // Session is linked. No temporary files has been generated.
+        let Some(SessionFileOrigin::Generated(filename)) = &self.filename else {
             return Ok(());
-        }
+        };
 
-        // Remove session main file.
-        let filename = self.filename()?;
+        // Close file handles before removing files. Windows rejects removing open files.
+        self.writer.take();
+        self.grabber.take();
+
         debug!("cleaning up files: {filename:?}");
         if filename.exists() {
             std::fs::remove_file(&filename).map_err(|e| stypes::NativeError {
                 severity: stypes::Severity::ERROR,
                 kind: stypes::NativeErrorKind::Io,
                 message: Some(format!(
-                    "Removing session main file fialed. Error: {e}. Path: {}",
+                    "Removing session main file failed. Error: {e}. Path: {}",
                     filename.display()
                 )),
             })?;
         }
 
-        // Remove attachments directory if exists.
         let attachments_dir = filename
             .to_str()
             .and_then(|file| file.strip_suffix(&format!(".{SESSION_FILE_EXTENSION}")))
@@ -308,7 +307,7 @@ impl SessionFile {
 
         if attachments_dir.exists() {
             debug!(
-                "Cleaning up attachments direcotry: {}",
+                "Cleaning up attachments directory: {}",
                 attachments_dir.display()
             );
 
@@ -329,5 +328,47 @@ impl SessionFile {
 impl Default for SessionFile {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs::{self, File},
+        io::BufWriter,
+    };
+
+    use super::{SessionFile, SessionFileOrigin};
+
+    #[test]
+    fn cleanup_removes_generated_file_and_attachments() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let session_path = temp_dir.path().join("generated.session");
+        let attachments_dir = temp_dir.path().join("generated");
+        fs::create_dir(&attachments_dir).unwrap();
+        fs::write(attachments_dir.join("attachment.txt"), "content").unwrap();
+
+        let mut session_file = SessionFile::new();
+        session_file.filename = Some(SessionFileOrigin::Generated(session_path.clone()));
+        session_file.writer = Some(BufWriter::new(File::create(&session_path).unwrap()));
+
+        session_file.cleanup().unwrap();
+
+        assert!(!session_path.exists());
+        assert!(!attachments_dir.exists());
+    }
+
+    #[test]
+    fn cleanup_keeps_linked_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let session_path = temp_dir.path().join("linked.session");
+        fs::write(&session_path, "content").unwrap();
+
+        let mut session_file = SessionFile::new();
+        session_file.filename = Some(SessionFileOrigin::Linked(session_path.clone()));
+
+        session_file.cleanup().unwrap();
+
+        assert!(session_path.exists());
     }
 }

--- a/crates/core/session/tests/snapshot_tests/mod.rs
+++ b/crates/core/session/tests/snapshot_tests/mod.rs
@@ -17,14 +17,12 @@ use utls::*;
 async fn observe_dlt_session() {
     let input = "../../../development/resources/attachments.dlt";
     let parser_settings = stypes::DltParserSettings::default();
-    let session_main_file = run_observe_session(
+    let session_files = run_observe_session(
         input,
         stypes::FileFormat::Binary,
         stypes::ParserType::Dlt(parser_settings.clone()),
     )
     .await;
-
-    let session_files = SessionFiles::from_session_file(&session_main_file);
 
     insta::with_settings!({
         description => "Snapshot for DLT file with text attachments.",
@@ -51,14 +49,12 @@ async fn observe_dlt_with_someip_session() {
         ..Default::default()
     };
 
-    let session_main_file = run_observe_session(
+    let session_files = run_observe_session(
         input,
         stypes::FileFormat::Binary,
         stypes::ParserType::Dlt(parser_settings.clone()),
     )
     .await;
-
-    let session_files = SessionFiles::from_session_file(&session_main_file);
 
     insta::with_settings!({
         description => "Snapshot for DLT file with SomeIP network trace.",
@@ -86,14 +82,12 @@ async fn observe_someip_bcapng_session() {
         fibex_file_paths: Some(vec![String::from(fibex_file)]),
     };
 
-    let session_main_file = run_observe_session(
+    let session_files = run_observe_session(
         input,
         stypes::FileFormat::PcapNG,
         stypes::ParserType::SomeIp(parser_settings.clone()),
     )
     .await;
-
-    let session_files = SessionFiles::from_session_file(&session_main_file);
 
     insta::with_settings!({
         description => "Snapshot for SomeIP file with Pcapng byte source.",
@@ -121,14 +115,12 @@ async fn observe_someip_legacy_session() {
         fibex_file_paths: Some(vec![String::from(fibex_file)]),
     };
 
-    let session_main_file = run_observe_session(
+    let session_files = run_observe_session(
         input,
         stypes::FileFormat::PcapLegacy,
         stypes::ParserType::SomeIp(parser_settings.clone()),
     )
     .await;
-
-    let session_files = SessionFiles::from_session_file(&session_main_file);
 
     insta::with_settings!({
         description => "Snapshot for SomeIP file with Pcap Legacy byte source.",

--- a/crates/core/session/tests/snapshot_tests/utls.rs
+++ b/crates/core/session/tests/snapshot_tests/utls.rs
@@ -85,15 +85,14 @@ fn session_dir_form_file(session_file: &Path) -> PathBuf {
         .expect("Session path can't fail while converting to string")
 }
 
-/// Runs a processor observe session generating the session files in Chipmunk temporary directory
-/// and returning the path of the main session file.
+/// Runs a processor observe session and returns the generated files.
 /// # Note:
 /// This function it made for test purposes with snapshots.
 pub async fn run_observe_session<P: Into<PathBuf>>(
     input: P,
     file_format: stypes::FileFormat,
     parser_type: stypes::ParserType,
-) -> PathBuf {
+) -> SessionFiles {
     let input: PathBuf = input.into();
 
     assert!(
@@ -123,9 +122,17 @@ pub async fn run_observe_session<P: Into<PathBuf>>(
         }
     }
 
-    session
+    let session_file = session
         .get_state()
         .get_session_file()
         .await
-        .expect("We must have a session file after observe session is done")
+        .expect("We must have a session file after observe session is done");
+    let session_files = SessionFiles::from_session_file(&session_file);
+
+    session
+        .stop(Uuid::new_v4())
+        .await
+        .expect("Session should stop after snapshot files are captured");
+
+    session_files
 }


### PR DESCRIPTION
* Send close request and wait for acknowledgement with timeout that will be sent on closing app for all still open sessions.
* Service will call stop on request and send acknowledgement message back.
* Add fallback for sessions closed without calling stop before to ensure the session in that case will also be cleaned up
* Treat already requested session shutdown as success and wait for the destroyed confirmation.
* Wait for cleanup confirmation when sending the stop signal races with an already closing operations loop.