### PR TITLE
Multiple Files Setup Order: Sort in table + Manual reorder with Drag&Drop

### DIFF
--- a/crates/app/src/host/ui/multi_setup/main_table/mod.rs
+++ b/crates/app/src/host/ui/multi_setup/main_table/mod.rs
@@ -1,54 +1,98 @@
+//! Multi-file setup table rendering and click-driven sorting.
+
 use std::path::Path;
 
-use egui::{Align, Label, Layout, RichText, ScrollArea, Sense, TextStyle, Ui, Widget, vec2};
+use egui::{
+    Align, Align2, CursorIcon, Label, Layout, Rect, Response, RichText, ScrollArea, Sense, Stroke,
+    TextStyle, Ui, Widget, pos2, vec2,
+};
 use egui_extras::{Column, TableBuilder};
 use enum_iterator::all;
 
-use crate::host::{
-    common::ui_utls::{main_panel_group_frame, truncate_path_to_width},
-    ui::multi_setup::{main_table::table_columns::TableColumn, state::MultiFileState},
+use crate::{
+    common::phosphor::icons,
+    host::{
+        common::{
+            colors::SOURCE_HIGHLIGHT_COLORS,
+            ui_utls::{main_panel_group_frame, truncate_path_to_width},
+        },
+        ui::multi_setup::{
+            main_table::table_columns::TableColumn,
+            state::{FileUiState, MultiFileState},
+        },
+    },
 };
 
 mod table_columns;
 
-pub fn render_content(ui: &mut Ui, state: &mut MultiFileState) {
-    main_panel_group_frame(ui).show(ui, |ui| {
-        ui.label(RichText::new("Multiple files").heading());
-
-        ui.add_space(10.);
-
-        ScrollArea::horizontal().show(ui, |ui| {
-            render_table(ui, state);
-            ui.add_space(5.);
-        });
-    });
+/// Multi-file table with persistent column sorting state.
+#[derive(Debug, Default)]
+pub struct MainTable {
+    sort: Option<TableSort>,
 }
 
-fn render_table(ui: &mut Ui, state: &mut MultiFileState) {
-    let available_height = ui.available_height();
-    let table = TableBuilder::new(ui)
-        .auto_shrink(true)
-        .drag_to_scroll(false)
-        .striped(false)
-        .resizable(false)
-        .cell_layout(Layout::left_to_right(Align::Center))
-        .column(Column::initial(10.0)) // Color
-        .column(Column::initial(50.0)) // type
-        .column(Column::remainder()) // name
-        .column(Column::initial(200.0)) // path
-        .column(Column::initial(70.0)) // size
-        .column(Column::initial(130.0)) // modify date
-        .min_scrolled_height(0.0)
-        .max_scroll_height(available_height)
-        .sense(Sense::click());
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TableSort {
+    column: TableColumn,
+    direction: SortDirection,
+}
 
-    table
-        .header(20.0, |mut header| {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SortDirection {
+    Ascending,
+    Descending,
+}
+
+impl MainTable {
+    /// Renders the table and applies sorting requested through its headers.
+    pub fn render_content(&mut self, ui: &mut Ui, state: &mut MultiFileState) {
+        main_panel_group_frame(ui).show(ui, |ui| {
+            ui.label(RichText::new("Multiple files").heading());
+
+            ui.add_space(10.);
+
+            ScrollArea::horizontal().show(ui, |ui| {
+                self.render_table(ui, state);
+                ui.add_space(5.);
+            });
+        });
+    }
+
+    fn render_table(&mut self, ui: &mut Ui, state: &mut MultiFileState) {
+        let available_height = ui.available_height();
+        let table = TableBuilder::new(ui)
+            .auto_shrink(true)
+            .drag_to_scroll(false)
+            .striped(false)
+            .resizable(false)
+            .cell_layout(Layout::left_to_right(Align::Center))
+            .column(Column::initial(10.0)) // Color
+            .column(Column::initial(60.0)) // type
+            .column(Column::remainder().at_least(120.0)) // name
+            .column(Column::initial(200.0)) // path
+            .column(Column::initial(70.0)) // size
+            .column(Column::initial(140.0)) // modify date
+            .min_scrolled_height(0.0)
+            .max_scroll_height(available_height)
+            .sense(Sense::click());
+
+        let mut requested_sort = None;
+        let table = table.header(20.0, |mut header| {
             for column in all::<TableColumn>() {
-                header.col(|ui| table_header(ui, column));
+                header.col(|ui| {
+                    if table_header(ui, column, self.sort).clicked() {
+                        requested_sort = Some(column);
+                    }
+                });
             }
-        })
-        .body(|body| {
+        });
+
+        if let Some(column) = requested_sort {
+            self.sort_files(&mut state.files, column);
+        }
+
+        let mut inclusion_changed = false;
+        table.body(|body| {
             body.rows(20.0, state.files.len(), |mut row| {
                 let file = &mut state.files[row.index()];
 
@@ -68,13 +112,117 @@ fn render_table(ui: &mut Ui, state: &mut MultiFileState) {
 
                 if row.response().clicked() {
                     file.included = !file.included;
+                    inclusion_changed = true;
                 }
             });
         });
+
+        if inclusion_changed {
+            assign_source_colors(&mut state.files);
+        }
+    }
+
+    fn sort_files(&mut self, files: &mut [FileUiState], column: TableColumn) {
+        if column == TableColumn::Color {
+            return;
+        }
+
+        let direction = match self.sort {
+            Some(sort) if sort.column == column => match sort.direction {
+                SortDirection::Ascending => SortDirection::Descending,
+                SortDirection::Descending => SortDirection::Ascending,
+            },
+            _ => SortDirection::Ascending,
+        };
+
+        let sort = TableSort { column, direction };
+        self.sort = Some(sort);
+        files.sort_by(|left, right| {
+            let ordering = column.compare(left, right);
+            match direction {
+                SortDirection::Ascending => ordering,
+                SortDirection::Descending => ordering.reverse(),
+            }
+        });
+        assign_source_colors(files);
+    }
 }
 
-fn table_header(ui: &mut Ui, column: TableColumn) {
-    ui.label(RichText::new(column.header()).strong());
+fn assign_source_colors(files: &mut [FileUiState]) {
+    // Concat source indexes exclude files that are not included in the command.
+    let colors = SOURCE_HIGHLIGHT_COLORS.iter().copied().cycle();
+    for (file, color) in files.iter_mut().filter(|file| file.included).zip(colors) {
+        file.color = color;
+    }
+}
+
+fn table_header(ui: &mut Ui, column: TableColumn, sort: Option<TableSort>) -> Response {
+    if column == TableColumn::Color {
+        return ui.label(RichText::new(column.header()).strong());
+    }
+
+    const HORIZONTAL_PADDING: f32 = 2.0;
+    const ICON_GAP: f32 = 3.0;
+    const ICON_SLOT_WIDTH: f32 = 14.0;
+
+    let text_color = ui.visuals().strong_text_color();
+    let label_font = TextStyle::Body.resolve(ui.style());
+    let label_galley =
+        ui.painter()
+            .layout_no_wrap(column.header().to_owned(), label_font, text_color);
+    let desired_width =
+        label_galley.size().x + ICON_GAP + ICON_SLOT_WIDTH + HORIZONTAL_PADDING * 2.0;
+    let desired_size = vec2(
+        desired_width.min(ui.available_width()),
+        ui.available_height(),
+    );
+    let (rect, response) = ui.allocate_exact_size(desired_size, Sense::click());
+    let response = response.on_hover_cursor(CursorIcon::PointingHand);
+    let visuals = ui.style().interact(&response);
+
+    if response.hovered() || response.is_pointer_button_down_on() {
+        ui.painter()
+            .rect_filled(rect, visuals.corner_radius, visuals.weak_bg_fill);
+    }
+
+    let icon_rect = Rect::from_min_max(
+        pos2(
+            rect.max.x - HORIZONTAL_PADDING - ICON_SLOT_WIDTH,
+            rect.min.y,
+        ),
+        pos2(rect.max.x - HORIZONTAL_PADDING, rect.max.y),
+    );
+    let label_pos = pos2(
+        rect.min.x + HORIZONTAL_PADDING,
+        rect.center().y - label_galley.size().y / 2.0,
+    );
+    let label_clip = Rect::from_min_max(rect.min, pos2(icon_rect.min.x - ICON_GAP, rect.max.y));
+    ui.painter()
+        .with_clip_rect(label_clip)
+        .galley(label_pos, label_galley, text_color);
+
+    if let Some(sort) = sort.filter(|sort| sort.column == column) {
+        let icon = match sort.direction {
+            SortDirection::Ascending => icons::regular::SORT_ASCENDING,
+            SortDirection::Descending => icons::regular::SORT_DESCENDING,
+        };
+        let accent_color = ui.visuals().selection.stroke.color;
+        let icon_font = TextStyle::Body.resolve(ui.style());
+        ui.painter().text(
+            icon_rect.center(),
+            Align2::CENTER_CENTER,
+            icon,
+            icon_font,
+            accent_color,
+        );
+        ui.painter().hline(
+            rect.x_range(),
+            rect.bottom() - 1.0,
+            Stroke::new(1.0_f32, accent_color),
+        );
+    }
+
+    response
 }
 
 fn table_cell_text(ui: &mut Ui, content: String) {
@@ -93,5 +241,179 @@ fn table_cell_path(ui: &mut Ui, path: &str) {
             ui.set_max_width(ui.spacing().tooltip_width);
             ui.label(path);
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        path::{Path, PathBuf},
+        time::{Duration, UNIX_EPOCH},
+    };
+
+    use egui::Color32;
+    use stypes::FileFormat;
+
+    use super::{
+        MainTable, SOURCE_HIGHLIGHT_COLORS, SortDirection, TableColumn, TableSort,
+        assign_source_colors,
+    };
+    use crate::host::ui::multi_setup::state::FileUiState;
+
+    fn test_file(name: &str, path: &str, format: FileFormat) -> FileUiState {
+        FileUiState {
+            name: name.to_owned(),
+            path: PathBuf::from(path),
+            parent_path: None,
+            format,
+            size_bytes: None,
+            size_txt: None,
+            modified_at: None,
+            last_modify: None,
+            color: Color32::BLACK,
+            included: true,
+        }
+    }
+
+    #[test]
+    fn sort_requests_toggle_and_new_columns_start_ascending() {
+        let mut files = vec![
+            test_file("b", "/b", FileFormat::Text),
+            test_file("a", "/a", FileFormat::Text),
+            test_file("c", "/c", FileFormat::Text),
+        ];
+        files[0].size_bytes = Some(1);
+        files[1].size_bytes = Some(3);
+        files[2].size_bytes = Some(2);
+        let mut table = MainTable::default();
+
+        table.sort_files(&mut files, TableColumn::Name);
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| file.name.as_str())
+                .collect::<Vec<_>>(),
+            ["a", "b", "c"]
+        );
+        let expected_sort = TableSort {
+            column: TableColumn::Name,
+            direction: SortDirection::Ascending,
+        };
+        assert_eq!(table.sort, Some(expected_sort));
+
+        table.sort_files(&mut files, TableColumn::Name);
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| file.name.as_str())
+                .collect::<Vec<_>>(),
+            ["c", "b", "a"]
+        );
+        let expected_sort = TableSort {
+            column: TableColumn::Name,
+            direction: SortDirection::Descending,
+        };
+        assert_eq!(table.sort, Some(expected_sort));
+
+        table.sort_files(&mut files, TableColumn::Size);
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| file.name.as_str())
+                .collect::<Vec<_>>(),
+            ["b", "c", "a"]
+        );
+        let expected_sort = TableSort {
+            column: TableColumn::Size,
+            direction: SortDirection::Ascending,
+        };
+        assert_eq!(table.sort, Some(expected_sort));
+    }
+
+    #[test]
+    fn sorting_reassigns_colors_by_included_order() {
+        let mut files = vec![
+            test_file("c", "/c", FileFormat::Text),
+            test_file("b", "/b", FileFormat::Text),
+            test_file("a", "/a", FileFormat::Text),
+        ];
+        files[1].included = false;
+        files[1].color = Color32::WHITE;
+
+        MainTable::default().sort_files(&mut files, TableColumn::Name);
+
+        assert_eq!(files[0].color, SOURCE_HIGHLIGHT_COLORS[0]);
+        assert_eq!(files[1].color, Color32::WHITE);
+        assert_eq!(files[2].color, SOURCE_HIGHLIGHT_COLORS[1]);
+
+        files[1].included = true;
+        assign_source_colors(&mut files);
+
+        assert_eq!(
+            files.iter().map(|file| file.color).collect::<Vec<_>>(),
+            SOURCE_HIGHLIGHT_COLORS[..3]
+        );
+    }
+
+    #[test]
+    fn types_sort_in_displayed_alphabetical_order() {
+        let mut files = vec![
+            test_file("text", "/text", FileFormat::Text),
+            test_file("pcap-ng", "/pcap-ng", FileFormat::PcapNG),
+            test_file("binary", "/binary", FileFormat::Binary),
+            test_file("pcap", "/pcap", FileFormat::PcapLegacy),
+        ];
+
+        MainTable::default().sort_files(&mut files, TableColumn::Type);
+
+        assert_eq!(
+            files.iter().map(|file| file.format).collect::<Vec<_>>(),
+            [
+                FileFormat::Binary,
+                FileFormat::PcapLegacy,
+                FileFormat::PcapNG,
+                FileFormat::Text,
+            ]
+        );
+    }
+
+    #[test]
+    fn paths_sort_by_complete_path() {
+        let mut first = test_file("z.log", "/a/z.log", FileFormat::Text);
+        first.parent_path = Some("/z".to_owned());
+        let mut second = test_file("a.log", "/b/a.log", FileFormat::Text);
+        second.parent_path = Some("/a".to_owned());
+        let mut files = vec![second, first];
+
+        MainTable::default().sort_files(&mut files, TableColumn::Path);
+
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| file.path.as_path())
+                .collect::<Vec<_>>(),
+            [Path::new("/a/z.log"), Path::new("/b/a.log")]
+        );
+    }
+
+    #[test]
+    fn modification_dates_sort_chronologically() {
+        let mut newer = test_file("newer", "/newer", FileFormat::Text);
+        newer.modified_at = Some(UNIX_EPOCH + Duration::from_secs(20));
+        newer.last_modify = Some("01/01/1970, 00:00:00".to_owned());
+        let mut older = test_file("older", "/older", FileFormat::Text);
+        older.modified_at = Some(UNIX_EPOCH + Duration::from_secs(10));
+        older.last_modify = Some("31/12/2099, 23:59:59".to_owned());
+        let mut files = vec![newer, older];
+
+        MainTable::default().sort_files(&mut files, TableColumn::ModifyDate);
+
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| file.name.as_str())
+                .collect::<Vec<_>>(),
+            ["older", "newer"]
+        );
     }
 }

