### PR TITLE
Add "Jump to Log" Overlay

### DIFF
--- a/crates/app/src/host/ui/command_palette/commands.rs
+++ b/crates/app/src/host/ui/command_palette/commands.rs
@@ -9,41 +9,17 @@ use crate::{
     host::{
         command::HostCommand,
         common::{parsers::ParserNames, sources::StreamNames},
+        notification::AppNotification,
         ui::{
             UiActions, file_dialog_commands,
             state::{HostState, modal::HostModal},
             storage::HostStorage,
-            tabs::HostTabs,
+            tabs::{HostTab, HostTabs},
         },
     },
 };
 
 use super::CommandPaletteItem;
-
-/// Host-level action launched from a command-palette result.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CommandAction {
-    GoHome,
-    OpenFiles,
-    OpenFilesWithPlugin,
-    OpenFolderFiles(FileFormat),
-    CloseCurrentTab,
-    NextTab,
-    PreviousTab,
-    OpenPluginManager,
-    OpenSettings,
-    ReloadPlugins,
-    ShowShortcuts,
-    ShowAbout,
-    SetTheme(Theme),
-    ToggleRightPanel,
-    ToggleBottomPanel,
-    ToggleSdeBar,
-    ConnectionSetup {
-        stream: StreamNames,
-        parser: ParserNames,
-    },
-}
 
 /// Static command-palette entry.
 #[derive(Debug, Clone, Copy)]
@@ -136,6 +112,14 @@ const COMMANDS: &[CommandDefinition] = &[
         action: CommandAction::ToggleSdeBar,
     },
     CommandDefinition {
+        title: "Jump to Row",
+        action: CommandAction::JumpToRow,
+    },
+    CommandDefinition {
+        title: "Find in Search Results",
+        action: CommandAction::NestedSearch,
+    },
+    CommandDefinition {
         title: "Terminal with Plain Text",
         action: CommandAction::ConnectionSetup {
             stream: StreamNames::Process,
@@ -221,11 +205,89 @@ const COMMANDS: &[CommandDefinition] = &[
     },
 ];
 
+/// Host-level action launched from a command-palette result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandAction {
+    GoHome,
+    OpenFiles,
+    OpenFilesWithPlugin,
+    OpenFolderFiles(FileFormat),
+    CloseCurrentTab,
+    NextTab,
+    PreviousTab,
+    OpenPluginManager,
+    OpenSettings,
+    ReloadPlugins,
+    ShowShortcuts,
+    ShowAbout,
+    SetTheme(Theme),
+    ToggleRightPanel,
+    ToggleBottomPanel,
+    ToggleSdeBar,
+    JumpToRow,
+    NestedSearch,
+    ConnectionSetup {
+        stream: StreamNames,
+        parser: ParserNames,
+    },
+}
+
+/// Active-tab scope used to select commands when the palette opens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandScope {
+    Global,
+    Session,
+}
+
+impl CommandAction {
+    fn scope(self) -> CommandScope {
+        match self {
+            Self::JumpToRow | Self::NestedSearch => CommandScope::Session,
+            Self::GoHome
+            | Self::OpenFiles
+            | Self::OpenFilesWithPlugin
+            | Self::OpenFolderFiles(_)
+            | Self::CloseCurrentTab
+            | Self::NextTab
+            | Self::PreviousTab
+            | Self::OpenPluginManager
+            | Self::OpenSettings
+            | Self::ReloadPlugins
+            | Self::ShowShortcuts
+            | Self::ShowAbout
+            | Self::SetTheme(_)
+            | Self::ToggleRightPanel
+            | Self::ToggleBottomPanel
+            | Self::ToggleSdeBar
+            | Self::ConnectionSetup { .. } => CommandScope::Global,
+        }
+    }
+}
+
+impl CommandScope {
+    /// Returns the command scope for the active host tab.
+    pub fn from_tabs(tabs: &HostTabs) -> Self {
+        if matches!(tabs.active(), HostTab::Session(_)) {
+            Self::Session
+        } else {
+            Self::Global
+        }
+    }
+
+    fn includes(self, command_scope: Self) -> bool {
+        command_scope == Self::Global || command_scope == self
+    }
+}
+
 /// Rebuilds command-palette results from the static command list.
