### PR TITLE
Add Dependencies Declaration Guidelines

### DIFF
--- a/.ai/knowledge/INDEX.md
+++ b/.ai/knowledge/INDEX.md
@@ -25,5 +25,7 @@ Use this file to choose the next context file to read. Do not load every context
 
 Load only when the task explicitly targets that area.
 
+- Rust workspace and dependencies: `.ai/knowledge/rust-workspace.md`
+  - Use when editing `Cargo.toml`, adding dependencies, or changing workspace configuration.
 - CLI parser/export: `.ai/knowledge/crates/cli/AGENTS.md`
 - Plugins: `.ai/knowledge/plugins/AGENTS.md`

--- a/.ai/knowledge/rust-workspace.md
+++ b/.ai/knowledge/rust-workspace.md
@@ -1,0 +1,18 @@
+# Rust Workspace Context
+
+## Dependency Management
+
+For crates in the main workspace under `crates/`, declare dependency versions and internal crate paths only in the root `Cargo.toml` under `[workspace.dependencies]`.
+
+In crate-local `Cargo.toml` files, reference dependencies with `workspace = true` and keep them in the matching group:
+
+```toml
+[dependencies]
+# Internal crates
+stypes.workspace = true
+
+# External crates
+serde.workspace = true
+```
+
+Keep the root workspace dependency list grouped by internal crates, external dependencies, and development dependencies.

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -84,6 +84,7 @@ tar.workspace = true
 flate2.workspace = true
 
 [dev-dependencies]
+# External crates
 tempfile.workspace = true
 
 [lints]

--- a/crates/bufread/Cargo.toml
+++ b/crates/bufread/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 [dependencies]
 
 [dev-dependencies]
+# External crates
 criterion.workspace = true
 proptest.workspace = true
 rand.workspace = true

--- a/crates/core/indexer_base/Cargo.toml
+++ b/crates/core/indexer_base/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 workspace = true 
 
 [dependencies]
+# External crates
 log.workspace = true
 serde = { workspace = true , features = ["derive"] }
 thiserror.workspace = true

--- a/crates/core/merging/Cargo.toml
+++ b/crates/core/merging/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 workspace = true 
 
 [dependencies]
+# External crates
 log.workspace = true
 serde = { workspace = true , features = ["derive"] }
 serde_json.workspace = true

--- a/crates/core/parsers/Cargo.toml
+++ b/crates/core/parsers/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 [dependencies]
 # Internal crates
 someip_tools.workspace = true
+stypes.workspace = true
 
 # External crates
 byteorder.workspace = true
@@ -24,7 +25,7 @@ thiserror.workspace = true
 rand.workspace = true
 someip-messages.workspace = true
 someip-payload.workspace = true
-stypes.workspace = true
 
 [dev-dependencies]
+# External crates
 stringreader.workspace = true

--- a/crates/core/plugins_host/Cargo.toml
+++ b/crates/core/plugins_host/Cargo.toml
@@ -27,7 +27,10 @@ wasmtime.workspace = true
 wasmtime-wasi.workspace = true
 
 [dev-dependencies]
+# Internal crates
 processor.workspace = true
+
+# External crates
 criterion = { workspace = true, features = ["async_tokio"] }
 
 [[bench]]

--- a/crates/core/processor/Cargo.toml
+++ b/crates/core/processor/Cargo.toml
@@ -32,7 +32,10 @@ thiserror.workspace = true
 tokio-util.workspace = true
 
 [dev-dependencies]
+# Internal crates
 plugins_host.workspace = true
+
+# External crates
 criterion = { workspace = true, features = ["async_tokio"] }
 pretty_assertions.workspace = true
 rand.workspace = true

--- a/crates/core/session/Cargo.toml
+++ b/crates/core/session/Cargo.toml
@@ -40,6 +40,7 @@ uuid = { workspace = true , features = ["serde", "v4"] }
 walkdir.workspace = true
 
 [dev-dependencies]
+# External crates
 lazy_static.workspace = true
 tempfile.workspace = true
 insta.workspace = true

--- a/crates/core/someip_tools/Cargo.toml
+++ b/crates/core/someip_tools/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 workspace = true 
 
 [dependencies]
+# External crates
 nom.workspace = true
 thiserror.workspace = true
 

--- a/crates/core/sources/Cargo.toml
+++ b/crates/core/sources/Cargo.toml
@@ -28,7 +28,9 @@ uuid = { workspace = true , features = ["serde", "v4"] }
 socket2.workspace = true
 
 [target.'cfg(windows)'.dependencies]
+# Internal crates
 shell_tools.workspace = true
 
 [dev-dependencies]
+# External crates
 env_logger.workspace = true

--- a/crates/core/text_grep/Cargo.toml
+++ b/crates/core/text_grep/Cargo.toml
@@ -25,4 +25,5 @@ thiserror.workspace = true
 regex.workspace = true
 
 [dev-dependencies]
+# External crates
 tempfile.workspace = true

--- a/crates/dir_checksum/Cargo.toml
+++ b/crates/dir_checksum/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 description = "A Library which provides methods to calculate the checksum of the files in a given path recursively considering `gitignore` rules"
 
 [dependencies]
+# External crates
 blake3 = { workspace = true, features = ["rayon"] }
 ignore.workspace = true
 memmap2.workspace = true
@@ -14,6 +15,7 @@ thiserror.workspace = true
 log.workspace = true
 
 [dev-dependencies]
+# External crates
 tempdir.workspace = true
 anyhow.workspace = true
 pretty_assertions.workspace = true

--- a/crates/file_tools/Cargo.toml
+++ b/crates/file_tools/Cargo.toml
@@ -9,4 +9,5 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# External crates
 anyhow.workspace = true

--- a/crates/plugins_api/Cargo.toml
+++ b/crates/plugins_api/Cargo.toml
@@ -4,10 +4,12 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+# External crates
 log.workspace = true
 wit-bindgen.workspace = true
 
 [dev-dependencies]
+# External crates
 trybuild.workspace = true
 
 [features]

--- a/crates/stypes/Cargo.toml
+++ b/crates/stypes/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
+# External crates
 serde = { workspace = true, features = ["derive"] }
 dlt-core = { workspace = true, features = ["fibex", "statistics", "serialization"] }
 uuid = { workspace = true, features = ["serde", "v4"] }

--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -20,6 +20,23 @@ You can pass additional Cargo or application arguments after the recipe:
 just run -r -- path/to/file
 ```
 
+## Dependency Management
+
+For crates in the main workspace under `crates/`, declare dependency versions and internal crate paths only in the root `Cargo.toml` under `[workspace.dependencies]`.
+
+In crate-local `Cargo.toml` files, reference dependencies with `workspace = true` and keep them in the matching group:
+
+```toml
+[dependencies]
+# Internal crates
+stypes.workspace = true
+
+# External crates
+serde.workspace = true
+```
+
+Keep the root workspace dependency list grouped by internal crates, external dependencies, and development dependencies.
+
 ## Formatting and Checks
 
 Check Rust formatting without changing files:


### PR DESCRIPTION
This PR closes #2601 

* Add guideline to declare dependencies in main workspace only and reference them in the crates.
* Add guideline group dependencies declarations between internal and external for better observability
* Small fixes in `Cargo.toml` file moving deps to their matching groups and creating groups if missing.
* Include the guidelines in both developer and AI agents' docs.