--- a/crates/app/src/host/ui/multi_setup/main_table/mod.rs
+++ b/crates/app/src/host/ui/multi_setup/main_table/mod.rs
@@ -588,12 +588,14 @@ mod tests {
     }
 
     #[test]
-    fn paths_sort_by_complete_path() {
-        let mut first = test_file("z.log", "/a/z.log", FileFormat::Text);
-        first.parent_path = Some("/z".to_owned());
-        let mut second = test_file("a.log", "/b/a.log", FileFormat::Text);
-        second.parent_path = Some("/a".to_owned());
-        let mut files = vec![second, first];
+    fn paths_sort_by_parent_and_preserve_equal_order() {
+        let mut other_parent = test_file("other.log", "/b/other.log", FileFormat::Text);
+        other_parent.parent_path = Some("/a".to_owned());
+        let mut same_parent_first = test_file("z.log", "/a/z.log", FileFormat::Text);
+        same_parent_first.parent_path = Some("/z".to_owned());
+        let mut same_parent_second = test_file("a.log", "/a/a.log", FileFormat::Text);
+        same_parent_second.parent_path = Some("/y".to_owned());
+        let mut files = vec![other_parent, same_parent_first, same_parent_second];
 
         MainTable::default().sort_files(&mut files, TableColumn::Path);
 
@@ -602,7 +604,11 @@ mod tests {
                 .iter()
                 .map(|file| file.path.as_path())
                 .collect::<Vec<_>>(),
-            [Path::new("/a/z.log"), Path::new("/b/a.log")]
+            [
+                Path::new("/a/z.log"),
+                Path::new("/a/a.log"),
+                Path::new("/b/other.log"),
+            ]
         );
     }
 

--- a/crates/app/src/host/ui/multi_setup/main_table/mod.rs
+++ b/crates/app/src/host/ui/multi_setup/main_table/mod.rs
@@ -3,8 +3,8 @@
 use std::path::Path;
 
 use egui::{
-    Align, Align2, Context, CursorIcon, Label, Layout, Rect, Response, RichText, ScrollArea, Sense,
-    Stroke, TextStyle, Ui, Widget, pos2, vec2,
+    Align, Align2, Color32, Context, CursorIcon, Label, Layout, Rect, Response, RichText,
+    ScrollArea, Sense, Stroke, TextStyle, Ui, Widget, pos2, vec2,
 };
 use egui_extras::{Column, TableBuilder};
 use enum_iterator::all;
@@ -18,7 +18,7 @@ use crate::{
         },
         ui::multi_setup::{
             main_table::table_columns::TableColumn,
-            state::{FileUiState, MultiFileState},
+            state::{FileInclusion, FileUiState, MultiFileState},
         },
     },
 };