-pub fn recompute_results(matcher: &mut FuzzyMatcher) -> Vec<CommandPaletteItem> {
+pub fn recompute_results(
+    matcher: &mut FuzzyMatcher,
+    active_scope: CommandScope,
+) -> Vec<CommandPaletteItem> {
     let mut matches: Vec<_> = COMMANDS
         .iter()
         .enumerate()
+        .filter(|(_, command)| active_scope.includes(command.action.scope()))
         .filter_map(|(index, command)| {
             matcher
                 .score(command.title)
@@ -327,6 +389,24 @@ pub fn execute_action(
             *visible = !*visible;
             true
         }
+        CommandAction::JumpToRow => {
+            if let HostTab::Session(session) = tabs.active_mut() {
+                session.open_jump_to_row();
+            }
+            true
+        }
+        CommandAction::NestedSearch => {
+            if let HostTab::Session(session) = tabs.active_mut() {
+                if session.nested_search_available() {
+                    session.toggle_nested_search(&mut state.preferences);
+                } else {
+                    actions.add_notification(AppNotification::Info(
+                        "Nested search requires search results.".to_owned(),
+                    ));
+                }
+            }
+            true
+        }
         CommandAction::ConnectionSetup { stream, parser } => actions.try_send_command(
             cmd_tx,
             HostCommand::ConnectionSessionSetup { stream, parser },
@@ -352,7 +432,7 @@ mod tests {
     fn empty_query_preserves_command_order() {
         let mut matcher = build_matcher("");
 
-        let results = recompute_results(&mut matcher);
+        let results = recompute_results(&mut matcher, CommandScope::Session);
 
         assert_eq!(results.len(), COMMANDS.len());
         let expected: Vec<_> = COMMANDS[..3].iter().map(|command| command.action).collect();
@@ -364,7 +444,7 @@ mod tests {
     fn fuzzy_query_matches_titles_only_and_highlights_title() {
         let mut matcher = build_matcher("pm");
 
-        let results = recompute_results(&mut matcher);
+        let results = recompute_results(&mut matcher, CommandScope::Global);
 
         assert!(result_actions(&results).contains(&CommandAction::OpenPluginManager));
         assert!(!result_actions(&results).contains(&CommandAction::ReloadPlugins));
@@ -374,5 +454,20 @@ mod tests {
             .find(|item| item.action == CommandAction::OpenPluginManager)
             .expect("plugin manager command should match");
         assert!(!plugin_manager.title.highlights.is_empty());
+    }
+
+    #[test]
+    fn session_commands_follow_active_scope() {
+        let mut matcher = build_matcher("");
+
+        let global_results = recompute_results(&mut matcher, CommandScope::Global);
+        let global_actions = result_actions(&global_results);
+        assert!(!global_actions.contains(&CommandAction::JumpToRow));
+        assert!(!global_actions.contains(&CommandAction::NestedSearch));
+
+        let session_results = recompute_results(&mut matcher, CommandScope::Session);
+        let session_actions = result_actions(&session_results);
+        assert!(session_actions.contains(&CommandAction::JumpToRow));
+        assert!(session_actions.contains(&CommandAction::NestedSearch));
     }
 }

--- a/crates/app/src/host/ui/command_palette/mod.rs
+++ b/crates/app/src/host/ui/command_palette/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 
-use commands::CommandAction;
+use commands::{CommandAction, CommandScope};
 
 mod commands;
 mod row;
@@ -25,6 +25,8 @@ pub struct CommandPalette {
     query: String,
     matcher: FuzzyMatcher,
     results: Vec<CommandPaletteItem>,
+    /// Active-tab scope captured for the current palette search session.
+    active_scope: CommandScope,
     selected_index: usize,
     /// True until the search field receives focus after opening.
     first_open_frame: bool,
@@ -49,7 +51,8 @@ impl CommandPalette {
     pub fn new(cmd_tx: Sender<HostCommand>) -> Self {
         let mut matcher = FuzzyMatcher::default();
         matcher.build_query("");
-        let results = commands::recompute_results(&mut matcher);
+        let active_scope = CommandScope::Global;
+        let results = commands::recompute_results(&mut matcher, active_scope);
 
         Self {
             cmd_tx,
@@ -57,6 +60,7 @@ impl CommandPalette {
             query: String::new(),
             matcher,
             results,
+            active_scope,
             selected_index: 0,
             first_open_frame: false,
             scroll_selected_into_view: false,
@@ -69,13 +73,14 @@ impl CommandPalette {
     }
 
     /// Opens the overlay and starts a fresh command search session.
-    pub fn open(&mut self) {
+    pub fn open(&mut self, tabs: &HostTabs) {
         let Self {
             cmd_tx: _,
             open,
             query,
             matcher,
             results,
+            active_scope,
             selected_index,
             first_open_frame,
             scroll_selected_into_view,
@@ -88,7 +93,8 @@ impl CommandPalette {
         *open = true;
         query.clear();
         matcher.build_query("");
-        *results = commands::recompute_results(matcher);
+        *active_scope = CommandScope::from_tabs(tabs);
+        *results = commands::recompute_results(matcher, *active_scope);
         *selected_index = 0;
         *first_open_frame = true;
         *scroll_selected_into_view = false;
@@ -174,7 +180,8 @@ impl CommandPalette {
 
                     if query_response.changed() {
                         self.matcher.build_query(&self.query);
-                        self.results = commands::recompute_results(&mut self.matcher);
+                        self.results =
+                            commands::recompute_results(&mut self.matcher, self.active_scope);
                         self.selected_index = 0;
                         self.scroll_selected_into_view = true;
                     }
@@ -201,6 +208,7 @@ impl CommandPalette {
             query,
             matcher,
             results,
+            active_scope,
             selected_index,
             first_open_frame,
             scroll_selected_into_view,
@@ -209,7 +217,8 @@ impl CommandPalette {
         *open = false;
         query.clear();
         matcher.build_query("");
-        *results = commands::recompute_results(matcher);
+        *active_scope = CommandScope::Global;
+        *results = commands::recompute_results(matcher, *active_scope);
         *selected_index = 0;
         *first_open_frame = false;
         *scroll_selected_into_view = false;
@@ -319,9 +328,10 @@ mod tests {
         let mut palette = CommandPalette::new(cmd_tx);
         palette.query = "plugin".to_owned();
         palette.matcher.build_query(&palette.query);
-        palette.results = commands::recompute_results(&mut palette.matcher);
+        palette.results = commands::recompute_results(&mut palette.matcher, CommandScope::Global);
+        let tabs = HostTabs::new(palette.cmd_tx.clone());
 
-        palette.open();
+        palette.open(&tabs);
 
         assert!(palette.is_open());
         assert!(palette.query.is_empty());

--- a/crates/app/src/host/ui/command_palette/row.rs
+++ b/crates/app/src/host/ui/command_palette/row.rs
@@ -129,6 +129,8 @@ fn action_icon(action: CommandAction) -> &'static str {
             icons::regular::SIDEBAR
         }
         CommandAction::ToggleSdeBar => icons::regular::TERMINAL_WINDOW,
+        CommandAction::JumpToRow => icons::regular::LIST_NUMBERS,
+        CommandAction::NestedSearch => icons::regular::MAGNIFYING_GLASS,
         CommandAction::ConnectionSetup { .. } => icons::regular::TERMINAL,
     }
 }

--- a/crates/app/src/host/ui/menu.rs
+++ b/crates/app/src/host/ui/menu.rs
@@ -133,27 +133,6 @@ impl MainMenuBar {
                 }
             });
 
-            ui.menu_button("Edit", |ui| {
-                ui.set_min_size(MENU_MIN_SIZE);
-
-                let nested_search_available = matches!(
-                    tabs.active(),
-                    HostTab::Session(session) if session.nested_search_available()
-                );
-                if ui
-                    .add_enabled(
-                        nested_search_available,
-                        Button::new("Find in Search Results"),
-                    )
-                    .clicked()
-                {
-                    if let HostTab::Session(session) = tabs.active_mut() {
-                        session.toggle_nested_search(&mut state.preferences);
-                    }
-                    ui.close();
-                }
-            });
-
             ui.menu_button("Connections", |ui| {
                 render_connections_menu(ui, actions, &self.cmd_tx);
             });
@@ -180,6 +159,28 @@ impl MainMenuBar {
                     ui.close();
                 }
             });
+
+            if let HostTab::Session(session) = tabs.active_mut() {
+                ui.menu_button("Session", |ui| {
+                    ui.set_min_size(MENU_MIN_SIZE);
+
+                    if ui.button("Jump to Row").clicked() {
+                        session.open_jump_to_row();
+                        ui.close();
+                    }
+
+                    if ui
+                        .add_enabled(
+                            session.nested_search_available(),
+                            Button::new("Find in Search Results"),
+                        )
+                        .clicked()
+                    {
+                        session.toggle_nested_search(&mut state.preferences);
+                        ui.close();
+                    }
+                });
+            }
 
             ui.menu_button("View", |ui| {
                 ui.set_min_size(MENU_MIN_SIZE);

--- a/crates/app/src/host/ui/mod.rs
+++ b/crates/app/src/host/ui/mod.rs
@@ -493,6 +493,18 @@ impl Host {
             },
         );
     }
+
+    /// Returns whether a host- or active-tab-owned input overlay is open.
+    fn has_input_overlay(&self) -> bool {
+        let Self {
+            quick_open,
+            command_palette,
+            tabs,
+            ..
+        } = self;
+
+        quick_open.is_open() || command_palette.is_open() || tabs.has_input_overlay()
+    }
 }
 
 fn render_tab_bar_utilities(
@@ -590,9 +602,9 @@ impl eframe::App for Host {
     }
 
     fn ui(&mut self, ui: &mut Ui, frame: &mut eframe::Frame) {
+        let overlay_was_open = self.has_input_overlay();
+
         let Self {
-            quick_open,
-            command_palette,
             storage,
             state,
             tabs,
@@ -600,10 +612,11 @@ impl eframe::App for Host {
             ..
         } = self;
 
-        let overlay_was_open = quick_open.is_open() || command_palette.is_open();
-        quick_open.handle_input(ui, storage, ui_actions);
-        command_palette.handle_input(ui, state, tabs, storage, ui_actions);
-        if !overlay_was_open && !quick_open.is_open() && !command_palette.is_open() {
+        self.quick_open.handle_input(ui, storage, ui_actions);
+        self.command_palette
+            .handle_input(ui, state, tabs, storage, ui_actions);
+
+        if !overlay_was_open && !self.has_input_overlay() {
             shortcuts::handler::handle(self, ui.ctx());
         }
 

--- a/crates/app/src/host/ui/shortcuts/handler.rs
+++ b/crates/app/src/host/ui/shortcuts/handler.rs
@@ -99,7 +99,7 @@ fn handle_app_shortcuts(host: &mut Host, ctx: &Context) -> bool {
     }
 
     if consume_shortcut(ctx, command_palette_shortcut) {
-        command_palette.open();
+        command_palette.open(tabs);
         return true;
     }
 

--- a/crates/app/src/host/ui/tabs/mod.rs
+++ b/crates/app/src/host/ui/tabs/mod.rs
@@ -88,16 +88,29 @@ impl HostTabs {
         &mut self.tabs[self.active_idx]
     }
 
+    /// Returns whether the active tab owns a lightweight input overlay.
+    pub fn has_input_overlay(&self) -> bool {
+        self.active().has_input_overlay()
+    }
+
     /// Activates the Home tab.
     pub fn activate_home(&mut self) {
-        self.active_idx = HOME_TAB_IDX;
+        self.activate_tab(HOME_TAB_IDX);
     }
 
     /// Activates the tab at `index` when it exists.
     pub fn activate_tab(&mut self, index: usize) {
-        if index < self.tabs.len() {
-            self.active_idx = index;
+        if index >= self.tabs.len() || index == self.active_idx {
+            return;
         }
+
+        self.tabs[self.active_idx].close_input_overlays();
+        self.active_idx = index;
+    }
+
+    fn activate_last_tab(&mut self) {
+        let last_idx = self.tabs.len() - 1;
+        self.activate_tab(last_idx);
     }
 
     /// Activates the next tab, wrapping around at the end.
@@ -106,7 +119,8 @@ impl HostTabs {
             return;
         }
 
-        self.active_idx = (self.active_idx + 1) % self.tabs.len();
+        let next_idx = (self.active_idx + 1) % self.tabs.len();
+        self.activate_tab(next_idx);
     }
 
     /// Activates the previous tab, wrapping around at the start.
@@ -115,11 +129,12 @@ impl HostTabs {
             return;
         }
 
-        self.active_idx = if self.active_idx == HOME_TAB_IDX {
+        let previous_idx = if self.active_idx == HOME_TAB_IDX {
             self.tabs.len() - 1
         } else {
             self.active_idx - 1
         };
+        self.activate_tab(previous_idx);
     }
 
     /// Opens or focuses the singleton Plugin Manager tab.
@@ -129,14 +144,14 @@ impl HostTabs {
             .iter()
             .position(|tab| matches!(tab, HostTab::PluginManager(_)))
         {
-            self.active_idx = tab_idx;
+            self.activate_tab(tab_idx);
             return;
         }
 
         let plugin_manager = PluginManagerView::new(self.cmd_tx.clone());
         let tab = HostTab::PluginManager(Box::new(plugin_manager));
         self.tabs.push(tab);
-        self.active_idx = self.tabs.len() - 1;
+        self.activate_last_tab();
     }
 
     /// Opens or focuses the singleton application settings tab.
@@ -146,28 +161,28 @@ impl HostTabs {
             .iter()
             .position(|tab| matches!(tab, HostTab::AppSettings(_)))
         {
-            self.active_idx = tab_idx;
+            self.activate_tab(tab_idx);
             return;
         }
 
         let settings = AppSettingsView::new(settings);
         let tab = HostTab::AppSettings(Box::new(settings));
         self.tabs.push(tab);
-        self.active_idx = self.tabs.len() - 1;
+        self.activate_last_tab();
     }
 
     /// Adds and activates a single-session setup tab.
     pub fn add_session_setup(&mut self, setup_state: SessionSetupState) {
         let setup = SessionSetup::new(setup_state, self.cmd_tx.clone());
         self.tabs.push(HostTab::SessionSetup(Box::new(setup)));
-        self.active_idx = self.tabs.len() - 1;
+        self.activate_last_tab();
     }
 
     /// Adds and activates a multiple-file setup tab.
     pub fn add_multi_files(&mut self, state: MultiFileState) {
         let setup = MultiFileSetup::new(state, self.cmd_tx.clone());
         self.tabs.push(HostTab::MultiFileSetup(Box::new(setup)));
-        self.active_idx = self.tabs.len() - 1;
+        self.activate_last_tab();
     }
 
     /// Adds a session tab, replacing a matching setup tab when one is provided.
@@ -183,7 +198,7 @@ impl HostTabs {
         }
 
         self.tabs.push(HostTab::Session(Box::new(session)));
-        self.active_idx = self.tabs.len() - 1;
+        self.activate_last_tab();
     }
 
     /// Gracefully closes all live session services during application shutdown.
@@ -431,6 +446,7 @@ impl HostTabs {
 
     fn update_active_on_close(&mut self, removed_idx: usize) {
         if self.active_idx == removed_idx {
+            self.tabs[self.active_idx].close_input_overlays();
             let remaining_tabs = self.tabs.len().saturating_sub(1);
             self.active_idx = if removed_idx < remaining_tabs {
                 removed_idx
@@ -439,6 +455,32 @@ impl HostTabs {
             };
         } else if self.active_idx > removed_idx {
             self.active_idx -= 1;
+        }
+    }
+}
+
+impl HostTab {
+    /// Returns whether this tab owns an open lightweight input overlay.
+    fn has_input_overlay(&self) -> bool {
+        match self {
+            Self::Session(session) => session.has_input_overlay(),
+            Self::Home(_)
+            | Self::SessionSetup(_)
+            | Self::MultiFileSetup(_)
+            | Self::PluginManager(_)
+            | Self::AppSettings(_) => false,
+        }
+    }
+
+    /// Closes and resets lightweight input overlays owned by this tab.
+    fn close_input_overlays(&mut self) {
+        match self {
+            Self::Session(session) => session.close_input_overlays(),
+            Self::Home(_)
+            | Self::SessionSetup(_)
+            | Self::MultiFileSetup(_)
+            | Self::PluginManager(_)
+            | Self::AppSettings(_) => {}
         }
     }
 }

--- a/crates/app/src/session/ui/jump_to_row.rs
+++ b/crates/app/src/session/ui/jump_to_row.rs
@@ -1,0 +1,487 @@
+//! Session-owned Jump to Row input overlay.
+
+use egui::{Align2, Event, Key, Modifiers, Order, Ui, Window, pos2, vec2};
+
+use crate::host::common::ui_utls::{
+    clicked_outside_rect, show_validation_message, sized_singleline_text_edit,
+};
+
+use super::shared::{SearchTableSync, SessionShared};
+
+/// Lightweight overlay for selecting a zero-based session row.
+#[derive(Debug, Default)]
+pub struct JumpToRow {
+    open: bool,
+    input: String,
+    first_open_frame: bool,
+    show_validation: bool,
+}
+
+impl JumpToRow {
+    /// Opens a fresh row input session unless the overlay is already open.
+    pub fn open(&mut self) {
+        let Self {
+            open,
+            input,
+            first_open_frame,
+            show_validation,
+        } = self;
+
+        if *open {
+            return;
+        }
+
+        *open = true;
+        input.clear();
+        *first_open_frame = true;
+        *show_validation = false;
+    }
+
+    /// Returns whether the overlay is visible.
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    /// Closes the overlay and discards its input.
+    pub fn close(&mut self) {
+        let Self {
+            open,
+            input,
+            first_open_frame,
+            show_validation,
+        } = self;
+
+        *open = false;
+        input.clear();
+        *first_open_frame = false;
+        *show_validation = false;
+    }
+
+    /// Handles overlay input and renders the open overlay.
+    pub fn render(&mut self, shared: &mut SessionShared, parent_ui: &Ui) {
+        if parent_ui.input_mut(|input| input.consume_key(Modifiers::NONE, Key::Escape)) {
+            self.close();
+            return;
+        }
+
+        let logs_count = shared.logs.logs_count();
+        if consume_enter(parent_ui) {
+            self.show_validation = true;
+
+            if let RowValidation::Valid(row) = validate_row(&self.input, logs_count) {
+                shared.logs.focus_main_row(row, SearchTableSync::Sync);
+                self.close();
+                return;
+            }
+        }
+
+        self.render_window(parent_ui, logs_count);
+    }
+
+    fn render_window(&mut self, parent_ui: &Ui, logs_count: u64) {
+        const PANEL_WIDTH: f32 = 320.0;
+        const PANEL_TOP_OFFSET: f32 = 90.0;
+
+        let screen_rect = parent_ui.ctx().content_rect();
+        let panel_pos = pos2(screen_rect.center().x, screen_rect.top() + PANEL_TOP_OFFSET);
+        let window_id = parent_ui.make_persistent_id("jump_to_row_window");
+        let first_open_frame = self.first_open_frame;
+        let window_response = Window::new("jump_to_row")
+            .id(window_id)
+            .order(Order::Foreground)
+            .title_bar(false)
+            .collapsible(false)
+            .resizable(false)
+            .scroll(false)
+            .fixed_pos(panel_pos)
+            .pivot(Align2::CENTER_TOP)
+            .show(parent_ui.ctx(), |ui| {
+                ui.set_width(PANEL_WIDTH);
+                ui.heading("Jump to Row");
+
+                let input_id = ui.make_persistent_id("jump_to_row_input");
+                let input_response = sized_singleline_text_edit(
+                    ui,
+                    &mut self.input,
+                    vec2(ui.available_width(), 25.0),
+                    7,
+                )
+                .id(input_id)
+                .hint_text("Enter row number")
+                .lock_focus(true)
+                .show(ui)
+                .response;
+
+                if first_open_frame {
+                    input_response.request_focus();
+                }
+                if input_response.changed() {
+                    self.show_validation = true;
+                }
+
+                let validation_message = self.validation_message(logs_count);
+                show_validation_message(ui, validation_message);
+
+                ui.label("Enter to jump, Esc to cancel");
+            });
+        self.first_open_frame = false;
+
+        let clicked_outside = window_response
+            .as_ref()
+            .is_some_and(|response| clicked_outside_rect(parent_ui, response.response.rect));
+        if !first_open_frame && clicked_outside {
+            self.close();
+        }
+    }
+
+    fn validation_message(&self, logs_count: u64) -> Option<&'static str> {
+        if !self.show_validation {
+            return None;
+        }
+
+        validate_row(&self.input, logs_count).message()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RowValidation {
+    InvalidInput,
+    OutOfBounds,
+    Valid(u64),
+}
+
+impl RowValidation {
+    fn message(self) -> Option<&'static str> {
+        match self {
+            Self::InvalidInput => Some("Enter a valid row number."),
+            Self::OutOfBounds => Some("Row is out of bounds."),
+            Self::Valid(_) => None,
+        }
+    }
+}
+
+fn validate_row(input: &str, logs_count: u64) -> RowValidation {
+    match input.parse::<u64>() {
+        Ok(row) if row < logs_count => RowValidation::Valid(row),
+        Ok(_) => RowValidation::OutOfBounds,
+        Err(_) => RowValidation::InvalidInput,
+    }
+}
+
+fn consume_enter(ui: &Ui) -> bool {
+    ui.input_mut(|input| {
+        let mut consumed = false;
+        input.events.retain(|event| {
+            let matched = matches!(
+                event,
+                Event::Key {
+                    key: Key::Enter,
+                    pressed: true,
+                    ..
+                }
+            );
+            consumed |= matched;
+            !matched
+        });
+        consumed
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use egui::{Context, Event, Key, Modifiers, PointerButton, RawInput, Rect, pos2, vec2};
+    use stypes::{FileFormat, ObserveOrigin};
+    use uuid::Uuid;
+
+    use super::{JumpToRow, RowValidation, validate_row};
+    use crate::{
+        host::common::parsers::ParserNames,
+        session::{
+            types::ObserveOperation,
+            ui::{
+                SessionInfo,
+                definitions::schema::LogSchemaSpec,
+                shared::{SearchTableSync, SessionShared},
+            },
+        },
+    };
+
+    fn new_shared(logs_count: u64) -> SessionShared {
+        let origin = ObserveOrigin::File(
+            "source".to_owned(),
+            FileFormat::Text,
+            PathBuf::from("source.log"),
+        );
+        let observe_op = ObserveOperation::new(Uuid::new_v4(), origin);
+        let session_info = SessionInfo {
+            id: Uuid::new_v4(),
+            title: "test".to_owned(),
+            parser: ParserNames::Text,
+            raw_export_supported: false,
+        };
+        let mut shared = SessionShared::new(session_info, observe_op, LogSchemaSpec::Text);
+        shared.logs.set_logs_count(logs_count);
+        shared
+    }
+
+    fn key_input(key: Key, modifiers: Modifiers) -> RawInput {
+        RawInput {
+            events: vec![Event::Key {
+                key,
+                physical_key: Some(key),
+                pressed: true,
+                repeat: false,
+                modifiers,
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn render(jump: &mut JumpToRow, shared: &mut SessionShared, input: RawInput) {
+        let ctx = Context::default();
+        let _ = ctx.run_ui(input, |ui| jump.render(shared, ui));
+    }
+
+    fn pointer_input(pressed: bool) -> RawInput {
+        let pos = pos2(10.0, 10.0);
+        RawInput {
+            screen_rect: Some(Rect::from_min_size(pos2(0.0, 0.0), vec2(800.0, 600.0))),
+            events: vec![
+                Event::PointerMoved(pos),
+                Event::PointerButton {
+                    pos,
+                    button: PointerButton::Primary,
+                    pressed,
+                    modifiers: Modifiers::NONE,
+                },
+            ],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn opening_starts_with_fresh_input() {
+        let mut jump = JumpToRow::default();
+        jump.input = "stale".to_owned();
+
+        jump.open();
+        assert!(jump.is_open());
+        assert!(jump.input.is_empty());
+
+        jump.input = "in progress".to_owned();
+        jump.open();
+        assert_eq!(jump.input, "in progress");
+
+        jump.close();
+        jump.open();
+        assert!(jump.input.is_empty());
+    }
+
+    #[test]
+    fn validation_classifies_raw_input_and_boundaries() {
+        for (input, logs_count, expected) in [
+            ("", 10, RowValidation::InvalidInput),
+            ("text", 10, RowValidation::InvalidInput),
+            ("-1", 10, RowValidation::InvalidInput),
+            (" 4", 10, RowValidation::InvalidInput),
+            ("4 ", 10, RowValidation::InvalidInput),
+            ("18446744073709551616", 10, RowValidation::InvalidInput),
+            ("0", 0, RowValidation::OutOfBounds),
+            ("0", 1, RowValidation::Valid(0)),
+            ("+4", 10, RowValidation::Valid(4)),
+            ("9", 10, RowValidation::Valid(9)),
+            ("10", 10, RowValidation::OutOfBounds),
+        ] {
+            assert_eq!(
+                validate_row(input, logs_count),
+                expected,
+                "input: {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validation_stays_hidden_until_edit_or_submit() {
+        let mut jump = JumpToRow::default();
+        let mut shared = new_shared(10);
+        let ctx = Context::default();
+        jump.open();
+
+        let _ = ctx.run_ui(RawInput::default(), |ui| jump.render(&mut shared, ui));
+        assert!(jump.validation_message(10).is_none());
+
+        let text_input = RawInput {
+            events: vec![Event::Text("x".to_owned())],
+            ..Default::default()
+        };
+        let _ = ctx.run_ui(text_input, |ui| jump.render(&mut shared, ui));
+        assert_eq!(jump.input, "x");
+        assert!(jump.validation_message(10).is_some());
+
+        let _ = ctx.run_ui(key_input(Key::Backspace, Modifiers::NONE), |ui| {
+            jump.render(&mut shared, ui)
+        });
+        assert!(jump.input.is_empty());
+        assert!(jump.validation_message(10).is_some());
+
+        let text_input = RawInput {
+            events: vec![Event::Text("4".to_owned())],
+            ..Default::default()
+        };
+        let _ = ctx.run_ui(text_input, |ui| jump.render(&mut shared, ui));
+        assert_eq!(jump.input, "4");
+        assert!(jump.validation_message(10).is_none());
+    }
+
+    #[test]
+    fn enter_modifiers_use_the_same_submission_path() {
+        for modifiers in [
+            Modifiers::NONE,
+            Modifiers::CTRL,
+            Modifiers::COMMAND,
+            Modifiers::SHIFT,
+            Modifiers::ALT,
+        ] {
+            let mut jump = JumpToRow::default();
+            let mut shared = new_shared(10);
+            jump.open();
+            jump.input = "4".to_owned();
+
+            render(&mut jump, &mut shared, key_input(Key::Enter, modifiers));
+
+            assert!(!jump.is_open(), "modifiers: {modifiers:?}");
+            assert_eq!(shared.logs.single_selected_row(), Some(4));
+            let focus = shared
+                .logs
+                .take_main_row_focus()
+                .expect("valid row should request focus");
+            assert_eq!(focus.row, 4);
+            assert_eq!(focus.search_table_sync, SearchTableSync::Sync);
+        }
+    }
+
+    #[test]
+    fn valid_rows_replace_selection_and_request_focus() {
+        for row in [0, 4, 9] {
+            let mut jump = JumpToRow::default();
+            let mut shared = new_shared(10);
+            shared.logs.replace_selection_with(7);
+            jump.open();
+            jump.input = row.to_string();
+
+            render(
+                &mut jump,
+                &mut shared,
+                key_input(Key::Enter, Modifiers::NONE),
+            );
+
+            assert!(!jump.is_open());
+            assert_eq!(shared.logs.single_selected_row(), Some(row));
+            let focus = shared
+                .logs
+                .take_main_row_focus()
+                .expect("valid row should request focus");
+            assert_eq!(focus.row, row);
+            assert_eq!(focus.search_table_sync, SearchTableSync::Sync);
+        }
+    }
+
+    #[test]
+    fn valid_selected_row_stays_selected() {
+        let mut jump = JumpToRow::default();
+        let mut shared = new_shared(10);
+        shared.logs.replace_selection_with(4);
+        jump.open();
+        jump.input = "4".to_owned();
+
+        render(
+            &mut jump,
+            &mut shared,
+            key_input(Key::Enter, Modifiers::NONE),
+        );
+
+        assert!(!jump.is_open());
+        assert_eq!(shared.logs.single_selected_row(), Some(4));
+        assert_eq!(shared.logs.selected_count(), 1);
+    }
+
+    #[test]
+    fn invalid_rows_preserve_session_state() {
+        for (input, logs_count) in [
+            ("", 10),
+            ("text", 10),
+            ("-1", 10),
+            ("18446744073709551616", 10),
+            (" 4", 10),
+            ("10", 10),
+            ("11", 10),
+            ("0", 0),
+        ] {
+            let mut jump = JumpToRow::default();
+            let mut shared = new_shared(logs_count);
+            shared.logs.replace_selection_with(3);
+            shared.logs.request_main_row_focus(6, SearchTableSync::Skip);
+            jump.open();
+            jump.input = input.to_owned();
+
+            render(
+                &mut jump,
+                &mut shared,
+                key_input(Key::Enter, Modifiers::NONE),
+            );
+
+            assert!(jump.is_open(), "input: {input:?}");
+            assert!(jump.validation_message(logs_count).is_some());
+            assert_eq!(shared.logs.single_selected_row(), Some(3));
+            let focus = shared
+                .logs
+                .take_main_row_focus()
+                .expect("existing focus should be preserved");
+            assert_eq!(focus.row, 6);
+            assert_eq!(focus.search_table_sync, SearchTableSync::Skip);
+        }
+    }
+
+    #[test]
+    fn opening_click_does_not_close_overlay() {
+        let mut jump = JumpToRow::default();
+        let mut shared = new_shared(10);
+        let ctx = Context::default();
+
+        let _ = ctx.run_ui(pointer_input(true), |_| {});
+        jump.open();
+        let _ = ctx.run_ui(pointer_input(false), |ui| jump.render(&mut shared, ui));
+        assert!(jump.is_open());
+
+        let _ = ctx.run_ui(pointer_input(true), |ui| jump.render(&mut shared, ui));
+        let _ = ctx.run_ui(pointer_input(false), |ui| jump.render(&mut shared, ui));
+        assert!(!jump.is_open());
+    }
+
+    #[test]
+    fn escape_closes_without_changing_session_state() {
+        let mut jump = JumpToRow::default();
+        let mut shared = new_shared(10);
+        shared.logs.replace_selection_with(3);
+        shared.logs.request_main_row_focus(6, SearchTableSync::Skip);
+        jump.open();
+        jump.input = "8".to_owned();
+
+        render(
+            &mut jump,
+            &mut shared,
+            key_input(Key::Escape, Modifiers::NONE),
+        );
+
+        assert!(!jump.is_open());
+        assert_eq!(shared.logs.single_selected_row(), Some(3));
+        let focus = shared
+            .logs
+            .take_main_row_focus()
+            .expect("existing focus should be preserved");
+        assert_eq!(focus.row, 6);
+        assert_eq!(focus.search_table_sync, SearchTableSync::Skip);
+    }
+}

--- a/crates/app/src/session/ui/jump_to_row.rs
+++ b/crates/app/src/session/ui/jump_to_row.rs
@@ -263,8 +263,10 @@ mod tests {
 
     #[test]
     fn opening_starts_with_fresh_input() {
-        let mut jump = JumpToRow::default();
-        jump.input = "stale".to_owned();
+        let mut jump = JumpToRow {
+            input: "stale".to_owned(),
+            ..Default::default()
+        };
 
         jump.open();
         assert!(jump.is_open());

--- a/crates/app/src/session/ui/mod.rs
+++ b/crates/app/src/session/ui/mod.rs
@@ -45,6 +45,7 @@ use crate::{
 };
 use bottom_panel::{BottomPanelUI, BottomTabType};
 use common::log_table::{LogTableKind, table::TableScroll};
+use jump_to_row::JumpToRow;
 use logs_table::LogsTable;
 use side_panel::{SidePanelUi, SideTabType};
 
@@ -53,6 +54,7 @@ mod bottom_panel;
 mod common;
 pub mod definitions;
 mod export_modal;
+mod jump_to_row;
 mod logs_table;
 mod recent;
 mod sde_bar;
@@ -73,6 +75,7 @@ pub struct Session {
     shared: SessionShared,
     pub recent_session: RecentSessionRuntime,
     logs_table: LogsTable,
+    jump_to_row: JumpToRow,
     sde_bar: SdeBarUi,
     bottom_panel: BottomPanelUI,
     side_panel: SidePanelUi,
@@ -120,6 +123,7 @@ impl Session {
             shared,
             recent_session,
             logs_table,
+            jump_to_row: JumpToRow::default(),
             sde_bar,
             bottom_panel,
             attachment_modal: attachment_modal::AttachmentModalUi::new(),
@@ -136,6 +140,21 @@ impl Session {
         self.sde_bar.is_available()
     }
 
+    /// Opens Jump to Row for this session.
+    pub fn open_jump_to_row(&mut self) {
+        self.jump_to_row.open();
+    }
+
+    /// Returns whether this session owns an open lightweight input overlay.
+    pub fn has_input_overlay(&self) -> bool {
+        self.jump_to_row.is_open()
+    }
+
+    /// Closes and resets lightweight input overlays owned by this session.
+    pub fn close_input_overlays(&mut self) {
+        self.jump_to_row.close();
+    }
+
     pub fn render_content(
         &mut self,
         actions: &mut UiActions,
@@ -146,6 +165,7 @@ impl Session {
         let Self {
             cmd_tx,
             logs_table,
+            jump_to_row,
             sde_bar,
             bottom_panel,
             side_panel,
@@ -157,6 +177,10 @@ impl Session {
             shared.signals.is_empty(),
             "Signals leaked from previous frame."
         );
+
+        if jump_to_row.is_open() {
+            jump_to_row.render(shared, ui);
+        }
 
         shared.exports.handle_dialogs(actions, cmd_tx);
 
@@ -768,7 +792,7 @@ fn clear_text_edit_focus(ctx: &Context) {
 mod tests {
     use std::{assert_matches, path::PathBuf};
 
-    use egui::{Event, Key, Modifiers, RawInput};
+    use egui::{Context, Event, Key, Modifiers, RawInput};
     use processor::search::filter::SearchFilter;
     use regex::Regex;
     use session_core::state::{IndexedNavigation, NestedMatch};
@@ -798,7 +822,7 @@ mod tests {
         let (host_message_tx, _host_message_rx) = mpsc::channel(4);
         let (notification_tx, _notification_rx) = mpsc::channel(4);
         let shared_senders =
-            SharedSenders::new(host_message_tx, notification_tx, egui::Context::default());
+            SharedSenders::new(host_message_tx, notification_tx, Context::default());
         let (communication, service) = communication::init(shared_senders);
         let (host_cmd_tx, _host_cmd_rx) = mpsc::channel(4);
 
@@ -883,7 +907,7 @@ mod tests {
             }],
             ..Default::default()
         };
-        let ctx = egui::Context::default();
+        let ctx = Context::default();
         let mut consumed = false;
         let _ = ctx.run_ui(input, |ui| {
             consumed = session.handle_shortcuts(&mut actions, &mut host_state, ui.ctx(), None);
@@ -926,7 +950,7 @@ mod tests {
             }],
             ..Default::default()
         };
-        let ctx = egui::Context::default();
+        let ctx = Context::default();
         let mut consumed = false;
         let _ = ctx.run_ui(input, |ui| {
             consumed = session.handle_shortcuts(&mut actions, &mut host_state, ui.ctx(), None);

--- a/crates/app/src/session/ui/shortcuts.rs
+++ b/crates/app/src/session/ui/shortcuts.rs
@@ -52,6 +52,10 @@ const SEARCH_FOCUS_DISPLAY: &str = "Slash / Cmd+F";
 const SEARCH_FOCUS_DISPLAY: &str = "Slash / Ctrl+F";
 
 static SHORTCUTS: SessionShortcuts = SessionShortcuts {
+    jump_to_row: Shortcut::new(
+        &[KeyboardShortcut::new(Modifiers::COMMAND, Key::G)],
+        "Jump to row",
+    ),
     activate_main_output: Shortcut::new(
         &[KeyboardShortcut::new(Modifiers::COMMAND, Key::Num1)],
         "Focus main logs table",
@@ -173,6 +177,7 @@ static SHORTCUTS: SessionShortcuts = SessionShortcuts {
 };
 
 struct SessionShortcuts {
+    jump_to_row: Shortcut,
     activate_main_output: Shortcut,
     activate_search_output: Shortcut,
     active_page_up: Shortcut,
@@ -198,8 +203,9 @@ struct SessionShortcuts {
     previous_bookmark: Shortcut,
 }
 
-pub fn shortcut_defs() -> [&'static Shortcut; 22] {
+pub fn shortcut_defs() -> [&'static Shortcut; 23] {
     let SessionShortcuts {
+        jump_to_row,
         activate_main_output,
         activate_search_output,
         active_page_up,
@@ -226,6 +232,7 @@ pub fn shortcut_defs() -> [&'static Shortcut; 22] {
     } = &SHORTCUTS;
 
     [
+        jump_to_row,
         activate_search_tab,
         activate_search_tab_outside_text,
         toggle_nested_search,
@@ -266,6 +273,7 @@ pub fn handle(
     } = host_state;
 
     let SessionShortcuts {
+        jump_to_row,
         activate_main_output,
         activate_search_output,
         active_page_up,
@@ -290,6 +298,11 @@ pub fn handle(
         next_bookmark,
         previous_bookmark,
     } = &SHORTCUTS;
+
+    if consume_shortcut(ctx, jump_to_row) {
+        session.open_jump_to_row();
+        return true;
+    }
 
     if consume_shortcut(ctx, activate_main_output) {
         session.activate_main_logs_table(ctx);


### PR DESCRIPTION
This PR closes #2603 

This PR adds **Jump to Log** with menu entry and the shortcut _ctrl/cmd+g_, enabling user to jump to a specific log giving its number (zero indexed to match current app UI indexing).
It also extends **command palette** with extra filtering and adds more commands 

It includes:
#### Jump to Log:
* Add implementation for jump to the provided logs number. It will be enabled via menu entries and shortcuts.
* Add live validation to the overlay input.
* Change Edit menu entry to `Session` and enable it on session tabs only.

#### Command Palette Changes: 
* Add command scope type to avoid showing session only commands on none running session tabs.
* Extend commands with:
  - Nested search command
  - Jump to log command