### PR TITLE
Use Tokio virtual time for timing-sensitive tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ bincode = "1.3"
 bytecount = "0.6"
 byteorder = "1.5"
 bytes = "1.3"
-tokio = { version = "1.45", features = ["full"] }
+tokio = { version = "1.45", features = ["full", "test-util"] }
 reqwest = "0.12"
 semver = "1"
 tokio-stream = "0.1"

--- a/crates/core/processor/src/producer/tests/cancel_safety.rs
+++ b/crates/core/processor/src/producer/tests/cancel_safety.rs
@@ -10,7 +10,7 @@ use super::*;
 const SOURCE_SLEEP_DURATION: Duration = Duration::from_millis(70);
 
 /// Cancel safety test for producer session without parse errors.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn cancel_safe_no_errors() {
     let parser = MockParser::new([
         Ok(vec![MockParseSeed::new(
@@ -111,7 +111,7 @@ async fn cancel_safe_no_errors() {
 }
 
 /// Cancel safety test for producer session with parse incomplete errors.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn cancel_safe_incomplete() {
     let parser = MockParser::new([
         Ok(vec![MockParseSeed::new(
@@ -219,7 +219,7 @@ async fn cancel_safe_incomplete() {
 }
 
 /// Cancel safety test for producer session with parse end of file error.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn cancel_safe_eof() {
     let parser = MockParser::new([
         Ok(vec![MockParseSeed::new(
@@ -321,7 +321,7 @@ async fn cancel_safe_eof() {
 
 /// Cancel safety test for producer session with parse errors, without calling load
 /// on source because of them.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn cancel_safe_parse_err_no_load() {
     let parser = MockParser::new([
         Ok(vec![MockParseSeed::new(
@@ -424,7 +424,7 @@ async fn cancel_safe_parse_err_no_load() {
 
 /// Cancel safety test for producer session with parse errors, causing to call load
 /// on source because of them.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn cancel_safe_parse_err_with_load() {
     let parser = MockParser::new([
         Ok(vec![MockParseSeed::new(
@@ -534,7 +534,7 @@ async fn cancel_safe_parse_err_with_load() {
 }
 
 /// Cancel safety test use no errors using `timeout()` method instead of `select!{}` macro.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn cancel_safe_timeout() {
     let parser = MockParser::new([
         Ok(vec![MockParseSeed::new(

--- a/crates/core/processor/src/producer/tests/mock_byte_source.rs
+++ b/crates/core/processor/src/producer/tests/mock_byte_source.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::time::Duration;
 
 use tokio::task::JoinHandle;
-use tokio::time::sleep;
+use tokio::time::{Instant, sleep};
 
 use sources::{ByteSource, Error, ReloadInfo, SourceFilter};
 
@@ -195,23 +195,23 @@ async fn general_test_mock_byte_source() {
     assert!(matches!(fourth_reload, Err(Error::NotSupported)));
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn test_mock_byte_source_delay() {
     let delay = Duration::from_millis(5);
     let seeds = [Ok(Some(MockReloadSeed::new(5, 0).sleep_duration(delay)))];
     let mut source = MockByteSource::new(10, seeds);
 
-    let instance = std::time::Instant::now();
+    let started = Instant::now();
 
     let res = source.load(None).await;
 
-    let passed = instance.elapsed();
+    let elapsed = started.elapsed();
 
     // Method should succeed
     assert!(res.is_ok());
 
-    // Reload should have taken more than the delayed time.
-    assert!(passed > delay);
+    // Reload should not complete before the configured delay.
+    assert!(elapsed >= delay);
 }
 
 #[tokio::test]
@@ -246,7 +246,7 @@ async fn test_mock_byte_source_income() {
     ));
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn test_load_cancel_safety() {
     const SLEEP_DURATION: Duration = Duration::from_millis(50);
 

--- a/crates/core/sources/src/socket/tcp.rs
+++ b/crates/core/sources/src/socket/tcp.rs
@@ -179,7 +179,7 @@ mod tests {
         io::AsyncWriteExt,
         net::TcpListener,
         task::yield_now,
-        time::{sleep, timeout},
+        time::{Instant, sleep, timeout},
     };
 
     static MESSAGES: &[&str] = &["one", "two", "three"];
@@ -199,7 +199,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_tcp_reload() -> Result<(), std::io::Error> {
         static SERVER: &str = "127.0.0.1:4000";
         let listener = TcpListener::bind(&SERVER).await.unwrap();
@@ -228,7 +228,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_general_source_reload() {
         static SERVER: &str = "127.0.0.1:4001";
         let listener = TcpListener::bind(&SERVER).await.unwrap();
@@ -277,7 +277,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn reconnect_no_msgs() {
         static SERVER: &str = "127.0.0.1:4003";
         let listener = TcpListener::bind(&SERVER).await.unwrap();
@@ -316,23 +316,43 @@ mod tests {
         assert!(rec_res.is_ok());
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn reconnect_with_state_msgs() {
         static SERVER: &str = "127.0.0.1:4004";
-        let listener = TcpListener::bind(&SERVER).await.unwrap();
-        let send_handle = tokio::spawn(async move {
-            accept_and_send(&listener, 30).await;
-            // Then disconnected the server and sleep.
-            drop(listener);
-            sleep(Duration::from_millis(160)).await;
+        const OUTAGE_DURATION: Duration = Duration::from_millis(160);
 
-            // Start new server sending data again.
-            let listener = TcpListener::bind(&SERVER).await.unwrap();
-            accept_and_send(&listener, 30).await;
-        });
+        let listener = TcpListener::bind(&SERVER).await.unwrap();
 
         // Enable reconnect with state channels.
         let (state_tx, mut state_rx) = tokio::sync::watch::channel(ReconnectStateMsg::Connected);
+        let mut outage_state_rx = state_tx.subscribe();
+
+        let send_handle = tokio::spawn(async move {
+            accept_and_send(&listener, 30).await;
+
+            let outage_started = Instant::now();
+            drop(listener);
+
+            let four_attempts_elapsed = loop {
+                outage_state_rx.changed().await.unwrap();
+                if matches!(
+                    *outage_state_rx.borrow_and_update(),
+                    ReconnectStateMsg::Reconnecting { attempts } if attempts >= 4
+                ) {
+                    break outage_started.elapsed();
+                }
+            };
+
+            if let Some(remaining) = OUTAGE_DURATION.checked_sub(four_attempts_elapsed) {
+                tokio::time::advance(remaining).await;
+            }
+
+            // Start new server after the 160 millisecond outage.
+            let listener = TcpListener::bind(&SERVER).await.unwrap();
+            accept_and_send(&listener, 30).await;
+
+            four_attempts_elapsed
+        });
 
         let rec_info = ReconnectInfo::new(1000, Duration::from_millis(50), Some(state_tx));
 
@@ -381,14 +401,15 @@ mod tests {
             }
         });
 
-        let (_, rec_res, reconnect_res) =
+        let (send_res, rec_res, reconnect_res) =
             tokio::join!(send_handle, receive_handle, reconnect_handler);
 
+        assert!(send_res.unwrap() <= OUTAGE_DURATION);
         assert!(rec_res.is_ok());
         assert!(reconnect_res.is_ok());
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn reconnect_fail() {
         static SERVER: &str = "127.0.0.1:4005";
         let listener = TcpListener::bind(&SERVER).await.unwrap();
@@ -446,7 +467,7 @@ mod tests {
 
     /// Ensure load and reconnect functions are cancel safe by keep sending notifications
     /// in rapid interval while calling them.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn load_reconnect_cancel_safe() {
         static SERVER: &str = "127.0.0.1:4006";
         let listener = TcpListener::bind(&SERVER).await.unwrap();
@@ -513,7 +534,7 @@ mod tests {
 
     /// Ensure load and reconnect functions are cancel safe by keep calling it within a timeout
     /// function with rapid interval.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn load_reconnect_cancel_safe_timeout() {
         static SERVER: &str = "127.0.0.1:4007";
         let listener = TcpListener::bind(&SERVER).await.unwrap();

--- a/crates/core/sources/src/socket/udp.rs
+++ b/crates/core/sources/src/socket/udp.rs
@@ -197,7 +197,7 @@ mod tests {
     /// This test demonstrate that parsers which consume the bytes of one result at a
     /// time while miss parsing the whole bytes when the server isn't sending more data
     /// even that the buffer has bytes in it.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_source_buffer_overflow() {
         const SENDER: &str = "127.0.0.1:4002";
         const RECEIVER: &str = "127.0.0.1:5002";


### PR DESCRIPTION
This PR closes #2602 

It includes:
* Enable Tokio's `test-util` feature and pause time in processor and source tests. Instead of waiting for real clock ticks.
* Preserve cancellation, timeout, and reconnect behavior while eliminating real millisecond waits and verifying reconnect attempts against virtual elapsed time.