@@ -112,12 +112,14 @@ impl MainTable {
                 let row_index = row.index();
                 let file = &mut state.files[row_index];
 
-                row.set_selected(file.included);
+                row.set_selected(file.inclusion.is_included());
 
                 row.col(|ui| {
                     let (res, paint) =
                         ui.allocate_painter(vec2(10.0, ui.available_height()), Sense::hover());
-                    paint.rect_filled(res.rect, 0, file.color);
+                    if let Some(color) = file.inclusion.color() {
+                        paint.rect_filled(res.rect, 0, color);
+                    }
                 });
 
                 row.col(|ui| table_cell_text(ui, file.format.to_string()));
@@ -132,7 +134,13 @@ impl MainTable {
                 }
 
                 if response.clicked() {
-                    file.included = !file.included;
+                    file.inclusion = match file.inclusion {
+                        FileInclusion::Included(_) => FileInclusion::Excluded,
+                        FileInclusion::Excluded => {
+                            // Source colors are reassigned after table construction.
+                            FileInclusion::Included(Color32::TRANSPARENT)
+                        }
+                    };
                     inclusion_changed = true;
                 }
             });
@@ -234,8 +242,12 @@ fn handle_file_drag(
 fn assign_source_colors(files: &mut [FileUiState]) {
     // Concat source indexes exclude files that are not included in the command.
     let colors = SOURCE_HIGHLIGHT_COLORS.iter().copied().cycle();
-    for (file, color) in files.iter_mut().filter(|file| file.included).zip(colors) {
-        file.color = color;
+    for (file, color) in files
+        .iter_mut()
+        .filter(|file| file.inclusion.is_included())
+        .zip(colors)
+    {
+        file.inclusion = FileInclusion::Included(color);
     }
 }
 
@@ -338,8 +350,8 @@ mod tests {
     use stypes::FileFormat;
 
     use super::{
-        FileMove, MainTable, SOURCE_HIGHLIGHT_COLORS, SortDirection, TableColumn, TableSort,
-        assign_source_colors,
+        FileInclusion, FileMove, MainTable, SOURCE_HIGHLIGHT_COLORS, SortDirection, TableColumn,
+        TableSort, assign_source_colors,
     };
     use crate::host::ui::multi_setup::state::FileUiState;
 
@@ -353,8 +365,7 @@ mod tests {
             size_txt: None,
             modified_at: None,
             last_modify: None,
-            color: Color32::BLACK,
-            included: true,
+            inclusion: FileInclusion::Included(Color32::BLACK),
         }
     }
 
@@ -461,8 +472,7 @@ mod tests {
             test_file("b", "/b", FileFormat::Text),
             test_file("a", "/a", FileFormat::Text),
         ];
-        files[1].included = false;
-        files[1].color = Color32::WHITE;
+        files[1].inclusion = FileInclusion::Excluded;
         let mut table = MainTable::default();
         table.sort_files(&mut files, TableColumn::Name);
 
@@ -482,9 +492,15 @@ mod tests {
             ["c", "a", "b"]
         );
         assert_eq!(table.sort, None);
-        assert_eq!(files[0].color, SOURCE_HIGHLIGHT_COLORS[0]);
-        assert_eq!(files[1].color, SOURCE_HIGHLIGHT_COLORS[1]);
-        assert_eq!(files[2].color, Color32::WHITE);
+        assert_eq!(
+            files[0].inclusion,
+            FileInclusion::Included(SOURCE_HIGHLIGHT_COLORS[0])
+        );
+        assert_eq!(
+            files[1].inclusion,
+            FileInclusion::Included(SOURCE_HIGHLIGHT_COLORS[1])
+        );
+        assert_eq!(files[2].inclusion, FileInclusion::Excluded);
     }
 
     #[test]
@@ -523,20 +539,28 @@ mod tests {
             test_file("b", "/b", FileFormat::Text),
             test_file("a", "/a", FileFormat::Text),
         ];
-        files[1].included = false;
-        files[1].color = Color32::WHITE;
+        files[1].inclusion = FileInclusion::Excluded;
 
         MainTable::default().sort_files(&mut files, TableColumn::Name);
 
-        assert_eq!(files[0].color, SOURCE_HIGHLIGHT_COLORS[0]);
-        assert_eq!(files[1].color, Color32::WHITE);
-        assert_eq!(files[2].color, SOURCE_HIGHLIGHT_COLORS[1]);
+        assert_eq!(
+            files[0].inclusion,
+            FileInclusion::Included(SOURCE_HIGHLIGHT_COLORS[0])
+        );
+        assert_eq!(files[1].inclusion, FileInclusion::Excluded);
+        assert_eq!(
+            files[2].inclusion,
+            FileInclusion::Included(SOURCE_HIGHLIGHT_COLORS[1])
+        );
 
-        files[1].included = true;
+        files[1].inclusion = FileInclusion::Included(Color32::BLACK);
         assign_source_colors(&mut files);
 
         assert_eq!(
-            files.iter().map(|file| file.color).collect::<Vec<_>>(),
+            files
+                .iter()
+                .filter_map(|file| file.inclusion.color())
+                .collect::<Vec<_>>(),
             SOURCE_HIGHLIGHT_COLORS[..3]
         );
     }

