### PR TITLE
Adjust filter highlights in overlapping cases.

### DIFF
--- a/crates/app/src/session/ui/common/log_table/table.rs
+++ b/crates/app/src/session/ui/common/log_table/table.rs
@@ -500,7 +500,8 @@ pub fn apply_log_row_colors(
     main_log_pos: Option<u64>,
     is_selected: bool,
 ) {
-    // Selected wins over filters/bookmarks. Search/filter colors win over bookmark fallback.
+    // Selected wins. Among matched filters, later filters in effective search order win,
+    // matching legacy Chipmunk 3 precedence. Search/filter colors win over bookmark fallback.
     let row_colors = if is_selected {
         Some(&SELECTED_LOG_COLORS)
     } else if let Some(pos) = main_log_pos {
@@ -508,7 +509,7 @@ pub fn apply_log_row_colors(
             .search
             .current_matches_map()
             .and_then(|map| map.get(&LogMainIndex(pos)))
-            .and_then(|matches| matches.first())
+            .and_then(|matches| matches.last())
             .and_then(|filter_idx| {
                 let idx = filter_idx.0 as usize;
                 if let Some(filter_id) = shared.filters.enabled_filter_ids().nth(idx) {


### PR DESCRIPTION
This PR closes #2598 

It changes highlight color selection in cases we have multiple filters matching the same log entry to select the color of the last filter instead of the first one to match the behavior in legacy Chipmunk 3.

The reason for this change that we don't break users experience without a valid reason.