--- a/crates/app/src/host/ui/multi_setup/main_table/mod.rs
+++ b/crates/app/src/host/ui/multi_setup/main_table/mod.rs
@@ -1,10 +1,10 @@
-//! Multi-file setup table rendering and click-driven sorting.
+//! Multi-file setup table rendering, sorting, and drag reordering.
 
 use std::path::Path;
 
 use egui::{
-    Align, Align2, CursorIcon, Label, Layout, Rect, Response, RichText, ScrollArea, Sense, Stroke,
-    TextStyle, Ui, Widget, pos2, vec2,
+    Align, Align2, Context, CursorIcon, Label, Layout, Rect, Response, RichText, ScrollArea, Sense,
+    Stroke, TextStyle, Ui, Widget, pos2, vec2,
 };
 use egui_extras::{Column, TableBuilder};
 use enum_iterator::all;
@@ -43,6 +43,17 @@ enum SortDirection {
     Descending,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct FileDrag {
+    source_index: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FileMove {
+    source_index: usize,
+    insert_index: usize,
+}
+
 impl MainTable {
     /// Renders the table and applies sorting requested through its headers.
     pub fn render_content(&mut self, ui: &mut Ui, state: &mut MultiFileState) {
@@ -60,7 +71,10 @@ impl MainTable {
 
     fn render_table(&mut self, ui: &mut Ui, state: &mut MultiFileState) {
         let available_height = ui.available_height();
+        let ctx = ui.ctx().clone();
+        let drop_stroke = ui.visuals().selection.stroke;
         let table = TableBuilder::new(ui)
+            .id_salt(state.id())
             .auto_shrink(true)
             .drag_to_scroll(false)
             .striped(false)
@@ -74,7 +88,7 @@ impl MainTable {
             .column(Column::initial(140.0)) // modify date
             .min_scrolled_height(0.0)
             .max_scroll_height(available_height)
-            .sense(Sense::click());
+            .sense(Sense::click_and_drag());
 
         let mut requested_sort = None;
         let table = table.header(20.0, |mut header| {
@@ -92,9 +106,11 @@ impl MainTable {
         }
 
         let mut inclusion_changed = false;
+        let mut pending_move = None;
         table.body(|body| {
             body.rows(20.0, state.files.len(), |mut row| {
-                let file = &mut state.files[row.index()];
+                let row_index = row.index();
+                let file = &mut state.files[row_index];
 
                 row.set_selected(file.included);
 
@@ -110,7 +126,12 @@ impl MainTable {
                 row.col(|ui| table_cell_text(ui, file.size_txt.to_owned().unwrap_or_default()));
                 row.col(|ui| table_cell_text(ui, file.last_modify.to_owned().unwrap_or_default()));
 
-                if row.response().clicked() {
+                let response = row.response();
+                if let Some(file_move) = handle_file_drag(&ctx, &response, row_index, drop_stroke) {
+                    pending_move = Some(file_move);
+                }
+
+                if response.clicked() {
                     file.included = !file.included;
                     inclusion_changed = true;
                 }
@@ -120,6 +141,30 @@ impl MainTable {
         if inclusion_changed {
             assign_source_colors(&mut state.files);
         }
+
+        // Delayed mutation keeps row indexes stable throughout table construction.
+        if let Some(file_move) = pending_move {
+            self.move_file(&mut state.files, file_move);
+        }
+    }
+
+    fn move_file(&mut self, files: &mut Vec<FileUiState>, file_move: FileMove) {
+        if file_move.source_index >= files.len() {
+            return;
+        }
+
+        let mut target_index = file_move.insert_index.min(files.len());
+        if file_move.source_index < target_index {
+            target_index -= 1;
+        }
+        if file_move.source_index == target_index {
+            return;
+        }
+
+        let file = files.remove(file_move.source_index);
+        files.insert(target_index, file);
+        self.sort = None;
+        assign_source_colors(files);
     }
 
     fn sort_files(&mut self, files: &mut [FileUiState], column: TableColumn) {
@@ -146,6 +191,44 @@ impl MainTable {
         });
         assign_source_colors(files);
     }
+}
+
+fn handle_file_drag(
+    ctx: &Context,
+    response: &Response,
+    row_index: usize,
+    drop_stroke: Stroke,
+) -> Option<FileMove> {
+    response.dnd_set_drag_payload(FileDrag {
+        source_index: row_index,
+    });
+
+    let hovered_payload = response.dnd_hover_payload::<FileDrag>()?;
+    let line_y = response.rect.bottom() - drop_stroke.width / 2.0;
+    let painter = ctx
+        .layer_painter(response.layer_id)
+        .with_clip_rect(response.interact_rect);
+
+    if hovered_payload.source_index == row_index {
+        let hover_stroke = Stroke::new(drop_stroke.width, drop_stroke.color.gamma_multiply(0.5));
+        painter.hline(response.rect.x_range(), line_y, hover_stroke);
+        return None;
+    }
+
+    let insert_index = if hovered_payload.source_index < row_index {
+        row_index + 1
+    } else {
+        row_index
+    };
+    painter.hline(response.rect.x_range(), line_y, drop_stroke);
+
+    let payload = response.dnd_release_payload::<FileDrag>()?;
+    let file_move = FileMove {
+        source_index: payload.source_index,
+        insert_index,
+    };
+
+    Some(file_move)
 }
 
 fn assign_source_colors(files: &mut [FileUiState]) {
@@ -255,7 +338,7 @@ mod tests {
     use stypes::FileFormat;
 
     use super::{
-        MainTable, SOURCE_HIGHLIGHT_COLORS, SortDirection, TableColumn, TableSort,
+        FileMove, MainTable, SOURCE_HIGHLIGHT_COLORS, SortDirection, TableColumn, TableSort,
         assign_source_colors,
     };
     use crate::host::ui::multi_setup::state::FileUiState;
@@ -328,6 +411,109 @@ mod tests {
             direction: SortDirection::Ascending,
         };
         assert_eq!(table.sort, Some(expected_sort));
+    }
+
+    #[test]
+    fn manual_reordering_moves_files_in_both_directions() {
+        let mut files = vec![
+            test_file("a", "/a", FileFormat::Text),
+            test_file("b", "/b", FileFormat::Text),
+            test_file("c", "/c", FileFormat::Text),
+            test_file("d", "/d", FileFormat::Text),
+        ];
+        let mut table = MainTable::default();
+
+        table.move_file(
+            &mut files,
+            FileMove {
+                source_index: 0,
+                insert_index: 3,
+            },
+        );
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| file.name.as_str())
+                .collect::<Vec<_>>(),
+            ["b", "c", "a", "d"]
+        );
+
+        table.move_file(
+            &mut files,
+            FileMove {
+                source_index: 3,
+                insert_index: 1,
+            },
+        );
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| file.name.as_str())
+                .collect::<Vec<_>>(),
+            ["b", "d", "c", "a"]
+        );
+    }
+
+    #[test]
+    fn manual_reordering_clears_sort_and_reassigns_colors() {
+        let mut files = vec![
+            test_file("c", "/c", FileFormat::Text),
+            test_file("b", "/b", FileFormat::Text),
+            test_file("a", "/a", FileFormat::Text),
+        ];
+        files[1].included = false;
+        files[1].color = Color32::WHITE;
+        let mut table = MainTable::default();
+        table.sort_files(&mut files, TableColumn::Name);
+
+        table.move_file(
+            &mut files,
+            FileMove {
+                source_index: 2,
+                insert_index: 0,
+            },
+        );
+
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| file.name.as_str())
+                .collect::<Vec<_>>(),
+            ["c", "a", "b"]
+        );
+        assert_eq!(table.sort, None);
+        assert_eq!(files[0].color, SOURCE_HIGHLIGHT_COLORS[0]);
+        assert_eq!(files[1].color, SOURCE_HIGHLIGHT_COLORS[1]);
+        assert_eq!(files[2].color, Color32::WHITE);
+    }
+
+    #[test]
+    fn no_op_drop_preserves_active_sort() {
+        let mut files = vec![
+            test_file("c", "/c", FileFormat::Text),
+            test_file("b", "/b", FileFormat::Text),
+            test_file("a", "/a", FileFormat::Text),
+        ];
+        let mut table = MainTable::default();
+        table.sort_files(&mut files, TableColumn::Name);
+        let active_sort = table.sort;
+
+        table.move_file(
+            &mut files,
+            FileMove {
+                source_index: 1,
+                insert_index: 2,
+            },
+        );
+
+        assert_eq!(
+            files
+                .iter()
+                .map(|file| file.name.as_str())
+                .collect::<Vec<_>>(),
+            ["a", "b", "c"]
+        );
+        assert_eq!(table.sort, active_sort);
     }
 
     #[test]

--- a/crates/app/src/host/ui/multi_setup/main_table/table_columns.rs
+++ b/crates/app/src/host/ui/multi_setup/main_table/table_columns.rs
@@ -1,7 +1,14 @@
+//! Column definitions and sort comparisons for the multi-file table.
+
+use std::cmp::Ordering;
+
 use enum_iterator::Sequence;
+use stypes::FileFormat;
+
+use crate::host::ui::multi_setup::state::FileUiState;
 
 /// Table columns types for multiple files setup view.
-#[derive(Debug, Clone, Copy, PartialEq, Sequence)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Sequence)]
 pub enum TableColumn {
     Color,
     Type,
@@ -20,6 +27,26 @@ impl TableColumn {
             TableColumn::Path => "PATH",
             TableColumn::Size => "SIZE",
             TableColumn::ModifyDate => "MOD. DATE",
+        }
+    }
+
+    /// Compares two files using this column's ordering semantics.
+    pub fn compare(self, left: &FileUiState, right: &FileUiState) -> Ordering {
+        match self {
+            TableColumn::Color => Ordering::Equal,
+            TableColumn::Type => {
+                let rank = |format| match format {
+                    FileFormat::Binary => 0,
+                    FileFormat::PcapLegacy => 1,
+                    FileFormat::PcapNG => 2,
+                    FileFormat::Text => 3,
+                };
+                rank(left.format).cmp(&rank(right.format))
+            }
+            TableColumn::Name => left.name.cmp(&right.name),
+            TableColumn::Path => left.path.cmp(&right.path),
+            TableColumn::Size => left.size_bytes.cmp(&right.size_bytes),
+            TableColumn::ModifyDate => left.modified_at.cmp(&right.modified_at),
         }
     }
 }

--- a/crates/app/src/host/ui/multi_setup/main_table/table_columns.rs
+++ b/crates/app/src/host/ui/multi_setup/main_table/table_columns.rs
@@ -44,7 +44,7 @@ impl TableColumn {
                 rank(left.format).cmp(&rank(right.format))
             }
             TableColumn::Name => left.name.cmp(&right.name),
-            TableColumn::Path => left.path.cmp(&right.path),
+            TableColumn::Path => left.path.parent().cmp(&right.path.parent()),
             TableColumn::Size => left.size_bytes.cmp(&right.size_bytes),
             TableColumn::ModifyDate => left.modified_at.cmp(&right.modified_at),
         }

--- a/crates/app/src/host/ui/multi_setup/mod.rs
+++ b/crates/app/src/host/ui/multi_setup/mod.rs
@@ -1,3 +1,5 @@
+//! Multi-file session setup UI.
+
 use egui::{Align, CentralPanel, Frame, Layout, Panel, Ui};
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -12,6 +14,7 @@ use crate::{
     },
 };
 
+use main_table::MainTable;
 use side_panel::MultiSidePanel;
 
 mod main_table;
@@ -23,6 +26,7 @@ pub struct MultiFileSetup {
     pub state: MultiFileState,
     cmd_tx: mpsc::Sender<HostCommand>,
     side_panel: MultiSidePanel,
+    main_table: MainTable,
 }
 
 impl MultiFileSetup {
@@ -31,6 +35,7 @@ impl MultiFileSetup {
             state,
             cmd_tx,
             side_panel: MultiSidePanel::default(),
+            main_table: MainTable::default(),
         }
     }
 
@@ -68,7 +73,7 @@ impl MultiFileSetup {
             });
 
         CentralPanel::default().show_inside(ui, |ui| {
-            main_table::render_content(ui, &mut self.state);
+            self.main_table.render_content(ui, &mut self.state);
         });
     }
 

--- a/crates/app/src/host/ui/multi_setup/mod.rs
+++ b/crates/app/src/host/ui/multi_setup/mod.rs
@@ -86,7 +86,7 @@ impl MultiFileSetup {
             .state
             .files
             .iter()
-            .filter(|f| f.included)
+            .filter(|file| file.inclusion.is_included())
             .take(2) // No need to continue if we already have two.
             .count();
 
@@ -98,8 +98,8 @@ impl MultiFileSetup {
                 .state
                 .files
                 .iter()
-                .filter(|f| f.included)
-                .map(|f| (f.path.to_owned(), f.format))
+                .filter(|file| file.inclusion.is_included())
+                .map(|file| (file.path.to_owned(), file.format))
                 .collect();
 
             let cmd = HostCommand::ConcatFiles(files);
@@ -117,8 +117,8 @@ impl MultiFileSetup {
                 .state
                 .files
                 .iter()
-                .filter(|f| f.included)
-                .map(|f| f.path.to_owned())
+                .filter(|file| file.inclusion.is_included())
+                .map(|file| file.path.to_owned())
                 .collect();
             let cmd = HostCommand::OpenAsSessions(files);
             if actions.try_send_command(&self.cmd_tx, cmd) {

--- a/crates/app/src/host/ui/multi_setup/side_panel.rs
+++ b/crates/app/src/host/ui/multi_setup/side_panel.rs
@@ -47,7 +47,11 @@ impl MultiSidePanel {
             ui.end_row();
 
             ui.label("Selected files:");
-            let selected_count = state.files.iter().filter(|f| f.included).count();
+            let selected_count = state
+                .files
+                .iter()
+                .filter(|file| file.inclusion.is_included())
+                .count();
             ui.label(selected_count.to_string());
         });
     }
@@ -62,10 +66,12 @@ impl MultiSidePanel {
 
         let mut total_size = 0;
         self.segments_cache
-            .extend(state.files.iter().filter(|f| f.included).map(|f| {
-                let size = f.size_bytes.unwrap_or_default();
+            .extend(state.files.iter().filter_map(|file| {
+                let color = file.inclusion.color()?;
+                let size = file.size_bytes.unwrap_or_default();
                 total_size += size;
-                FileSegment::new(size, f.color)
+                let segment = FileSegment::new(size, color);
+                Some(segment)
             }));
 
         if self.segments_cache.is_empty() {

--- a/crates/app/src/host/ui/multi_setup/state/file.rs
+++ b/crates/app/src/host/ui/multi_setup/state/file.rs
@@ -1,4 +1,6 @@
-use std::path::PathBuf;
+//! UI state for a file in the multi-file setup.
+
+use std::{path::PathBuf, time::SystemTime};
 
 use chrono::{DateTime, Local};
 use egui::Color32;
@@ -15,6 +17,8 @@ pub struct FileUiState {
     pub format: FileFormat,
     pub size_bytes: Option<u64>,
     pub size_txt: Option<String>,
+    /// Raw modification time used for chronological sorting.
+    pub modified_at: Option<SystemTime>,
     pub last_modify: Option<String>,
     pub color: Color32,
     pub included: bool,
@@ -40,17 +44,18 @@ impl FileUiState {
 
         let size_txt = size_bytes.map(file_utls::format_file_size);
 
-        let last_modify = meta
-            .and_then(|m| {
-                m.modified()
-                    .inspect_err(|err| {
-                        log::warn!(
-                            "Get modified date for file {} failed. {err}.",
-                            path.display()
-                        );
-                    })
-                    .ok()
-            })
+        let modified_at = meta.as_ref().and_then(|m| {
+            m.modified()
+                .inspect_err(|err| {
+                    log::warn!(
+                        "Get modified date for file {} failed. {err}.",
+                        path.display()
+                    );
+                })
+                .ok()
+        });
+
+        let last_modify = modified_at
             .map(DateTime::<Local>::from)
             .map(|dt| dt.format("%d/%m/%Y, %H:%M:%S").to_string());
 
@@ -63,6 +68,7 @@ impl FileUiState {
             format,
             size_bytes,
             size_txt,
+            modified_at,
             last_modify,
             color,
             included: true,

--- a/crates/app/src/host/ui/multi_setup/state/file.rs
+++ b/crates/app/src/host/ui/multi_setup/state/file.rs
@@ -20,8 +20,35 @@ pub struct FileUiState {
     /// Raw modification time used for chronological sorting.
     pub modified_at: Option<SystemTime>,
     pub last_modify: Option<String>,
-    pub color: Color32,
-    pub included: bool,
+    /// Inclusion state and positional source color.
+    pub inclusion: FileInclusion,
+}
+
+/// Whether a file participates in the multi-file operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileInclusion {
+    /// Included with its positional source color.
+    Included(Color32),
+    /// Excluded from the operation.
+    Excluded,
+}
+
+impl FileInclusion {
+    /// Returns whether the file participates in the operation.
+    pub const fn is_included(self) -> bool {
+        match self {
+            Self::Included(_) => true,
+            Self::Excluded => false,
+        }
+    }
+
+    /// Returns the positional source color of an included file.
+    pub const fn color(self) -> Option<Color32> {
+        match self {
+            Self::Included(color) => Some(color),
+            Self::Excluded => None,
+        }
+    }
 }
 
 impl FileUiState {
@@ -70,8 +97,7 @@ impl FileUiState {
             size_txt,
             modified_at,
             last_modify,
-            color,
-            included: true,
+            inclusion: FileInclusion::Included(color),
         }
     }
 }

--- a/crates/app/src/host/ui/multi_setup/state/mod.rs
+++ b/crates/app/src/host/ui/multi_setup/state/mod.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 mod file;
 
-pub use file::FileUiState;
+pub use file::{FileInclusion, FileUiState};
 
 use crate::host::common;
 


### PR DESCRIPTION
This PR closes #2572 

It includes:
* Sort files in multiple files table based on table columns in both directions
* Manually changing order of the items via drag and drop
* Clear the color of not included files