### PR TITLE
Producer: Split produce function into fetch/process & Proper Handling for Incomplete Error

### DIFF
--- a/crates/app/src/session/service/export.rs
+++ b/crates/app/src/session/service/export.rs
@@ -246,7 +246,8 @@ impl SessionService {
                 if len == 0 {
                     Ok(Vec::new())
                 } else {
-                    Ok(vec![0..=(len as u64 - 1)])
+                    let rng: RangeInclusive<_> = 0..=(len as u64 - 1);
+                    Ok(vec![rng])
                 }
             }
             ExportTarget::Indexed => {

--- a/crates/bufread/src/lib.rs
+++ b/crates/bufread/src/lib.rs
@@ -40,6 +40,12 @@ impl<R> BufReader<R> {
     pub fn buffer(&self) -> &[u8] {
         self.buffer.read_slice()
     }
+
+    /// Returns the number of bytes the next read could add to the inner buffer without
+    /// consuming any of the buffered ones.
+    pub fn write_available(&self) -> usize {
+        self.buffer.write_available()
+    }
 }
 
 impl<R: Read> Read for BufReader<R> {
@@ -176,6 +182,12 @@ impl DeqBuffer {
     /// Returns the number of currently available bytes for writing.
     pub fn write_available(&self) -> usize {
         self.slice.len() - self.end
+    }
+
+    /// Returns the number of bytes that could be written after moving the remaining bytes
+    /// to the front of the buffer.
+    pub fn spare_capacity(&self) -> usize {
+        self.capacity() - self.read_available()
     }
 
     /// Returns the current slice to write to.

--- a/crates/cli/src/session/file.rs
+++ b/crates/cli/src/session/file.rs
@@ -51,7 +51,6 @@ where
     let mut msg_count = 0;
 
     loop {
-        collector.get_records().clear();
         tokio::select! {
             _ = cancel_token.cancelled() => {
                 file_writer.flush().context("Error writing data to file.")?;
@@ -60,28 +59,35 @@ where
                 return Ok(());
             },
             res = producer.produce_next(&mut collector) => {
-                let summary = res?;
-                match summary {
-                    ProduceSummary::Processed {..} => {
-                        for record in collector.get_records() {
-                           let msg =  match record {
-                                ParseYield::Message(msg) => msg,
-                                ParseYield::Attachment(..) => continue,
-                                ParseYield::MessageAndAttachment((msg, _att)) => msg,
-                            };
-                            msg_formatter.write_msg(&mut file_writer, msg)?;
+                // We don't support file tailing in the CLI tool, so a stalled source is the end
+                // of the input.
+                let last_round = match res? {
+                    ProduceSummary::Processed {..} => false,
+                    ProduceSummary::PendingRemainder {..} => {
+                        // Let the parser close the item it is still holding.
+                        producer.process_remaining(&mut collector)?;
+                        true
+                    },
+                    ProduceSummary::NoBytesAvailable {..} | ProduceSummary::Done {..} => true,
+                };
 
-                            msg_count += 1;
-                            if msg_count % UPDATE_MESSAGE_INTERVAL == 0 {
-                                println!("Processing... {msg_count} messages have been written to file.");
-                            }
-                        }
-                    },
-                    // We don't support file tailing in the CLI tool.
-                    ProduceSummary::NoBytesAvailable {..} | ProduceSummary::Done {..} => {
-                        write_sum(&mut producer);
-                        return Ok(());
-                    },
+                for record in collector.get_records().drain(..) {
+                   let msg =  match record {
+                        ParseYield::Message(msg) => msg,
+                        ParseYield::Attachment(..) => continue,
+                        ParseYield::MessageAndAttachment((msg, _att)) => msg,
+                    };
+                    msg_formatter.write_msg(&mut file_writer, &msg)?;
+
+                    msg_count += 1;
+                    if msg_count % UPDATE_MESSAGE_INTERVAL == 0 {
+                        println!("Processing... {msg_count} messages have been written to file.");
+                    }
+                }
+
+                if last_round {
+                    write_sum(&mut producer);
+                    return Ok(());
                 }
             }
 

--- a/crates/cli/src/session/socket.rs
+++ b/crates/cli/src/session/socket.rs
@@ -108,25 +108,30 @@ where
                 }
             }
             res = producer.produce_next(&mut collector) => {
-                let summary = res?;
+                // No tailing support for streams, so a stalled source is the end of the input.
+                let last_round = match res? {
+                    ProduceSummary::Processed {..} => false,
+                    ProduceSummary::PendingRemainder {..} => {
+                        // Let the parser close the item it is still holding.
+                        producer.process_remaining(&mut collector)?;
+                        true
+                    },
+                    ProduceSummary::NoBytesAvailable {..} | ProduceSummary::Done {..} => true,
+                };
 
-                match summary {
-                    ProduceSummary::Processed {..} => {
-                        for record in collector.get_records() {
-                           let msg =  match record {
-                                ParseYield::Message(msg) => msg,
-                                ParseYield::Attachment(..) => continue,
-                                ParseYield::MessageAndAttachment((msg, _att)) => msg,
-                            };
-                            msg_formatter.write_msg(&mut file_writer, msg)?;
-                            msg_since_last_flush += 1;
-                        }
-                    },
-                    // No tailing support for streams.
-                    ProduceSummary::NoBytesAvailable {..} | ProduceSummary::Done {..} => {
-                        write_sum(&mut producer);
-                        return Ok(());
-                    },
+                for record in collector.get_records().drain(..) {
+                   let msg =  match record {
+                        ParseYield::Message(msg) => msg,
+                        ParseYield::Attachment(..) => continue,
+                        ParseYield::MessageAndAttachment((msg, _att)) => msg,
+                    };
+                    msg_formatter.write_msg(&mut file_writer, &msg)?;
+                    msg_since_last_flush += 1;
+                }
+
+                if last_round {
+                    write_sum(&mut producer);
+                    return Ok(());
                 }
             }
         };

--- a/crates/core/dlt_tools/src/lib.rs
+++ b/crates/core/dlt_tools/src/lib.rs
@@ -69,6 +69,14 @@ pub async fn scan_dlt_ft(
                             Ok(ProduceSummary::Processed {..}) => {
                                 // Attachments are appended.
                             },
+                            Ok(ProduceSummary::PendingRemainder {..}) => {
+                                // Scanning doesn't tail, so a stalled source is the end of the
+                                // file: let the parser close its partial message, then stop.
+                                if let Err(err) = producer.process_remaining(&mut collector) {
+                                    return Err(format!("Error while processing DLT file. {err}"));
+                                }
+                                break;
+                            }
                             Ok(ProduceSummary::Done {..} | ProduceSummary::NoBytesAvailable {..}) => {
                                 // Stop as tailing isn't needed here.
                                 break;

--- a/crates/core/dlt_tools/src/lib.rs
+++ b/crates/core/dlt_tools/src/lib.rs
@@ -153,7 +153,7 @@ mod tests {
                 assert_eq!("test3.txt", files.get(2).unwrap().name);
             }
             Err(error) => {
-                panic!("{}", format!("{error}"));
+                panic!("{error}");
             }
         }
     }
@@ -170,7 +170,7 @@ mod tests {
                 assert_eq!(files.len(), 0);
             }
             Err(error) => {
-                panic!("{}", format!("{error}"));
+                panic!("{error}");
             }
         }
     }
@@ -195,7 +195,7 @@ mod tests {
                 assert_eq!("test2.txt", files.first().unwrap().name);
             }
             Err(error) => {
-                panic!("{}", format!("{error}"));
+                panic!("{error}");
             }
         }
     }
@@ -217,12 +217,12 @@ mod tests {
                         assert_eq!(size, 18);
                     }
                     Err(error) => {
-                        panic!("{}", format!("{error}"));
+                        panic!("{error}");
                     }
                 }
             }
             Err(error) => {
-                panic!("{}", format!("{error}"));
+                panic!("{error}");
             }
         }
 
@@ -246,12 +246,12 @@ mod tests {
                         assert_eq!(size, 0);
                     }
                     Err(error) => {
-                        panic!("{}", format!("{error}"));
+                        panic!("{error}");
                     }
                 }
             }
             Err(error) => {
-                panic!("{}", format!("{error}"));
+                panic!("{error}");
             }
         }
     }
@@ -279,12 +279,12 @@ mod tests {
                         assert_eq!(size, 6);
                     }
                     Err(error) => {
-                        panic!("{}", format!("{error}"));
+                        panic!("{error}");
                     }
                 }
             }
             Err(error) => {
-                panic!("{}", format!("{error}"));
+                panic!("{error}");
             }
         }
 
@@ -309,12 +309,12 @@ mod tests {
                         assert_eq!(size, 6);
                     }
                     Err(error) => {
-                        panic!("{}", format!("{error}"));
+                        panic!("{error}");
                     }
                 }
             }
             Err(error) => {
-                panic!("{}", format!("{error}"));
+                panic!("{error}");
             }
         }
 
@@ -344,12 +344,12 @@ mod tests {
                         assert_eq!(size, 6);
                     }
                     Err(error) => {
-                        panic!("{}", format!("{error}"));
+                        panic!("{error}");
                     }
                 }
             }
             Err(error) => {
-                panic!("{}", format!("{error}"));
+                panic!("{error}");
             }
         }
 

--- a/crates/core/parsers/src/dlt/mod.rs
+++ b/crates/core/parsers/src/dlt/mod.rs
@@ -2,8 +2,8 @@ pub mod attachment;
 pub mod fmt;
 
 use crate::{
-    Error, LogMessage, ParseOutput, ParseYield, SingleParser, dlt::fmt::FormattableMessage,
-    someip::FibexMetadata as FibexSomeipMetadata,
+    Error, LogMessage, ParseOutput, ParseYield, RemainderError, SingleParser,
+    dlt::fmt::FormattableMessage, someip::FibexMetadata as FibexSomeipMetadata,
 };
 use byteorder::{BigEndian, WriteBytesExt};
 use dlt_core::{
@@ -183,6 +183,17 @@ impl<'m> SingleParser for DltParser<'m> {
             }
         }
     }
+
+    fn parse_remaining(
+        &mut self,
+        _input: &[u8],
+        _timestamp: Option<u64>,
+    ) -> Result<Option<ParseYield<FormattableMessage<'m>>>, RemainderError> {
+        // A truncated DLT message can't be completed from the bytes at hand: its header states a
+        // length which those bytes don't reach. Keeping them lets the message parse whole if the
+        // source delivers the rest later.
+        Ok(None)
+    }
 }
 
 impl SingleParser for DltRangeParser {
@@ -210,6 +221,15 @@ impl SingleParser for DltRangeParser {
 
         Ok(item)
     }
+
+    fn parse_remaining(
+        &mut self,
+        _input: &[u8],
+        _timestamp: Option<u64>,
+    ) -> Result<Option<ParseYield<RangeMessage>>, RemainderError> {
+        // The range of a truncated message is unknown until its remaining bytes arrive.
+        Ok(None)
+    }
 }
 
 impl SingleParser for DltRawParser {
@@ -230,5 +250,15 @@ impl SingleParser for DltRawParser {
         let item = ParseOutput::new(total_consumed, msg.map(|m| m.into()));
 
         Ok(item)
+    }
+
+    fn parse_remaining(
+        &mut self,
+        _input: &[u8],
+        _timestamp: Option<u64>,
+    ) -> Result<Option<ParseYield<RawMessage>>, RemainderError> {
+        // Emitting the truncated bytes as a raw message would hand out a message the consumer
+        // can't parse back, so wait for the rest instead.
+        Ok(None)
     }
 }

--- a/crates/core/parsers/src/lib.rs
+++ b/crates/core/parsers/src/lib.rs
@@ -28,6 +28,16 @@ pub enum Error {
     Eof,
 }
 
+/// Why a parser rejected the bytes remaining after the last parse call.
+#[derive(Error, Debug)]
+pub enum RemainderError {
+    /// The bytes will never form an item. Recoverable: the caller resyncs past them.
+    #[error("Parse error: {0}")]
+    Parse(String),
+    #[error("Unrecoverable error, cannot continue: {0}")]
+    Unrecoverable(String),
+}
+
 /// The result of a single parsing step, returned by [`Parser::parse`]
 /// or [`SingleParser::parse_item`] calls.
 #[derive(Debug)]
@@ -87,6 +97,18 @@ pub trait Parser {
         input: &[u8],
         timestamp: Option<u64>,
     ) -> Result<impl Iterator<Item = ParseOutput<Self::Output>>, Error>;
+
+    /// Turns the bytes remaining after the last [`Parser::parse`] call into a final item,
+    /// knowing that no more bytes are coming for them right now.
+    ///
+    /// Returning an item consumes all of `input`. Returning `Ok(None)` -- which is what a parser
+    /// that cannot complete a partial item does -- leaves the bytes untouched, so a parser still
+    /// waiting for the rest of a message gets it if the source resumes.
+    fn parse_remaining(
+        &mut self,
+        input: &[u8],
+        timestamp: Option<u64>,
+    ) -> Result<Option<ParseYield<Self::Output>>, RemainderError>;
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -161,6 +183,16 @@ pub trait SingleParser {
         input: &[u8],
         timestamp: Option<u64>,
     ) -> Result<ParseOutput<Self::Output>, Error>;
+
+    /// Turns the bytes remaining after the last [`SingleParser::parse_item`] call into a final
+    /// item, knowing that no more bytes are coming for them right now.
+    ///
+    /// See [`Parser::parse_remaining`], which the blanket implementation forwards to this method.
+    fn parse_remaining(
+        &mut self,
+        input: &[u8],
+        timestamp: Option<u64>,
+    ) -> Result<Option<ParseYield<Self::Output>>, RemainderError>;
 }
 
 /// A blanket implementation of [`Parser`] for any type that implements [`SingleParser`].
@@ -196,5 +228,13 @@ where
         });
 
         Ok(iter)
+    }
+
+    fn parse_remaining(
+        &mut self,
+        input: &[u8],
+        timestamp: Option<u64>,
+    ) -> Result<Option<ParseYield<Self::Output>>, RemainderError> {
+        SingleParser::parse_remaining(self, input, timestamp)
     }
 }

--- a/crates/core/parsers/src/someip.rs
+++ b/crates/core/parsers/src/someip.rs
@@ -1,4 +1,4 @@
-use crate::{Error, LogMessage, ParseOutput, ParseYield, SingleParser};
+use crate::{Error, LogMessage, ParseOutput, ParseYield, RemainderError, SingleParser};
 use std::{
     borrow::Cow,
     cmp::Ordering,
@@ -343,6 +343,16 @@ impl SingleParser for SomeipParser {
             timestamp,
         )
         .map(|(rest, message)| ParseOutput::new(rest, message.map(ParseYield::from)))
+    }
+
+    fn parse_remaining(
+        &mut self,
+        _input: &[u8],
+        _timestamp: Option<u64>,
+    ) -> Result<Option<ParseYield<SomeipLogMessage>>, RemainderError> {
+        // A SOME/IP message is framed by the length field in its header, so a truncated one can
+        // only be completed by the bytes that are still missing.
+        Ok(None)
     }
 }
 

--- a/crates/core/parsers/src/text.rs
+++ b/crates/core/parsers/src/text.rs
@@ -1,4 +1,4 @@
-use crate::{Error, LogMessage, ParseOutput, ParseYield, SingleParser};
+use crate::{Error, LogMessage, ParseOutput, ParseYield, RemainderError, SingleParser};
 use serde::Serialize;
 use std::{fmt, io::Write};
 
@@ -36,28 +36,41 @@ impl SingleParser for StringTokenizer {
         if input.is_empty() {
             return Ok(ParseOutput::new(input.len(), None));
         }
-        let item = if let Some(msg_size) = memchr(b'\n', input) {
-            let content = String::from_utf8_lossy(&input[..msg_size]);
-            let string_msg = StringMessage {
-                content: content.to_string(),
-            };
-            ParseOutput::new(msg_size + 1, Some(string_msg.into()))
-        } else {
-            let content = String::from_utf8_lossy(input);
-            ParseOutput::new(
-                input.len(),
-                Some(ParseYield::from(StringMessage {
-                    content: content.to_string(),
-                })),
-            )
+        // Without a line break the input is the start of a line and not a line: reporting it as
+        // one would split every line that straddles a source buffer boundary.
+        let Some(msg_size) = memchr(b'\n', input) else {
+            return Err(Error::Incomplete);
         };
 
-        Ok(item)
+        let content = String::from_utf8_lossy(&input[..msg_size]);
+        let string_msg = StringMessage {
+            content: content.into_owned(),
+        };
+
+        let output = ParseOutput::new(msg_size + 1, Some(string_msg.into()));
+
+        Ok(output)
+    }
+
+    fn parse_remaining(
+        &mut self,
+        input: &[u8],
+        _timestamp: Option<u64>,
+    ) -> Result<Option<ParseYield<StringMessage>>, RemainderError> {
+        // No more bytes are coming, so the unterminated line is the last line.
+        let content = String::from_utf8_lossy(input);
+        let string_msg = StringMessage {
+            content: content.into_owned(),
+        };
+
+        Ok(Some(string_msg.into()))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use crate::Parser;
 
     use super::*;
@@ -107,17 +120,26 @@ mod tests {
     }
 
     #[test]
-    fn trailing_line_without_newline() {
+    fn line_without_newline_is_incomplete() {
         let mut parser = StringTokenizer {};
         let content = b"{\"key\":\"value\"}";
 
-        let out = parser.parse_item(content, None).unwrap();
+        let err = parser.parse_item(content, None).unwrap_err();
 
-        match out.message {
+        assert_matches!(err, Error::Incomplete);
+    }
+
+    #[test]
+    fn remainder_becomes_the_last_line() {
+        let mut parser = StringTokenizer {};
+
+        // Both traits are in scope in this module, so the call needs disambiguating.
+        let item = Parser::parse_remaining(&mut parser, b"{\"key\":\"value\"}", None).unwrap();
+
+        match item {
             Some(ParseYield::Message(StringMessage { content }))
                 if content.eq("{\"key\":\"value\"}") => {}
-            _ => panic!("Trailing line did not match"),
+            invalid => panic!("Remainder did not match: {invalid:?}"),
         }
-        assert_eq!(out.consumed, content.len());
     }
 }

--- a/crates/core/plugins_host/src/parser_shared/mod.rs
+++ b/crates/core/plugins_host/src/parser_shared/mod.rs
@@ -179,4 +179,14 @@ impl p::Parser for PluginsParser {
 
         res
     }
+
+    fn parse_remaining(
+        &mut self,
+        input: &[u8],
+        timestamp: Option<u64>,
+    ) -> Result<Option<p::ParseYield<PluginParseMessage>>, p::RemainderError> {
+        match &mut self.parser {
+            PlugVerParser::Ver010(parser) => parser.parse_remaining(input, timestamp),
+        }
+    }
 }

--- a/crates/core/plugins_host/src/v0_1_0/parser/mod.rs
+++ b/crates/core/plugins_host/src/v0_1_0/parser/mod.rs
@@ -168,4 +168,16 @@ impl p::Parser for PluginParser {
             .map(|item| p::ParseOutput::new(item.consumed as usize, item.value.map(|v| v.into())));
         Ok(res)
     }
+
+    fn parse_remaining(
+        &mut self,
+        _input: &[u8],
+        _timestamp: Option<u64>,
+    ) -> Result<Option<p::ParseYield<PluginParseMessage>>, p::RemainderError> {
+        // TODO: Plugin parsers cannot resolve a remainder yet. Supporting it needs a new call in
+        // the WIT parser interface plus the matching bindings here, which is deliberately out of
+        // scope for this change and tracked as separate work. Until then a plugin that tokenizes
+        // lines keeps splitting the last item of a stalled source, exactly as it does today.
+        Ok(None)
+    }
 }

--- a/crates/core/processor/benches/bench_utls.rs
+++ b/crates/core/processor/benches/bench_utls.rs
@@ -96,7 +96,8 @@ where
                 counter.loaded_bytes += bytes_consumed;
                 counter.skipped_bytes += skipped_bytes;
             }
-            processor::producer::ProduceSummary::NoBytesAvailable { skipped_bytes } => {
+            processor::producer::ProduceSummary::NoBytesAvailable { skipped_bytes }
+            | processor::producer::ProduceSummary::PendingRemainder { skipped_bytes } => {
                 counter.skipped_bytes += skipped_bytes;
                 break;
             }

--- a/crates/core/processor/benches/mocks/mock_parser.rs
+++ b/crates/core/processor/benches/mocks/mock_parser.rs
@@ -165,6 +165,15 @@ impl Parser for MockParser<IterOnce> {
 
         Ok(iter::once(item))
     }
+
+    /// The mock source never stalls, so the producer never asks for a remainder here.
+    fn parse_remaining(
+        &mut self,
+        _input: &[u8],
+        _timestamp: Option<u64>,
+    ) -> Result<Option<parsers::ParseYield<MockMessage>>, parsers::RemainderError> {
+        Ok(None)
+    }
 }
 
 // NOTE: Methods within trait implementation have inner non-async function that should never be
@@ -198,5 +207,14 @@ impl Parser for MockParser<IterMany> {
         });
 
         black_box(Ok(res))
+    }
+
+    /// The mock source never stalls, so the producer never asks for a remainder here.
+    fn parse_remaining(
+        &mut self,
+        _input: &[u8],
+        _timestamp: Option<u64>,
+    ) -> Result<Option<parsers::ParseYield<MockMessage>>, parsers::RemainderError> {
+        Ok(None)
     }
 }

--- a/crates/core/processor/benches/mocks/mock_source.rs
+++ b/crates/core/processor/benches/mocks/mock_source.rs
@@ -58,6 +58,18 @@ impl ByteSource for MockByteSource {
     }
 
     #[inline(always)]
+    fn can_buffer_more(&self) -> bool {
+        #[inline(never)]
+        fn inner() -> bool {
+            const CAN_BUFFER: bool = true;
+
+            black_box(CAN_BUFFER)
+        }
+
+        inner()
+    }
+
+    #[inline(always)]
     async fn load(
         &mut self,
         _filter: Option<&sources::SourceFilter>,

--- a/crates/core/processor/src/export/mod.rs
+++ b/crates/core/processor/src/export/mod.rs
@@ -81,36 +81,44 @@ where
             if cancel.is_cancelled() {
                 return Err(ExportError::Cancelled);
             }
-            match producer.produce_next(&mut collector).await {
-                Ok(ProduceSummary::Processed { .. }) => {
-                    for item in collector.get_records().drain(..) {
-                        let written = match item {
-                            ParseYield::Message(msg) => {
-                                msg.to_writer(&mut out_writer)?;
-                                true
-                            }
-                            ParseYield::MessageAndAttachment((msg, _)) => {
-                                msg.to_writer(&mut out_writer)?;
-                                true
-                            }
-                            _ => false,
-                        };
-                        if written && text_file {
-                            out_writer.write_all("\n".as_bytes())?;
-                        }
-                        if written {
-                            exported += 1;
-                        }
-                    }
+            let last_round = match producer.produce_next(&mut collector).await {
+                Ok(ProduceSummary::Processed { .. }) => false,
+                Ok(ProduceSummary::PendingRemainder { .. }) => {
+                    resolve_remainder(&mut producer, &mut collector);
+                    true
                 }
                 Ok(ProduceSummary::Done { .. } | ProduceSummary::NoBytesAvailable { .. }) => {
                     debug!("No more messages to export");
-                    return Ok(exported);
+                    true
                 }
                 Err(err) => {
                     log::error!("Error while raw export: {err:?}");
                     return Err(ExportError::Producer(err));
                 }
+            };
+
+            for item in collector.get_records().drain(..) {
+                let written = match item {
+                    ParseYield::Message(msg) => {
+                        msg.to_writer(&mut out_writer)?;
+                        true
+                    }
+                    ParseYield::MessageAndAttachment((msg, _)) => {
+                        msg.to_writer(&mut out_writer)?;
+                        true
+                    }
+                    _ => false,
+                };
+                if written && text_file {
+                    out_writer.write_all("\n".as_bytes())?;
+                }
+                if written {
+                    exported += 1;
+                }
+            }
+
+            if last_round {
+                return Ok(exported);
             }
         }
     }
@@ -120,81 +128,119 @@ where
             return Err(ExportError::Cancelled);
         }
 
-        match producer.produce_next(&mut collector).await {
-            Ok(ProduceSummary::Processed { .. }) => {
-                for item in collector.get_records().drain(..) {
-                    if !inside {
-                        if sections[section_index].first_line == current_index {
-                            inside = true;
-                        }
-                    } else if sections[section_index].last_line < current_index {
-                        inside = false;
-                        section_index += 1;
-                        if sections.len() <= section_index {
-                            // no more sections
-                            current_index += 1;
-                            break 'outer;
-                        }
-                        // check if we are in next section again
-                        if sections[section_index].first_line == current_index {
-                            inside = true;
-                        }
-                    }
-                    let written = match item {
-                        ParseYield::Message(msg) => {
-                            if inside {
-                                msg.to_writer(&mut out_writer)?;
-                            }
-                            current_index += 1;
-                            inside
-                        }
-                        ParseYield::MessageAndAttachment((msg, _)) => {
-                            if inside {
-                                msg.to_writer(&mut out_writer)?;
-                            }
-                            current_index += 1;
-                            inside
-                        }
-                        _ => false,
-                    };
-                    if written && text_file {
-                        out_writer.write_all("\n".as_bytes())?;
-                    }
-                }
+        let last_round = match producer.produce_next(&mut collector).await {
+            Ok(ProduceSummary::Processed { .. }) => false,
+            Ok(ProduceSummary::PendingRemainder { .. }) => {
+                resolve_remainder(&mut producer, &mut collector);
+                true
             }
             Ok(ProduceSummary::Done { .. } | ProduceSummary::NoBytesAvailable { .. }) => {
                 debug!("No more messages to export");
-                break 'outer;
+                true
             }
             Err(err) => {
                 log::error!("Error while raw export: {err:?}");
 
                 return Err(ExportError::Producer(err));
             }
+        };
+
+        for item in collector.get_records().drain(..) {
+            if !inside {
+                if sections[section_index].first_line == current_index {
+                    inside = true;
+                }
+            } else if sections[section_index].last_line < current_index {
+                inside = false;
+                section_index += 1;
+                if sections.len() <= section_index {
+                    // no more sections
+                    current_index += 1;
+                    break 'outer;
+                }
+                // check if we are in next section again
+                if sections[section_index].first_line == current_index {
+                    inside = true;
+                }
+            }
+            let written = match item {
+                ParseYield::Message(msg) => {
+                    if inside {
+                        msg.to_writer(&mut out_writer)?;
+                    }
+                    current_index += 1;
+                    inside
+                }
+                ParseYield::MessageAndAttachment((msg, _)) => {
+                    if inside {
+                        msg.to_writer(&mut out_writer)?;
+                    }
+                    current_index += 1;
+                    inside
+                }
+                _ => false,
+            };
+            if written && text_file {
+                out_writer.write_all("\n".as_bytes())?;
+            }
+        }
+
+        if last_round {
+            break 'outer;
         }
     }
     if read_to_end {
-        'outer: loop {
+        loop {
             if cancel.is_cancelled() {
                 return Err(ExportError::Cancelled);
             }
 
-            match producer.produce_next(&mut collector).await {
-                Ok(ProduceSummary::Processed { .. }) => {
-                    current_index += 1;
+            let last_round = match producer.produce_next(&mut collector).await {
+                Ok(ProduceSummary::Processed { .. }) => false,
+                Ok(ProduceSummary::PendingRemainder { .. }) => {
+                    resolve_remainder(&mut producer, &mut collector);
+                    true
                 }
-                Ok(ProduceSummary::Done { .. } | ProduceSummary::NoBytesAvailable { .. }) => {
-                    break 'outer;
-                }
+                Ok(ProduceSummary::Done { .. } | ProduceSummary::NoBytesAvailable { .. }) => true,
                 Err(err) => {
                     log::error!("Error while raw export: {err:?}");
                     return Err(ExportError::Producer(err));
                 }
+            };
+
+            // Nothing is written past the last section, only counted, but the records still have
+            // to be dropped each round: they are never drained otherwise and would pile up until
+            // the end of the file. Attachments don't count as lines, same as in the loop above.
+            current_index += collector
+                .get_records()
+                .drain(..)
+                .filter(|item| {
+                    matches!(
+                        item,
+                        ParseYield::Message(_) | ParseYield::MessageAndAttachment(_)
+                    )
+                })
+                .count();
+
+            if last_round {
+                break;
             }
         }
     }
     debug!("export_raw done ({current_index} messages)");
     Ok(current_index)
+}
+
+/// Lets the parser close the item it is still holding: exports never tail, so a stalled source
+/// is the end of the input here.
+fn resolve_remainder<P: Parser, D: ByteSource>(
+    producer: &mut MessageProducer<P, D>,
+    collector: &mut GeneralLogCollector<P::Output>,
+) {
+    if let Err(err) = producer.process_remaining(collector) {
+        // The trailing bytes are unusable, but everything before them has been exported.
+        log::error!("Error while resolving the remaining bytes: {err}");
+    }
 }
 
 fn sections_valid(sections: &[IndexSection]) -> bool {

--- a/crates/core/processor/src/map.rs
+++ b/crates/core/processor/src/map.rs
@@ -25,7 +25,7 @@ impl FiltersStats {
     }
 
     pub fn increment(&mut self, alias: impl Into<String>, value: Option<u64>) {
-        *self.stats.entry(alias.into()).or_insert(0) += value.map_or(1, |v| v);
+        *self.stats.entry(alias.into()).or_insert(0) += value.unwrap_or(1);
     }
 }
 
@@ -201,8 +201,8 @@ impl SearchMap {
     }
 
     pub fn set(&mut self, matches: Option<Vec<stypes::FilterMatch>>, stats: Option<FiltersStats>) {
-        self.matches = matches.map_or(vec![], |m| m);
-        self.stats = stats.map_or(FiltersStats::default(), |s| s);
+        self.matches = matches.unwrap_or_default();
+        self.stats = stats.unwrap_or_default();
     }
 
     pub fn append(&mut self, matches: &mut Vec<stypes::FilterMatch>) -> usize {

--- a/crates/core/processor/src/producer/mod.rs
+++ b/crates/core/processor/src/producer/mod.rs
@@ -4,7 +4,7 @@
 mod tests;
 
 use log::warn;
-use parsers::{Error as ParserError, ParseOutput, Parser};
+use parsers::{Error as ParserError, ParseOutput, ParseYield, Parser, RemainderError};
 use sources::{ByteSource, ReloadInfo, SourceFilter};
 
 mod logs_collector;
@@ -32,6 +32,13 @@ pub enum ProduceSummary {
     },
     /// No more bytes are available in the byte-source currently.
     NoBytesAvailable {
+        /// The amount of skipped bytes in the last `produce_next()` call
+        skipped_bytes: usize,
+    },
+    /// The parser is holding an incomplete item and the byte-source delivered nothing.
+    /// The bytes are kept: the caller must either wait for more data and produce again, or call
+    /// [`MessageProducer::process_remaining()`] to let the parser resolve them.
+    PendingRemainder {
         /// The amount of skipped bytes in the last `produce_next()` call
         skipped_bytes: usize,
     },
@@ -89,6 +96,10 @@ pub enum ProcessOutcome {
     /// The parser needs more bytes. Call [`MessageProducer::fetch()`] again, then
     /// [`MessageProducer::process()`] again.
     NeedMoreBytes,
+    /// The parser is holding an incomplete item and the source delivered nothing this round.
+    /// The bytes are kept: the caller must either wait for more data and fetch again, or call
+    /// [`MessageProducer::process_remaining()`] to let the parser resolve them.
+    PendingRemainder,
     /// No bytes are available in the source right now. The caller decides whether that
     /// means "wait for more" (tailing) or "stop".
     NoData,
@@ -325,9 +336,53 @@ impl<P: Parser, D: ByteSource> MessageProducer<P, D> {
                         return Ok(ProcessOutcome::NeedMoreBytes);
                     }
 
-                    trace!("No bytes has been loaded on last fetch, dropping one byte");
-                    self.drop_one_byte();
-                    skipped_bytes += DROP_STEP;
+                    // Nothing arrived this round. As long as the source could still deliver into
+                    // its buffer, the bytes we hold are the start of an item and dropping them
+                    // destroys data.
+                    if self.byte_source.can_buffer_more() {
+                        trace!("Source stalled while the parser holds an incomplete item");
+
+                        return Ok(ProcessOutcome::PendingRemainder);
+                    }
+
+                    // The buffer can't grow, so waiting would stall forever: the remainder has to
+                    // be resolved now. A parser that can turn it into an item gets to, the rest
+                    // resync as before.
+                    match self
+                        .parser
+                        .parse_remaining(self.byte_source.current_slice(), self.last_seen_ts)
+                    {
+                        Ok(Some(item)) => {
+                            let bytes_consumed = self.take_whole_buffer(item, collector);
+
+                            return Ok(ProcessOutcome::Parsed {
+                                bytes_consumed,
+                                messages_count: 1,
+                                skipped_bytes,
+                            });
+                        }
+                        Ok(None) => {
+                            trace!(
+                                "Buffer is full and the remainder is unresolvable, dropping one byte"
+                            );
+                            self.drop_one_byte();
+                            skipped_bytes += DROP_STEP;
+                        }
+                        // The parser rejected these bytes on their own terms: funnel into the
+                        // existing resync path so the message is delivered once the source
+                        // proves it is dry.
+                        Err(RemainderError::Parse(msg)) => {
+                            self.status = ProducerStatus::ParserErrored { msg };
+                            self.drop_one_byte();
+                            skipped_bytes += DROP_STEP;
+                        }
+                        Err(RemainderError::Unrecoverable(msg)) => {
+                            error!("Parsing the remaining bytes failed: Error {msg}");
+                            self.status = ProducerStatus::Done;
+
+                            return Err(ProcessError::Unrecoverable(msg));
+                        }
+                    }
                 }
                 Err(ParserError::Eof) => {
                     trace!("EOF reached...no more messages (skipped_bytes={skipped_bytes})");
@@ -401,6 +456,64 @@ impl<P: Parser, D: ByteSource> MessageProducer<P, D> {
         }
     }
 
+    /// Gives the parser a chance to turn the bytes it is still holding into a final item, for a
+    /// caller that knows no more bytes are coming right now.
+    ///
+    /// Bytes are consumed only if an item was produced: a parser that can't complete a partial
+    /// item keeps its pending bytes, so a source that resumes later (a growing file) still
+    /// completes them.
+    ///
+    /// # Return:
+    /// The number of items appended to `collector`, or the parser's rejection of the remainder.
+    pub fn process_remaining<C: LogRecordsCollector<P::Output>>(
+        &mut self,
+        collector: &mut C,
+    ) -> Result<usize, ProcessError> {
+        if self.is_done() || self.byte_source.is_empty() {
+            return Ok(0);
+        }
+
+        match self
+            .parser
+            .parse_remaining(self.byte_source.current_slice(), self.last_seen_ts)
+        {
+            Ok(Some(item)) => {
+                self.take_whole_buffer(item, collector);
+
+                Ok(1)
+            }
+            // Keep the bytes: a stalled source is not proof that the source is finished, and
+            // discarding them would make the parser resume in the middle of an item.
+            Ok(None) => Ok(0),
+            Err(RemainderError::Parse(msg)) => Err(ProcessError::Parse(msg)),
+            Err(RemainderError::Unrecoverable(msg)) => {
+                self.status = ProducerStatus::Done;
+
+                Err(ProcessError::Unrecoverable(msg))
+            }
+        }
+    }
+
+    /// Appends the parser's resolution of the bytes it was holding to the `collector`, consuming
+    /// all of them: a remainder item covers the whole buffer by definition.
+    ///
+    /// # Return:
+    /// The number of bytes consumed from the byte source.
+    fn take_whole_buffer<C: LogRecordsCollector<P::Output>>(
+        &mut self,
+        item: ParseYield<P::Output>,
+        collector: &mut C,
+    ) -> usize {
+        let bytes_consumed = self.byte_source.current_slice().len();
+        self.byte_source.consume(bytes_consumed);
+        self.total_messages += 1;
+        // The parser made sense of these bytes, so a remembered parse error is stale.
+        self.status = ProducerStatus::Running;
+        collector.append(item);
+
+        bytes_consumed
+    }
+
     /// Drops [`DROP_STEP`] bytes from the bytes available in the byte source, counting them as
     /// skipped, in order to resync the parser on the remaining bytes.
     fn drop_one_byte(&mut self) {
@@ -424,6 +537,11 @@ impl<P: Parser, D: ByteSource> MessageProducer<P, D> {
     /// Cancel safe by construction: the only await points are [`Self::fetch()`] calls, and
     /// every effect of a [`Self::process()`] call is committed to the producer, the byte source
     /// and the collector before the next await.
+    ///
+    /// # Note:
+    /// A pending remainder is never resolved here. This method is meant to sit on a `select!`
+    /// arm, where "no bytes right now" doesn't imply "no bytes ever": only the caller knows,
+    /// and it resolves the remainder with [`Self::process_remaining()`].
     ///
     /// # Return:
     /// Summary of producer state with infos about consumed, skipped bytes and produced log
@@ -458,6 +576,9 @@ impl<P: Parser, D: ByteSource> MessageProducer<P, D> {
                     return Ok(summary);
                 }
                 ProcessOutcome::NeedMoreBytes => continue,
+                ProcessOutcome::PendingRemainder => {
+                    return Ok(ProduceSummary::PendingRemainder { skipped_bytes });
+                }
                 ProcessOutcome::NoData => {
                     return Ok(ProduceSummary::NoBytesAvailable { skipped_bytes });
                 }

--- a/crates/core/processor/src/producer/mod.rs
+++ b/crates/core/processor/src/producer/mod.rs
@@ -1,3 +1,5 @@
+//! Connects a [`ByteSource`] with a [`Parser`], driving the ingestion pipeline of a session.
+
 #[cfg(test)]
 mod tests;
 
@@ -11,6 +13,9 @@ pub use logs_collector::{GeneralLogCollector, LogRecordsCollector};
 
 /// Number of bytes to skip on initial parse errors before terminating the session.
 const INITIAL_PARSE_ERROR_LIMIT: usize = 1024;
+
+/// Number of bytes dropped on each resync attempt after the parser rejected the current bytes.
+const DROP_STEP: usize = 1;
 
 /// Represents the producer state and processing infos after calling `produce_next()`
 /// on messages producer.
@@ -55,6 +60,78 @@ pub enum ProduceError {
     Parse(String),
 }
 
+/// Info about the bytes that a [`MessageProducer::fetch()`] call made available.
+///
+/// Deliberately not `Clone`, `Copy` or constructible outside this module: the only way to get
+/// one is [`MessageProducer::fetch()`], and [`MessageProducer::process()`] consumes it by value.
+/// That makes "process bytes only after fetching them, at most once per fetch" a fact the
+/// compiler checks rather than a convention documented on the two methods.
+#[derive(Debug)]
+pub struct FetchInfo {
+    /// Bytes newly loaded into the source buffer by this call.
+    newly_loaded_bytes: usize,
+    /// Bytes the source had to skip to reach usable data.
+    skipped_bytes: usize,
+}
+
+/// Result of a [`MessageProducer::process()`] call.
+#[derive(Debug)]
+pub enum ProcessOutcome {
+    /// Bytes were parsed and the items appended to the collector.
+    Parsed {
+        /// Total number of bytes consumed from the input buffer.
+        bytes_consumed: usize,
+        /// Number of messages that were parsed and appended to logs collector.
+        messages_count: usize,
+        /// Bytes skipped by the parser or dropped while resyncing.
+        skipped_bytes: usize,
+    },
+    /// The parser needs more bytes. Call [`MessageProducer::fetch()`] again, then
+    /// [`MessageProducer::process()`] again.
+    NeedMoreBytes,
+    /// No bytes are available in the source right now. The caller decides whether that
+    /// means "wait for more" (tailing) or "stop".
+    NoData,
+    /// The parser signalled end of data. The producer is finished and will stay finished.
+    Done,
+}
+
+/// Represents Error types which could occur during [`MessageProducer::process()`] call.
+#[derive(Debug, thiserror::Error)]
+pub enum ProcessError {
+    /// Unrecoverable error. Producer can't be used anymore.
+    #[error("Unrecoverable Producer Error: {0}")]
+    Unrecoverable(String),
+    /// Parsing error (Recoverable) from the underlying parser.
+    #[error("Parsing Error: {0}")]
+    Parse(String),
+}
+
+impl From<ProcessError> for ProduceError {
+    fn from(value: ProcessError) -> Self {
+        match value {
+            ProcessError::Unrecoverable(msg) => ProduceError::Unrecoverable(msg),
+            ProcessError::Parse(msg) => ProduceError::Parse(msg),
+        }
+    }
+}
+
+/// The producer's current status: exactly one of running, resyncing after a rejected parse, or
+/// finished.
+#[derive(Debug, Default)]
+enum ProducerStatus {
+    /// Parsing normally.
+    #[default]
+    Running,
+    /// The parser rejected the current bytes; kept so it can be delivered once the byte source
+    /// proves it has nothing more to give.
+    ParserErrored { msg: String },
+    /// End of data or an unrecoverable error. No more loading or parsing will happen.
+    Done,
+}
+
+/// Produces parsed log items by feeding the bytes of a [`ByteSource`] into a [`Parser`],
+/// keeping track of the totals of the running session.
 #[derive(Debug)]
 pub struct MessageProducer<P, D>
 where
@@ -68,11 +145,14 @@ where
     total_loaded: usize,
     total_skipped: usize,
     total_messages: usize,
-    done: bool,
+    /// Bytes dropped while resyncing the parser, which is the budget the
+    /// [`INITIAL_PARSE_ERROR_LIMIT`] guard spends.
+    total_dropped: usize,
+    status: ProducerStatus,
 }
 
 impl<P: Parser, D: ByteSource> MessageProducer<P, D> {
-    /// create a new producer by plugging into a byte source
+    /// Creates a new producer by plugging the given parser into the given byte source.
     pub fn new(parser: P, source: D) -> Self {
         MessageProducer {
             byte_source: source,
@@ -82,153 +162,39 @@ impl<P: Parser, D: ByteSource> MessageProducer<P, D> {
             total_loaded: 0,
             total_skipped: 0,
             total_messages: 0,
-            done: false,
+            total_dropped: 0,
+            status: ProducerStatus::default(),
         }
     }
 
-    /// Loads the next segment of bytes, parses them, and append them to the provided
-    /// [`LogRecordsCollector`].
+    /// Whether the producer is finished: no more loading or parsing will happen.
+    #[inline]
+    fn is_done(&self) -> bool {
+        matches!(self.status, ProducerStatus::Done)
+    }
+
+    /// Loads the next segment of bytes from the byte source into its internal buffer.
+    ///
+    /// This is the loading half of the producer. It never parses and never touches the logs
+    /// collector: use [`Self::process()`] for that.
     ///
     /// # Cancel Safety:
-    /// This function is cancel safe as long [`ByteSource::load()`] method on used byte source is
-    /// safe as well.
+    /// This is the only awaiting step of the producer and it is cancel safe as long as
+    /// [`ByteSource::load()`] is (the trait requires it). Dropping this future loses no bytes:
+    /// everything loaded lives in the source's internal buffer.
     ///
     /// # Return:
-    /// Summary of producer state with infos about consumed, skipped bytes and produced log
-    /// messages, otherwise it'll return a producer error.
-    pub async fn produce_next<C: LogRecordsCollector<P::Output>>(
-        &mut self,
-        collector: &mut C,
-    ) -> Result<ProduceSummary, ProduceError> {
-        // ### Cancel Safety ###:
-        // This function is cancel safe because:
-        // * there is no await calls or any function causing yielding between filling the internal
-        //   buffer and returning it.
-        // * Byte source will keep the loaded data in its internal buffer ensuring there
-        //   is no data loss when cancelling happen between load calls.
-
-        if self.done {
-            debug!("done...no next segment");
-            return Ok(self.final_report());
+    /// Infos about the bytes this call made available, or the error of the underlying byte
+    /// source on fail.
+    pub async fn fetch(&mut self) -> Result<FetchInfo, sources::Error> {
+        // A finished producer must stay finished and must never touch the source again.
+        if self.is_done() {
+            return Ok(FetchInfo {
+                newly_loaded_bytes: 0,
+                skipped_bytes: 0,
+            });
         }
-        let (_newly_loaded, mut skipped_bytes) = self.load().await?;
 
-        loop {
-            let current_slice = self.byte_source.current_slice();
-            debug!(
-                "current slice: (len: {}) (total {})",
-                current_slice.len(),
-                self.total_loaded
-            );
-
-            let mut available = current_slice.len();
-            if available == 0 {
-                trace!("No more bytes available from source");
-
-                return Ok(ProduceSummary::NoBytesAvailable { skipped_bytes });
-            }
-
-            let mut bytes_consumed = 0;
-            let mut messages_count = 0;
-
-            match self
-                .parser
-                .parse(self.byte_source.current_slice(), self.last_seen_ts)
-                .map(|iter| {
-                    iter.for_each(|item| match item {
-                        ParseOutput{consumed, message: Some(m)} => {
-                            let total_used_bytes = consumed + skipped_bytes;
-                            debug!(
-                            "Extracted a valid message, consumed {consumed} bytes (total used {total_used_bytes} bytes)"
-                            );
-                            bytes_consumed += consumed;
-                            messages_count += 1;
-                            collector.append(m);
-                        }
-                        ParseOutput{consumed: skipped, message: None} => {
-                            bytes_consumed += skipped;
-                            skipped_bytes += skipped;
-                            trace!("None, consumed {skipped} bytes");
-                        }
-                    })
-                }) {
-                Ok(()) => {
-                    self.byte_source.consume(bytes_consumed);
-                    self.total_messages += messages_count;
-
-                    return Ok(ProduceSummary::Processed { bytes_consumed, messages_count, skipped_bytes });
-                }
-                Err(ParserError::Incomplete) => {
-                    trace!("not enough bytes to parse a message. Load more data");
-                    let (newly_loaded, skipped) = self.load().await?;
-
-                    if newly_loaded > 0 {
-                        trace!("New bytes has been loaded, trying parsing again.");
-                        skipped_bytes += skipped;
-                    } else {
-                        trace!("No bytes has been loaded, drop one byte if available or load");
-
-                        if !self.drop_and_load(&mut available, &mut skipped_bytes).await? {
-                            trace!(
-                                "No available bytes after drop and load"
-                            );
-
-                            return Ok(ProduceSummary::NoBytesAvailable { skipped_bytes });
-                        }
-                    }
-                }
-                Err(ParserError::Eof) => {
-                    trace!("EOF reached...no more messages (skipped_bytes={skipped_bytes})");
-                    self.done = true;
-
-                    return Ok(self.final_report());
-                }
-                Err(ParserError::Parse(s)) => {
-                    // TODO: This is temporary solution. We need to inform the user each time we
-                    // hit the `INITIAL_PARSE_ERROR_LIMIT` and not break the session.
-                    // We may need the new item `MessageStreamItem::Skipped(bytes_count)`
-                    //
-                    // Return early when initial parse calls fail after consuming one megabyte.
-                    // This can happen when provided bytes aren't suitable for the select parser.
-                    // In such case we close the session directly to avoid having unresponsive
-                    // state while parse is calling on each skipped byte in the source.
-                    if !self.did_produce_items() && skipped_bytes > INITIAL_PARSE_ERROR_LIMIT {
-                        let err_msg = format!("Aborting session due to failing initial parse call with the error: {s}");
-                        warn!("{err_msg}");
-
-                        self.done = true;
-
-                        return Err(ProduceError::Unrecoverable(err_msg));
-                    }
-
-                    trace!("No parse possible, skip one byte and retry. Error: {s}");
-                    if self.drop_and_load(&mut available, &mut skipped_bytes).await? {
-                        continue;
-                    } else {
-                        trace!(
-                            "Return the last error parse as no available bytes after drop and load"
-                        );
-
-                        return Err(ProduceError::Parse(s));
-                    }
-                }
-                Err(ParserError::Unrecoverable(err)) => {
-                    error!("Parsing failed: Error {err}");
-                    self.done = true;
-
-                    return Err(ProduceError::Unrecoverable(err));
-                }
-            }
-        }
-    }
-
-    /// Calls load on the underline byte source filling it with more bytes.
-    /// Returning information about the state of the byte counts on success, or the
-    /// corresponding source error on fail.
-    ///
-    /// # Return:
-    /// Result<(newly_loaded_bytes, skipped_bytes), sources::Error>
-    async fn load(&mut self) -> Result<(usize, usize), sources::Error> {
         match self.byte_source.load(self.filter.as_ref()).await? {
             Some(ReloadInfo {
                 newly_loaded_bytes,
@@ -241,54 +207,263 @@ impl<P: Parser, D: ByteSource> MessageProducer<P, D> {
                 if let Some(ts) = last_known_ts {
                     self.last_seen_ts = Some(ts);
                 }
+
                 trace!(
-                    "did a do_reload, skipped {} bytes, loaded {} more bytes (total loaded and skipped: {})",
-                    skipped_bytes,
-                    newly_loaded_bytes,
+                    "did a do_reload, skipped {skipped_bytes} bytes, loaded {newly_loaded_bytes} more bytes (total loaded and skipped: {})",
                     self.total_loaded + self.total_skipped
                 );
-                Ok((newly_loaded_bytes, skipped_bytes))
+
+                let info = FetchInfo {
+                    newly_loaded_bytes,
+                    skipped_bytes,
+                };
+
+                Ok(info)
             }
             None => {
                 trace!("byte_source.reload result was None");
-                Ok((0, 0))
+
+                let info = FetchInfo {
+                    newly_loaded_bytes: 0,
+                    skipped_bytes: 0,
+                };
+
+                Ok(info)
             }
         }
     }
 
-    /// Drops one byte from the available bytes and loads more bytes if no more bytes are
-    /// available.
+    /// Parses the bytes currently held by the byte source and appends the produced items to the
+    /// given `collector`.
     ///
-    /// # Note:
-    /// This function is intended for internal use in producer loop only.
+    /// This is the parsing half of the producer. It never loads: when it needs more bytes it
+    /// says so with [`ProcessOutcome::NeedMoreBytes`] and the caller must run [`Self::fetch()`]
+    /// again to obtain a new `fetch_info` before calling this method again.
     ///
     /// # Return:
-    /// `true` when there are available bytes to be parsed, otherwise it'll return `false`
-    /// indicating that the session should be terminated.
-    async fn drop_and_load(
+    /// The outcome of the parse attempt, or a producer error.
+    pub fn process<C: LogRecordsCollector<P::Output>>(
         &mut self,
-        available: &mut usize,
-        skipped_bytes: &mut usize,
-    ) -> Result<bool, sources::Error> {
-        if *available > 0 {
-            trace!("Dropping one byte from loaded ones.");
-            const DROP_STEP: usize = 1;
-            *available -= DROP_STEP;
-            *skipped_bytes += DROP_STEP;
-            self.byte_source.consume(DROP_STEP);
+        fetch_info: FetchInfo,
+        collector: &mut C,
+    ) -> Result<ProcessOutcome, ProcessError> {
+        if self.is_done() {
+            debug!("done...no next segment");
 
-            // we still have bytes -> call parse on the remaining bytes without loading.
-            if *available > 0 {
-                return Ok(true);
-            }
+            return Ok(ProcessOutcome::Done);
         }
 
-        // Load more bytes.
-        trace!("No more bytes are available. Loading more bytes");
-        let (newly_loaded, skipped) = self.load().await?;
-        *available = self.byte_source.len();
-        *skipped_bytes += skipped;
-        Ok(newly_loaded > 0)
+        // Bytes skipped within this call: reported by the parser plus the ones dropped while
+        // resyncing after a parse error.
+        let mut skipped_bytes = 0;
+
+        loop {
+            let available = self.byte_source.current_slice().len();
+            debug!(
+                "current slice: (len: {available}) (total {})",
+                self.total_loaded
+            );
+
+            if available == 0 {
+                // The buffer is dry, either on entry or because resyncing dropped its last byte.
+                return self.on_empty_buffer(fetch_info.newly_loaded_bytes);
+            }
+
+            let mut bytes_consumed = 0;
+            let mut messages_count = 0;
+            let mut parser_skipped = 0;
+
+            match self
+                .parser
+                .parse(self.byte_source.current_slice(), self.last_seen_ts)
+                .map(|iter| {
+                    iter.for_each(|item| match item {
+                        ParseOutput {
+                            consumed,
+                            message: Some(m),
+                        } => {
+                            debug!("Extracted a valid message, consumed {consumed} bytes");
+                            bytes_consumed += consumed;
+                            messages_count += 1;
+                            collector.append(m);
+                        }
+                        ParseOutput {
+                            consumed: skipped,
+                            message: None,
+                        } => {
+                            bytes_consumed += skipped;
+                            parser_skipped += skipped;
+                            trace!("None, consumed {skipped} bytes");
+                        }
+                    })
+                }) {
+                Ok(()) => {
+                    self.byte_source.consume(bytes_consumed);
+                    self.total_messages += messages_count;
+                    self.total_skipped += parser_skipped;
+                    skipped_bytes += parser_skipped;
+                    self.status = ProducerStatus::Running;
+
+                    let parsed = ProcessOutcome::Parsed {
+                        bytes_consumed,
+                        messages_count,
+                        skipped_bytes,
+                    };
+
+                    return Ok(parsed);
+                }
+                Err(ParserError::Incomplete) => {
+                    // The parser is asking for more bytes rather than rejecting them, so any
+                    // remembered parse error is stale and must not be delivered later on.
+                    self.status = ProducerStatus::Running;
+
+                    // The last fetch delivered bytes and the parser still needs more of them:
+                    // let the caller load again instead of destroying data by dropping bytes.
+                    if fetch_info.newly_loaded_bytes > 0 {
+                        trace!("not enough bytes to parse a message. More data must be loaded");
+
+                        return Ok(ProcessOutcome::NeedMoreBytes);
+                    }
+
+                    trace!("No bytes has been loaded on last fetch, dropping one byte");
+                    self.drop_one_byte();
+                    skipped_bytes += DROP_STEP;
+                }
+                Err(ParserError::Eof) => {
+                    trace!("EOF reached...no more messages (skipped_bytes={skipped_bytes})");
+                    self.status = ProducerStatus::Done;
+
+                    return Ok(ProcessOutcome::Done);
+                }
+                Err(ParserError::Parse(err_msg)) => {
+                    // TODO: This is temporary solution. We need to inform the user each time we
+                    // hit the `INITIAL_PARSE_ERROR_LIMIT` and not break the session.
+                    // We may need the new item `MessageStreamItem::Skipped(bytes_count)`
+                    //
+                    // Return early when initial parse calls fail after dropping one megabyte.
+                    // This can happen when provided bytes aren't suitable for the select parser.
+                    // In such case we close the session directly to avoid having unresponsive
+                    // state while parse is calling on each dropped byte in the source.
+                    if !self.did_produce_items() && self.total_dropped > INITIAL_PARSE_ERROR_LIMIT {
+                        let abort_msg = format!(
+                            "Aborting session due to failing initial parse call with the error: {err_msg}"
+                        );
+                        warn!("{abort_msg}");
+
+                        self.status = ProducerStatus::Done;
+
+                        return Err(ProcessError::Unrecoverable(abort_msg));
+                    }
+
+                    trace!("No parse possible, skip one byte and retry. Error: {err_msg}");
+                    // Remember the error: it must be delivered when the source runs dry.
+                    self.status = ProducerStatus::ParserErrored { msg: err_msg };
+                    self.drop_one_byte();
+                    skipped_bytes += DROP_STEP;
+                }
+                Err(ParserError::Unrecoverable(err)) => {
+                    error!("Parsing failed: Error {err}");
+                    self.status = ProducerStatus::Done;
+
+                    return Err(ProcessError::Unrecoverable(err));
+                }
+            }
+        }
+    }
+
+    /// Resolves the outcome of [`Self::process()`] when the byte source holds no bytes,
+    /// delivering a parse error that couldn't be surfaced while resyncing, if any.
+    ///
+    /// `newly_loaded_bytes` is the count from the [`FetchInfo`] that preceded this call.
+    fn on_empty_buffer(
+        &mut self,
+        newly_loaded_bytes: usize,
+    ) -> Result<ProcessOutcome, ProcessError> {
+        trace!("No more bytes available from source");
+
+        match std::mem::take(&mut self.status) {
+            ProducerStatus::Running => Ok(ProcessOutcome::NoData),
+            ProducerStatus::ParserErrored { msg } if newly_loaded_bytes > 0 => {
+                // The source is still delivering: keep the error pending and give resyncing
+                // another chance with freshly loaded bytes.
+                self.status = ProducerStatus::ParserErrored { msg };
+
+                Ok(ProcessOutcome::NeedMoreBytes)
+            }
+            ProducerStatus::ParserErrored { msg } => {
+                trace!("Return the last parse error as no bytes are available anymore");
+
+                Err(ProcessError::Parse(msg))
+            }
+            ProducerStatus::Done => {
+                unreachable!("process() returns before reaching an empty buffer while done")
+            }
+        }
+    }
+
+    /// Drops [`DROP_STEP`] bytes from the bytes available in the byte source, counting them as
+    /// skipped, in order to resync the parser on the remaining bytes.
+    fn drop_one_byte(&mut self) {
+        self.byte_source.consume(DROP_STEP);
+        self.total_skipped += DROP_STEP;
+        self.total_dropped += DROP_STEP;
+
+        trace!(
+            "Dropped {DROP_STEP} byte while resyncing, {} bytes remaining",
+            self.byte_source.len()
+        );
+    }
+
+    /// Loads the next segment of bytes, parses them, and append them to the provided
+    /// [`LogRecordsCollector`].
+    ///
+    /// This is a convenience wrapper around [`Self::fetch()`] and [`Self::process()`] for
+    /// callers that don't need to interleave other work between the two steps.
+    ///
+    /// # Cancel Safety:
+    /// Cancel safe by construction: the only await points are [`Self::fetch()`] calls, and
+    /// every effect of a [`Self::process()`] call is committed to the producer, the byte source
+    /// and the collector before the next await.
+    ///
+    /// # Return:
+    /// Summary of producer state with infos about consumed, skipped bytes and produced log
+    /// messages, otherwise it'll return a producer error.
+    pub async fn produce_next<C: LogRecordsCollector<P::Output>>(
+        &mut self,
+        collector: &mut C,
+    ) -> Result<ProduceSummary, ProduceError> {
+        if self.is_done() {
+            debug!("done...no next segment");
+
+            return Ok(self.final_report());
+        }
+
+        let mut skipped_bytes = 0;
+
+        loop {
+            let fetch_info = self.fetch().await?;
+            skipped_bytes += fetch_info.skipped_bytes;
+
+            match self.process(fetch_info, collector)? {
+                ProcessOutcome::Parsed {
+                    bytes_consumed,
+                    messages_count,
+                    skipped_bytes: parse_skipped,
+                } => {
+                    let summary = ProduceSummary::Processed {
+                        bytes_consumed,
+                        messages_count,
+                        skipped_bytes: skipped_bytes + parse_skipped,
+                    };
+                    return Ok(summary);
+                }
+                ProcessOutcome::NeedMoreBytes => continue,
+                ProcessOutcome::NoData => {
+                    return Ok(ProduceSummary::NoBytesAvailable { skipped_bytes });
+                }
+                ProcessOutcome::Done => return Ok(self.final_report()),
+            }
+        }
     }
 
     /// Checks if the producer have already produced any parsed items in the current session.
@@ -297,7 +472,7 @@ impl<P: Parser, D: ByteSource> MessageProducer<P, D> {
         self.total_messages > 0
     }
 
-    /// Returns [`ProduceStatus::Done`] with summary for producer session.
+    /// Returns [`ProduceSummary::Done`] with summary for producer session.
     fn final_report(&self) -> ProduceSummary {
         ProduceSummary::Done {
             loaded_bytes: self.total_loaded,

--- a/crates/core/processor/src/producer/tests/cancel_safety.rs
+++ b/crates/core/processor/src/producer/tests/cancel_safety.rs
@@ -632,3 +632,77 @@ async fn cancel_safe_timeout() {
 
     assert!(timeout_received > 50);
 }
+
+/// Cancel safety test for the bare loading step of the producer, which is the only awaiting
+/// step and therefore the only one that a `select!` can ever cancel.
+#[tokio::test(start_paused = true)]
+async fn cancel_safe_fetch() {
+    const LOAD_SEEDS: [usize; 3] = [5, 4, 6];
+
+    let parser = MockParser::new([]);
+    let source = MockByteSource::new(
+        0,
+        [
+            Ok(Some(
+                MockReloadSeed::new(LOAD_SEEDS[0], 0).sleep_duration(SOURCE_SLEEP_DURATION),
+            )),
+            Ok(Some(
+                MockReloadSeed::new(LOAD_SEEDS[1], 0).sleep_duration(SOURCE_SLEEP_DURATION),
+            )),
+            Ok(Some(
+                MockReloadSeed::new(LOAD_SEEDS[2], 0).sleep_duration(SOURCE_SLEEP_DURATION),
+            )),
+            Ok(None),
+        ],
+    );
+
+    let mut producer = MessageProducer::new(parser, source);
+    let (cancel_tx, mut cancel_rx) = tokio::sync::mpsc::channel(32);
+
+    let cancel_handle = tokio::spawn(async move {
+        let mut count = 0;
+        while cancel_tx.send(()).await.is_ok() {
+            sleep(Duration::from_millis(2)).await;
+            count += 1;
+        }
+
+        assert!(count > 50);
+    });
+
+    let mut cancel_received = 0;
+    let mut fetch_idx = 0;
+    loop {
+        tokio::select! {
+            _ = cancel_rx.recv() => {
+                cancel_received += 1;
+            }
+            res = producer.fetch() => {
+                let info = res.unwrap();
+                match LOAD_SEEDS.get(fetch_idx) {
+                    // Every seeded load must be observed exactly once, despite the
+                    // constant cancelling of the fetch future.
+                    Some(&loaded) => {
+                        assert_eq!(info.newly_loaded_bytes, loaded);
+                        assert_eq!(info.skipped_bytes, 0);
+                    }
+                    None => {
+                        assert_eq!(info.newly_loaded_bytes, 0);
+                        break;
+                    }
+                }
+                fetch_idx += 1;
+            }
+        };
+    }
+    drop(cancel_rx);
+
+    assert_eq!(fetch_idx, LOAD_SEEDS.len());
+    assert_eq!(
+        producer.total_loaded_bytes(),
+        LOAD_SEEDS.iter().sum::<usize>()
+    );
+
+    assert!(cancel_received > 50);
+
+    assert!(cancel_handle.await.is_ok());
+}

--- a/crates/core/processor/src/producer/tests/line_boundaries.rs
+++ b/crates/core/processor/src/producer/tests/line_boundaries.rs
@@ -1,0 +1,142 @@
+//! Regression tests for text lines which straddle a reader buffer boundary.
+//!
+//! These pair the real [`StringTokenizer`] with a real [`BinaryByteSource`] whose capacity is
+//! injectable, which is the only level where the buffer sizes of the defect can be reproduced
+//! without feeding megabytes into the test.
+
+use std::io::{Cursor, Read};
+
+use parsers::{
+    ParseYield,
+    text::{StringMessage, StringTokenizer},
+};
+use sources::binary::raw::BinaryByteSource;
+
+use super::*;
+
+/// Reader which hands out its content in small chunks, the way a socket or a slow writer does.
+struct ChunkedRead {
+    content: Vec<u8>,
+    chunk_size: usize,
+    position: usize,
+}
+
+impl Read for ChunkedRead {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        let chunk_end = (self.position + self.chunk_size).min(self.content.len());
+        let size = buffer.len().min(chunk_end - self.position);
+        buffer[..size].copy_from_slice(&self.content[self.position..self.position + size]);
+        self.position += size;
+
+        Ok(size)
+    }
+}
+
+/// Drives the producer to the end of its input the way a caller which can't tail does: produce
+/// until the source stalls, then let the parser close whatever it is still holding.
+async fn collect_lines<R: Read + Send>(source: BinaryByteSource<R>) -> Vec<String> {
+    let mut producer = MessageProducer::new(StringTokenizer {}, source);
+    let mut collector = GeneralLogCollector::<StringMessage>::default();
+    let mut lines = Vec::new();
+
+    loop {
+        let summary = producer.produce_next(&mut collector).await.unwrap();
+        drain_lines(&mut collector, &mut lines);
+
+        match summary {
+            ProduceSummary::Processed { .. } => continue,
+            ProduceSummary::PendingRemainder { .. } => {
+                producer.process_remaining(&mut collector).unwrap();
+                drain_lines(&mut collector, &mut lines);
+
+                break;
+            }
+            ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => break,
+        }
+    }
+
+    lines
+}
+
+fn drain_lines(collector: &mut GeneralLogCollector<StringMessage>, lines: &mut Vec<String>) {
+    let records = collector
+        .get_records()
+        .drain(..)
+        .map(|record| match record {
+            ParseYield::Message(msg) => msg.to_string(),
+            invalid => panic!("Text parser produces messages only but got {invalid:?}"),
+        });
+
+    lines.extend(records);
+}
+
+#[tokio::test]
+async fn lines_crossing_buffer_boundaries_stay_whole() {
+    // 9 bytes per line against a 64 byte buffer: every buffer boundary falls inside a line.
+    let expected: Vec<String> = (0..30).map(|index| format!("line-{index:03}")).collect();
+    let input = expected
+        .iter()
+        .map(|line| format!("{line}\n"))
+        .collect::<String>();
+
+    let source = BinaryByteSource::custom(Cursor::new(input.into_bytes()), 64, 16);
+
+    assert_eq!(collect_lines(source).await, expected);
+}
+
+#[tokio::test]
+async fn line_arriving_in_chunks_stays_whole() {
+    let source = BinaryByteSource::custom(
+        ChunkedRead {
+            content: b"hello\nworld\n".to_vec(),
+            chunk_size: 3,
+            position: 0,
+        },
+        64,
+        16,
+    );
+
+    assert_eq!(collect_lines(source).await, ["hello", "world"]);
+}
+
+#[tokio::test]
+async fn last_line_without_newline_is_delivered() {
+    let source = BinaryByteSource::custom(Cursor::new(b"one\ntwo".to_vec()), 64, 16);
+
+    assert_eq!(collect_lines(source).await, ["one", "two"]);
+}
+
+#[tokio::test]
+async fn line_longer_than_min_space_still_splits() {
+    // Pins an accepted limitation: `BufReader` compacts only while the buffered bytes are below
+    // its minimum, so a longer remainder sits at the end of a full buffer which can't grow. The
+    // producer then has to emit it to keep the session going.
+    let input = format!("{}\n{}\n", "S".repeat(20), "L".repeat(60));
+
+    let source = BinaryByteSource::custom(Cursor::new(input.into_bytes()), 64, 8);
+
+    // The first 64 bytes hold the short line plus the first 43 bytes of the long one.
+    assert_eq!(
+        collect_lines(source).await,
+        ["S".repeat(20), "L".repeat(43), "L".repeat(17)]
+    );
+}
+
+#[tokio::test]
+async fn line_longer_than_the_buffer_splits_without_losing_bytes() {
+    let input = format!("{}\n", "L".repeat(100));
+
+    let source = BinaryByteSource::custom(Cursor::new(input.into_bytes()), 32, 8);
+
+    // A line which doesn't fit the buffer at all can only be delivered in buffer sized pieces,
+    // but no byte of it is lost and the run terminates.
+    assert_eq!(
+        collect_lines(source).await,
+        [
+            "L".repeat(32),
+            "L".repeat(32),
+            "L".repeat(32),
+            "L".repeat(4)
+        ]
+    );
+}

--- a/crates/core/processor/src/producer/tests/mock_byte_source.rs
+++ b/crates/core/processor/src/producer/tests/mock_byte_source.rs
@@ -15,6 +15,8 @@ pub struct MockByteSource {
     /// Handle for spawned load task, used with seeds having timeout
     /// to ensure load method is cancel safe in that situation.
     load_handle: Option<JoinHandle<Result<Option<ReloadInfo>, Error>>>,
+    /// Value to be returned on [`ByteSource::can_buffer_more()`] calls.
+    can_buffer_more: bool,
 }
 
 impl MockByteSource {
@@ -24,7 +26,15 @@ impl MockByteSource {
             buffer,
             reload_seeds: reload_seeds.into(),
             load_handle: None,
+            can_buffer_more: true,
         }
+    }
+
+    /// Makes the source report that its buffer can't take any more bytes.
+    pub fn buffer_full(mut self) -> Self {
+        self.can_buffer_more = false;
+
+        self
     }
 }
 
@@ -74,6 +84,10 @@ impl ByteSource for MockByteSource {
     /// count of currently loaded bytes
     fn len(&self) -> usize {
         self.buffer.len()
+    }
+
+    fn can_buffer_more(&self) -> bool {
+        self.can_buffer_more
     }
 
     async fn load(&mut self, _filter: Option<&SourceFilter>) -> Result<Option<ReloadInfo>, Error> {

--- a/crates/core/processor/src/producer/tests/mock_parser.rs
+++ b/crates/core/processor/src/producer/tests/mock_parser.rs
@@ -3,6 +3,7 @@ use std::{collections::VecDeque, fmt, io::Write, mem};
 use parsers::Error;
 use parsers::LogMessage;
 use parsers::ParseYield;
+use parsers::RemainderError;
 use serde::Serialize;
 
 use super::*;
@@ -37,14 +38,27 @@ impl LogMessage for MockMessage {
 pub struct MockParser {
     /// The seeds that will be used to return values on [`Parser::parse()`] calls
     seeds: VecDeque<Result<Vec<MockParseSeed>, Error>>,
+    /// The seeds that will be used to return values on [`Parser::parse_remaining()`] calls
+    remainder_seeds: VecDeque<MockRemainderSeed>,
 }
+
+/// Return value of one [`Parser::parse_remaining()`] call on [`MockParser`]
+pub type MockRemainderSeed = Result<Option<ParseYield<MockMessage>>, RemainderError>;
 
 impl MockParser {
     /// * `seeds`: Seeds items which that will be used to produce return-values on [`Parser::parse()`] calls
     pub fn new(seeds: impl Into<VecDeque<Result<Vec<MockParseSeed>, Error>>>) -> Self {
         Self {
             seeds: seeds.into(),
+            remainder_seeds: VecDeque::new(),
         }
+    }
+
+    /// * `seeds`: Seeds which will be returned on [`Parser::parse_remaining()`] calls
+    pub fn with_remainder_seeds(mut self, seeds: impl Into<VecDeque<MockRemainderSeed>>) -> Self {
+        self.remainder_seeds = seeds.into();
+
+        self
     }
 }
 
@@ -84,6 +98,16 @@ impl Parser for MockParser {
         Ok(seeds
             .into_iter()
             .map(|seed| ParseOutput::new(seed.cosumed, seed.parse_yeild)))
+    }
+
+    fn parse_remaining(
+        &mut self,
+        _input: &[u8],
+        _timestamp: Option<u64>,
+    ) -> Result<Option<ParseYield<MockMessage>>, RemainderError> {
+        self.remainder_seeds
+            .pop_front()
+            .expect("Remainder seeds count must match parse_remaining count")
     }
 }
 

--- a/crates/core/processor/src/producer/tests/mod.rs
+++ b/crates/core/processor/src/producer/tests/mod.rs
@@ -2,6 +2,7 @@ mod mock_byte_source;
 mod mock_parser;
 
 mod cancel_safety;
+mod line_boundaries;
 mod multi_parse;
 mod process;
 mod single_parse;

--- a/crates/core/processor/src/producer/tests/mod.rs
+++ b/crates/core/processor/src/producer/tests/mod.rs
@@ -3,6 +3,7 @@ mod mock_parser;
 
 mod cancel_safety;
 mod multi_parse;
+mod process;
 mod single_parse;
 
 use super::*;

--- a/crates/core/processor/src/producer/tests/multi_parse.rs
+++ b/crates/core/processor/src/producer/tests/multi_parse.rs
@@ -46,7 +46,9 @@ async fn parse_items_then_skip() {
             assert_eq!(bytes_consumed, 10);
             assert_eq!(skipped_bytes, 0);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -76,7 +78,9 @@ async fn parse_items_then_skip() {
             assert_eq!(bytes_consumed, 10);
             assert_eq!(skipped_bytes, 10);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -86,7 +90,9 @@ async fn parse_items_then_skip() {
     // NoBytesAvailable message should be sent
     let summary = producer.produce_next(&mut collector).await.unwrap();
     match summary {
-        ProduceSummary::Processed { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::Processed { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
         ProduceSummary::NoBytesAvailable { skipped_bytes } => {
@@ -132,7 +138,9 @@ async fn parse_incomplete() {
             assert_eq!(bytes_consumed, 30);
             assert_eq!(skipped_bytes, 0);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -152,7 +160,9 @@ async fn parse_incomplete() {
     // NoBytesAvailable message should be sent
     let summary = producer.produce_next(&mut collector).await.unwrap();
     match summary {
-        ProduceSummary::Processed { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::Processed { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
         ProduceSummary::NoBytesAvailable { skipped_bytes } => {
@@ -202,7 +212,9 @@ async fn success_parse_err_success() {
             assert_eq!(bytes_consumed, 15);
             assert_eq!(skipped_bytes, 0);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -237,7 +249,9 @@ async fn success_parse_err_success() {
             assert_eq!(bytes_consumed, 10 + 5);
             assert_eq!(skipped_bytes, 0);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -260,7 +274,9 @@ async fn success_parse_err_success() {
     // NoBytesAvailable message should be sent
     let summary = producer.produce_next(&mut collector).await.unwrap();
     match summary {
-        ProduceSummary::Processed { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::Processed { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
         ProduceSummary::NoBytesAvailable { skipped_bytes } => {
@@ -308,7 +324,9 @@ async fn parse_with_skipped_bytes() {
             assert_eq!(bytes_consumed, 8);
             assert_eq!(skipped_bytes, 4);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -338,7 +356,9 @@ async fn parse_with_skipped_bytes() {
             assert_eq!(bytes_consumed, 6);
             assert_eq!(skipped_bytes, 10);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -357,7 +377,9 @@ async fn parse_with_skipped_bytes() {
             assert_eq!(bytes_consumed, 15);
             assert_eq!(skipped_bytes, 15);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -367,7 +389,9 @@ async fn parse_with_skipped_bytes() {
     // NoBytesAvailable message should be sent
     let summary = producer.produce_next(&mut collector).await.unwrap();
     match summary {
-        ProduceSummary::Processed { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::Processed { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
         ProduceSummary::NoBytesAvailable { skipped_bytes } => {
@@ -406,7 +430,9 @@ async fn initial_parsing_error() {
     // Then the producer should be closed.
     let summary = producer.produce_next(&mut collector).await.unwrap();
     match summary {
-        ProduceSummary::Processed { .. } | ProduceSummary::NoBytesAvailable { .. } => {
+        ProduceSummary::Processed { .. }
+        | ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. } => {
             panic!("Summary should be Done but got {summary:?}");
         }
         ProduceSummary::Done { .. } => {}
@@ -463,7 +489,9 @@ async fn success_parse_error_success_err_skipped_bytes() {
             assert_eq!(bytes_consumed, 4 + 6);
             assert_eq!(skipped_bytes, 4);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -494,7 +522,9 @@ async fn success_parse_error_success_err_skipped_bytes() {
             assert_eq!(bytes_consumed, 4 + 10);
             assert_eq!(skipped_bytes, 6);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -518,7 +548,9 @@ async fn success_parse_error_success_err_skipped_bytes() {
     // NoBytesAvailable message should be sent
     let summary = producer.produce_next(&mut collector).await.unwrap();
     match summary {
-        ProduceSummary::Processed { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::Processed { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
         ProduceSummary::NoBytesAvailable { skipped_bytes } => {

--- a/crates/core/processor/src/producer/tests/multi_parse.rs
+++ b/crates/core/processor/src/producer/tests/multi_parse.rs
@@ -223,6 +223,9 @@ async fn success_parse_err_success() {
 
     // Three parse error causing 3 bytes to drop.
     // Then two Messages with content should be yielded consuming all the bytes.
+    // The three dropped bytes are counted on the `process()` call that dropped them, which
+    // ended in `NeedMoreBytes` and therefore doesn't report them here. They are still part of
+    // the producer totals.
     let summary = producer.produce_next(&mut collector).await.unwrap();
     match summary {
         ProduceSummary::Processed {
@@ -232,7 +235,7 @@ async fn success_parse_err_success() {
         } => {
             assert_eq!(messages_count, 2);
             assert_eq!(bytes_consumed, 10 + 5);
-            assert_eq!(skipped_bytes, 3);
+            assert_eq!(skipped_bytes, 0);
         }
         ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
@@ -250,6 +253,9 @@ async fn success_parse_err_success() {
         records[1],
         ParseYield::Message(MockMessage { content: 2 })
     ));
+
+    // The bytes dropped while resyncing are part of the producer totals.
+    assert_eq!(producer.total_skipped_bytes(), 3);
 
     // NoBytesAvailable message should be sent
     let summary = producer.produce_next(&mut collector).await.unwrap();
@@ -433,7 +439,8 @@ async fn success_parse_error_success_err_skipped_bytes() {
         [
             Ok(Some(MockReloadSeed::new(10, 4))),
             Ok(Some(MockReloadSeed::new(20, 4))),
-            Ok(None),
+            // The parse errors at the end drain the source without loading again: `process()`
+            // reads the result of the preceding `fetch()` instead of loading to find out.
             Ok(None),
             Ok(None),
         ],

--- a/crates/core/processor/src/producer/tests/process.rs
+++ b/crates/core/processor/src/producer/tests/process.rs
@@ -1,0 +1,414 @@
+//! Tests for the synchronous parsing half of the producer.
+//!
+//! [`MessageProducer::process()`] never loads, so most of the decision table can be driven
+//! without a runtime at all: `MockByteSource::new(init_len, [])` starts with bytes already in
+//! its buffer and panics if `load()` is called. The few cases whose outcome depends on the
+//! preceding [`MessageProducer::fetch()`] call use a runtime and do fetch for real.
+//!
+//! `process()` takes its [`FetchInfo`] by value, and the type has no public constructor outside
+//! of `fetch()`. The cases below that don't depend on the preceding fetch still need a value to
+//! pass in, so they use [`empty_fetch_info()`], built directly from a sibling module: unlike
+//! external callers, tests are free to construct one without going through a real `fetch()`.
+
+use super::mock_byte_source::*;
+use super::mock_parser::*;
+use super::*;
+
+use parsers::{Error as ParseError, ParseYield};
+
+/// Synthesizes a [`FetchInfo`] as if nothing had been fetched, for decision-table cases whose
+/// outcome does not depend on the preceding fetch.
+fn empty_fetch_info() -> FetchInfo {
+    FetchInfo {
+        newly_loaded_bytes: 0,
+        skipped_bytes: 0,
+    }
+}
+
+#[test]
+fn no_data_on_empty_source() {
+    let parser = MockParser::new([]);
+    let source = MockByteSource::new(0, []);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    // Parse must not be called at all when the source holds no bytes.
+    let outcome = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap();
+    assert!(matches!(outcome, ProcessOutcome::NoData));
+
+    assert!(collector.get_records().is_empty());
+}
+
+#[test]
+fn parsed_appends_items_and_consumes_bytes() {
+    let parser = MockParser::new([Ok(vec![MockParseSeed::new(
+        4,
+        Some(ParseYield::Message(MockMessage::from(1))),
+    )])]);
+    let source = MockByteSource::new(10, []);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    let outcome = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap();
+    match outcome {
+        ProcessOutcome::Parsed {
+            bytes_consumed,
+            messages_count,
+            skipped_bytes,
+        } => {
+            assert_eq!(bytes_consumed, 4);
+            assert_eq!(messages_count, 1);
+            assert_eq!(skipped_bytes, 0);
+        }
+        invalid => panic!("Outcome should be Parsed but got {invalid:?}"),
+    }
+
+    let records = collector.get_records();
+    assert_eq!(records.len(), 1);
+    assert!(matches!(
+        records[0],
+        ParseYield::Message(MockMessage { content: 1 })
+    ));
+
+    // Only the parsed bytes must be consumed from the source.
+    assert_eq!(producer.byte_source.len(), 6);
+    assert_eq!(producer.total_produced_items(), 1);
+}
+
+#[test]
+fn parsed_counts_bytes_skipped_by_parser() {
+    let parser = MockParser::new([Ok(vec![MockParseSeed::new(4, None)])]);
+    let source = MockByteSource::new(10, []);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    let outcome = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap();
+    match outcome {
+        ProcessOutcome::Parsed {
+            bytes_consumed,
+            messages_count,
+            skipped_bytes,
+        } => {
+            assert_eq!(bytes_consumed, 4);
+            assert_eq!(messages_count, 0);
+            assert_eq!(skipped_bytes, 4);
+        }
+        invalid => panic!("Outcome should be Parsed but got {invalid:?}"),
+    }
+
+    assert!(collector.get_records().is_empty());
+
+    // Bytes skipped by the parser belong to the producer totals too.
+    assert_eq!(producer.total_skipped_bytes(), 4);
+}
+
+#[tokio::test]
+async fn incomplete_after_productive_fetch_asks_for_more_bytes() {
+    let parser = MockParser::new([Err(ParseError::Incomplete)]);
+    let source = MockByteSource::new(0, [Ok(Some(MockReloadSeed::new(10, 0)))]);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    let fetch_info = producer.fetch().await.unwrap();
+
+    // The source is still delivering, so the incomplete message must not be resynced away.
+    let outcome = producer.process(fetch_info, &mut collector).unwrap();
+    assert!(matches!(outcome, ProcessOutcome::NeedMoreBytes));
+
+    assert_eq!(producer.byte_source.len(), 10);
+    assert_eq!(producer.total_skipped_bytes(), 0);
+    assert!(collector.get_records().is_empty());
+}
+
+#[test]
+fn incomplete_without_fetched_bytes_drops_bytes_until_dry() {
+    let parser = MockParser::new([
+        Err(ParseError::Incomplete),
+        Err(ParseError::Incomplete),
+        Err(ParseError::Incomplete),
+    ]);
+    let source = MockByteSource::new(3, []);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    // Nothing was fetched, so the parser can only be satisfied by resyncing: one byte is
+    // dropped per parse call until the buffer is empty.
+    let outcome = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap();
+    assert!(matches!(outcome, ProcessOutcome::NoData));
+
+    assert_eq!(producer.byte_source.len(), 0);
+    assert_eq!(producer.total_skipped_bytes(), 3);
+    assert!(collector.get_records().is_empty());
+}
+
+#[test]
+fn parse_error_resyncs_then_parses() {
+    let parser = MockParser::new([
+        Err(ParseError::Parse(String::from("broken"))),
+        Err(ParseError::Parse(String::from("broken"))),
+        Ok(vec![MockParseSeed::new(
+            3,
+            Some(ParseYield::Message(MockMessage::from(1))),
+        )]),
+    ]);
+    let source = MockByteSource::new(5, []);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    let outcome = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap();
+    match outcome {
+        ProcessOutcome::Parsed {
+            bytes_consumed,
+            messages_count,
+            skipped_bytes,
+        } => {
+            assert_eq!(bytes_consumed, 3);
+            assert_eq!(messages_count, 1);
+            // The two bytes dropped while resyncing.
+            assert_eq!(skipped_bytes, 2);
+        }
+        invalid => panic!("Outcome should be Parsed but got {invalid:?}"),
+    }
+
+    assert_eq!(collector.get_records().len(), 1);
+    assert_eq!(producer.byte_source.len(), 0);
+    assert_eq!(producer.total_skipped_bytes(), 2);
+}
+
+#[test]
+fn parse_error_is_delivered_when_source_is_dry() {
+    let parser = MockParser::new([
+        Err(ParseError::Parse(String::from("broken"))),
+        Err(ParseError::Parse(String::from("broken"))),
+    ]);
+    let source = MockByteSource::new(2, []);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    // Nothing was fetched and resyncing drained the buffer: the last parse error is the result.
+    let err = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap_err();
+    assert!(matches!(err, ProcessError::Parse(msg) if msg == "broken"));
+
+    assert_eq!(producer.byte_source.len(), 0);
+    assert_eq!(producer.total_skipped_bytes(), 2);
+}
+
+#[tokio::test]
+async fn parse_error_asks_for_more_bytes_while_source_delivers() {
+    let parser = MockParser::new([
+        Err(ParseError::Parse(String::from("broken"))),
+        Err(ParseError::Parse(String::from("broken"))),
+    ]);
+    let source = MockByteSource::new(0, [Ok(Some(MockReloadSeed::new(2, 0))), Ok(None)]);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    let fetch_info = producer.fetch().await.unwrap();
+
+    // Resyncing drained the buffer but the last fetch was productive: ask for more bytes
+    // instead of ending the session on the parse error.
+    let outcome = producer.process(fetch_info, &mut collector).unwrap();
+    assert!(matches!(outcome, ProcessOutcome::NeedMoreBytes));
+    assert_eq!(producer.byte_source.len(), 0);
+
+    // Once the source has nothing more to give, the remembered error is delivered.
+    let fetch_info = producer.fetch().await.unwrap();
+    let err = producer.process(fetch_info, &mut collector).unwrap_err();
+    assert!(matches!(err, ProcessError::Parse(msg) if msg == "broken"));
+
+    assert_eq!(producer.total_skipped_bytes(), 2);
+}
+
+#[tokio::test]
+async fn stale_parse_error_isnt_reported() {
+    // A parse error is remembered while resyncing so it can be delivered once the source runs
+    // dry. Once the parser starts asking for more bytes instead of rejecting them, that error
+    // no longer describes why the producer is stuck and must be forgotten: running dry then
+    // means "no data", not "parse error".
+    let parser = MockParser::new([
+        Err(ParseError::Parse(String::from("stale"))),
+        Err(ParseError::Parse(String::from("stale"))),
+        Err(ParseError::Incomplete),
+        Err(ParseError::Incomplete),
+        Err(ParseError::Incomplete),
+        Err(ParseError::Incomplete),
+    ]);
+    let source = MockByteSource::new(
+        0,
+        [
+            Ok(Some(MockReloadSeed::new(2, 0))),
+            Ok(Some(MockReloadSeed::new(3, 0))),
+            Ok(None),
+        ],
+    );
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    // Both bytes are dropped resyncing from the parse error, which is kept pending because the
+    // source is still delivering.
+    let fetch_info = producer.fetch().await.unwrap();
+    let outcome = producer.process(fetch_info, &mut collector).unwrap();
+    assert!(matches!(outcome, ProcessOutcome::NeedMoreBytes));
+
+    // The freshly loaded bytes only make the parser ask for more, superseding the parse error.
+    let fetch_info = producer.fetch().await.unwrap();
+    let outcome = producer.process(fetch_info, &mut collector).unwrap();
+    assert!(matches!(outcome, ProcessOutcome::NeedMoreBytes));
+
+    // The source is dry now: the remaining bytes get dropped and the run ends without items,
+    // not with the parse error from the very first call.
+    let fetch_info = producer.fetch().await.unwrap();
+    let outcome = producer.process(fetch_info, &mut collector).unwrap();
+    assert!(matches!(outcome, ProcessOutcome::NoData));
+
+    assert!(collector.get_records().is_empty());
+}
+
+#[test]
+fn eof_marks_producer_done() {
+    let parser = MockParser::new([Err(ParseError::Eof)]);
+    let source = MockByteSource::new(5, []);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    let outcome = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap();
+    assert!(matches!(outcome, ProcessOutcome::Done));
+
+    // The producer stays done: parse must not be called again (no seeds are left).
+    let outcome = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap();
+    assert!(matches!(outcome, ProcessOutcome::Done));
+}
+
+#[test]
+fn unrecoverable_parse_error_marks_producer_done() {
+    let parser = MockParser::new([Err(ParseError::Unrecoverable(String::from("fatal")))]);
+    let source = MockByteSource::new(5, []);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    let err = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap_err();
+    assert!(matches!(err, ProcessError::Unrecoverable(msg) if msg == "fatal"));
+
+    let outcome = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap();
+    assert!(matches!(outcome, ProcessOutcome::Done));
+}
+
+#[test]
+fn initial_parse_errors_abort_the_session() {
+    // The guard trips once more bytes than `INITIAL_PARSE_ERROR_LIMIT` have been dropped
+    // while resyncing, without a single item being produced.
+    const PARSE_CALLS: usize = INITIAL_PARSE_ERROR_LIMIT + 2;
+
+    let parse_seeds: Vec<_> = std::iter::repeat_with(|| Err(ParseError::Parse(String::new())))
+        .take(PARSE_CALLS)
+        .collect();
+    let parser = MockParser::new(parse_seeds);
+    let source = MockByteSource::new(PARSE_CALLS, []);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    let err = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap_err();
+    assert!(matches!(err, ProcessError::Unrecoverable(..)));
+
+    // Aborting is final.
+    let outcome = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap();
+    assert!(matches!(outcome, ProcessOutcome::Done));
+}
+
+#[tokio::test]
+async fn source_skips_dont_abort_the_session() {
+    // Sources report the bytes they skip on their own: pcap sources report the headers of every
+    // packet, and the whole payload of a packet rejected by the filter. Those bytes say nothing
+    // about the parser failing to make progress and must not spend the abort budget, no matter
+    // how far past `INITIAL_PARSE_ERROR_LIMIT` they take the skipped totals.
+    const SOURCE_SKIPPED: usize = INITIAL_PARSE_ERROR_LIMIT * 2;
+
+    let parser = MockParser::new([
+        Err(ParseError::Parse(String::from("broken"))),
+        Ok(vec![MockParseSeed::new(
+            9,
+            Some(ParseYield::Message(MockMessage::from(1))),
+        )]),
+    ]);
+    let source = MockByteSource::new(0, [Ok(Some(MockReloadSeed::new(10, SOURCE_SKIPPED)))]);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    let fetch_info = producer.fetch().await.unwrap();
+    assert!(producer.total_skipped_bytes() > INITIAL_PARSE_ERROR_LIMIT);
+
+    // The single parse error must resync by dropping one byte and carry on, not end the session.
+    let outcome = producer.process(fetch_info, &mut collector).unwrap();
+    match outcome {
+        ProcessOutcome::Parsed {
+            bytes_consumed,
+            messages_count,
+            skipped_bytes,
+        } => {
+            assert_eq!(bytes_consumed, 9);
+            assert_eq!(messages_count, 1);
+            assert_eq!(skipped_bytes, 1);
+        }
+        invalid => panic!("Outcome should be Parsed but got {invalid:?}"),
+    }
+
+    assert_eq!(collector.get_records().len(), 1);
+}
+
+#[tokio::test]
+async fn fetch_on_done_producer_leaves_source_untouched() {
+    let parser = MockParser::new([Err(ParseError::Eof)]);
+    // No reload seeds: the mock source panics if `load()` is called.
+    let source = MockByteSource::new(5, []);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    assert!(matches!(
+        producer
+            .process(empty_fetch_info(), &mut collector)
+            .unwrap(),
+        ProcessOutcome::Done
+    ));
+
+    let fetch_info = producer.fetch().await.unwrap();
+    assert_eq!(fetch_info.newly_loaded_bytes, 0);
+    assert_eq!(fetch_info.skipped_bytes, 0);
+}

--- a/crates/core/processor/src/producer/tests/process.rs
+++ b/crates/core/processor/src/producer/tests/process.rs
@@ -10,11 +10,13 @@
 //! pass in, so they use [`empty_fetch_info()`], built directly from a sibling module: unlike
 //! external callers, tests are free to construct one without going through a real `fetch()`.
 
+use std::assert_matches;
+
 use super::mock_byte_source::*;
 use super::mock_parser::*;
 use super::*;
 
-use parsers::{Error as ParseError, ParseYield};
+use parsers::{Error as ParseError, ParseYield, RemainderError};
 
 /// Synthesizes a [`FetchInfo`] as if nothing had been fetched, for decision-table cases whose
 /// outcome does not depend on the preceding fetch.
@@ -131,27 +133,226 @@ async fn incomplete_after_productive_fetch_asks_for_more_bytes() {
 }
 
 #[test]
-fn incomplete_without_fetched_bytes_drops_bytes_until_dry() {
-    let parser = MockParser::new([
-        Err(ParseError::Incomplete),
-        Err(ParseError::Incomplete),
-        Err(ParseError::Incomplete),
-    ]);
+fn incomplete_without_new_bytes_keeps_remainder() {
+    let parser = MockParser::new([Err(ParseError::Incomplete)]);
     let source = MockByteSource::new(3, []);
 
     let mut producer = MessageProducer::new(parser, source);
     let mut collector = GeneralLogCollector::default();
 
-    // Nothing was fetched, so the parser can only be satisfied by resyncing: one byte is
-    // dropped per parse call until the buffer is empty.
+    // The source is only paused: the bytes are the start of an item and must survive until it
+    // either delivers the rest or the caller declares the source finished.
     let outcome = producer
         .process(empty_fetch_info(), &mut collector)
         .unwrap();
-    assert!(matches!(outcome, ProcessOutcome::NoData));
+    assert_matches!(outcome, ProcessOutcome::PendingRemainder);
+
+    assert_eq!(producer.byte_source.len(), 3);
+    assert_eq!(producer.total_skipped_bytes(), 0);
+    assert!(collector.get_records().is_empty());
+}
+
+#[test]
+fn full_source_emits_remainder() {
+    let parser = MockParser::new([Err(ParseError::Incomplete)])
+        .with_remainder_seeds([Ok(Some(ParseYield::Message(MockMessage::from(1))))]);
+    let source = MockByteSource::new(3, []).buffer_full();
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    // Waiting for bytes that a full buffer can't take would stall forever, so the parser gets
+    // to close the item now. It covers the whole buffer by definition.
+    let outcome = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap();
+    match outcome {
+        ProcessOutcome::Parsed {
+            bytes_consumed,
+            messages_count,
+            skipped_bytes,
+        } => {
+            assert_eq!(bytes_consumed, 3);
+            assert_eq!(messages_count, 1);
+            assert_eq!(skipped_bytes, 0);
+        }
+        invalid => panic!("Outcome should be Parsed but got {invalid:?}"),
+    }
+
+    assert_eq!(collector.get_records().len(), 1);
+    assert_eq!(producer.byte_source.len(), 0);
+    assert_eq!(producer.total_produced_items(), 1);
+}
+
+#[test]
+fn full_source_drops_bytes_without_remainder() {
+    let parser = MockParser::new([
+        Err(ParseError::Incomplete),
+        Err(ParseError::Incomplete),
+        Err(ParseError::Incomplete),
+    ])
+    .with_remainder_seeds([Ok(None), Ok(None), Ok(None)]);
+    let source = MockByteSource::new(3, []).buffer_full();
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    // A parser which can't complete a partial item leaves the producer with the resync it had
+    // before: one byte dropped per parse call until the buffer is empty.
+    let outcome = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap();
+    assert_matches!(outcome, ProcessOutcome::NoData);
 
     assert_eq!(producer.byte_source.len(), 0);
     assert_eq!(producer.total_skipped_bytes(), 3);
     assert!(collector.get_records().is_empty());
+}
+
+#[test]
+fn full_source_parse_error_resyncs_then_reports() {
+    let parser = MockParser::new([Err(ParseError::Incomplete), Err(ParseError::Incomplete)])
+        .with_remainder_seeds([
+            Err(RemainderError::Parse(String::from("broken"))),
+            Err(RemainderError::Parse(String::from("broken"))),
+        ]);
+    let source = MockByteSource::new(2, []).buffer_full();
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    // Rejecting the remainder funnels into the resync path: bytes are dropped and the message
+    // is delivered once the buffer ran dry.
+    let err = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap_err();
+    assert_matches!(err, ProcessError::Parse(_));
+
+    assert_eq!(producer.byte_source.len(), 0);
+    assert_eq!(producer.total_skipped_bytes(), 2);
+}
+
+#[test]
+fn full_source_unrecoverable_ends_producer() {
+    let parser = MockParser::new([Err(ParseError::Incomplete)])
+        .with_remainder_seeds([Err(RemainderError::Unrecoverable(String::from("fatal")))]);
+    let source = MockByteSource::new(3, []).buffer_full();
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    let err = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap_err();
+    assert_matches!(err, ProcessError::Unrecoverable(_));
+
+    let outcome = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap();
+    assert_matches!(outcome, ProcessOutcome::Done);
+}
+
+#[test]
+fn process_remaining_emits_item() {
+    let parser = MockParser::new([])
+        .with_remainder_seeds([Ok(Some(ParseYield::Message(MockMessage::from(1))))]);
+    let source = MockByteSource::new(4, []);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    assert_eq!(producer.process_remaining(&mut collector).unwrap(), 1);
+
+    assert_eq!(collector.get_records().len(), 1);
+    assert_eq!(producer.byte_source.len(), 0);
+    assert_eq!(producer.total_produced_items(), 1);
+}
+
+#[test]
+fn process_remaining_keeps_bytes_without_item() {
+    let parser = MockParser::new([]).with_remainder_seeds([Ok(None)]);
+    let source = MockByteSource::new(4, []);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    // A stalled source is not a finished one: discarding here would make a parser waiting for
+    // the rest of a message resume in the middle of it.
+    assert_eq!(producer.process_remaining(&mut collector).unwrap(), 0);
+
+    assert_eq!(producer.byte_source.len(), 4);
+    assert_eq!(producer.total_skipped_bytes(), 0);
+    assert!(collector.get_records().is_empty());
+}
+
+#[test]
+fn process_remaining_reports_parse_error_without_consuming() {
+    let parser = MockParser::new([])
+        .with_remainder_seeds([Err(RemainderError::Parse(String::from("broken")))]);
+    let source = MockByteSource::new(4, []);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    let err = producer.process_remaining(&mut collector).unwrap_err();
+    assert_matches!(err, ProcessError::Parse(_));
+
+    assert_eq!(producer.byte_source.len(), 4);
+}
+
+#[test]
+fn process_remaining_is_idempotent() {
+    let parser = MockParser::new([])
+        .with_remainder_seeds([Ok(Some(ParseYield::Message(MockMessage::from(1))))]);
+    let source = MockByteSource::new(4, []);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    assert_eq!(producer.process_remaining(&mut collector).unwrap(), 1);
+
+    // Consuming the remainder is what makes the second call a no-op: no seed is left, so the
+    // parser would panic if it were called again.
+    assert_eq!(producer.process_remaining(&mut collector).unwrap(), 0);
+    assert_eq!(collector.get_records().len(), 1);
+}
+
+#[tokio::test]
+async fn remainder_survives_empty_result_and_completes_later() {
+    let parser = MockParser::new([
+        Err(ParseError::Incomplete),
+        Ok(vec![MockParseSeed::new(
+            7,
+            Some(ParseYield::Message(MockMessage::from(1))),
+        )]),
+    ])
+    .with_remainder_seeds([Ok(None)]);
+    let source = MockByteSource::new(4, [Ok(Some(MockReloadSeed::new(3, 0)))]);
+
+    let mut producer = MessageProducer::new(parser, source);
+    let mut collector = GeneralLogCollector::default();
+
+    // The source went quiet mid-item and the parser can't complete it yet.
+    let outcome = producer
+        .process(empty_fetch_info(), &mut collector)
+        .unwrap();
+    assert_matches!(outcome, ProcessOutcome::PendingRemainder);
+    assert_eq!(producer.process_remaining(&mut collector).unwrap(), 0);
+
+    // The kept bytes are the head of the item, so it parses whole once the source resumes.
+    let fetch_info = producer.fetch().await.unwrap();
+    let outcome = producer.process(fetch_info, &mut collector).unwrap();
+    match outcome {
+        ProcessOutcome::Parsed {
+            bytes_consumed,
+            messages_count,
+            ..
+        } => {
+            assert_eq!(bytes_consumed, 7);
+            assert_eq!(messages_count, 1);
+        }
+        invalid => panic!("Outcome should be Parsed but got {invalid:?}"),
+    }
 }
 
 #[test]
@@ -250,8 +451,6 @@ async fn stale_parse_error_isnt_reported() {
         Err(ParseError::Parse(String::from("stale"))),
         Err(ParseError::Incomplete),
         Err(ParseError::Incomplete),
-        Err(ParseError::Incomplete),
-        Err(ParseError::Incomplete),
     ]);
     let source = MockByteSource::new(
         0,
@@ -276,11 +475,11 @@ async fn stale_parse_error_isnt_reported() {
     let outcome = producer.process(fetch_info, &mut collector).unwrap();
     assert!(matches!(outcome, ProcessOutcome::NeedMoreBytes));
 
-    // The source is dry now: the remaining bytes get dropped and the run ends without items,
-    // not with the parse error from the very first call.
+    // The source is dry now: the pending bytes are kept for the caller to resolve, and no
+    // error is reported, least of all the one from the very first call.
     let fetch_info = producer.fetch().await.unwrap();
     let outcome = producer.process(fetch_info, &mut collector).unwrap();
-    assert!(matches!(outcome, ProcessOutcome::NoData));
+    assert_matches!(outcome, ProcessOutcome::PendingRemainder);
 
     assert!(collector.get_records().is_empty());
 }

--- a/crates/core/processor/src/producer/tests/single_parse.rs
+++ b/crates/core/processor/src/producer/tests/single_parse.rs
@@ -402,6 +402,9 @@ async fn success_parse_err_success() {
     // then load will be called providing 10 bytes which will be consumed by next parser call.
 
     // Second Message with content should be yielded consuming 10 the bytes.
+    // The three dropped bytes are counted on the `process()` call that dropped them, which
+    // ended in `NeedMoreBytes` and therefore doesn't report them here. They are still part of
+    // the producer totals.
     let summary = producer.produce_next(&mut collector).await.unwrap();
     match summary {
         ProduceSummary::Processed {
@@ -411,7 +414,7 @@ async fn success_parse_err_success() {
         } => {
             assert_eq!(messages_count, 1);
             assert_eq!(bytes_consumed, 10);
-            assert_eq!(skipped_bytes, 3);
+            assert_eq!(skipped_bytes, 0);
         }
         ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
@@ -429,6 +432,9 @@ async fn success_parse_err_success() {
 
     // Internal byte source must be empty
     assert_eq!(producer.byte_source.len(), 0);
+
+    // The bytes dropped while resyncing are part of the producer totals.
+    assert_eq!(producer.total_skipped_bytes(), 3);
 
     // NoBytesAvailable message should be sent
     let summary = producer.produce_next(&mut collector).await.unwrap();

--- a/crates/core/processor/src/producer/tests/single_parse.rs
+++ b/crates/core/processor/src/producer/tests/single_parse.rs
@@ -1,6 +1,6 @@
 //! Tests for parsers returning single value always
 
-use std::{collections::VecDeque, io::Cursor};
+use std::{assert_matches, collections::VecDeque, io::Cursor};
 
 use super::mock_byte_source::*;
 use super::mock_parser::*;
@@ -25,7 +25,9 @@ async fn empty_byte_source() {
     // NoBytesAvailable message should be sent
     let summary = producer.produce_next(&mut collector).await.unwrap();
     match summary {
-        ProduceSummary::Processed { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::Processed { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
         ProduceSummary::NoBytesAvailable { skipped_bytes } => {
@@ -50,28 +52,24 @@ async fn byte_source_fail() {
 }
 
 #[tokio::test]
-async fn text_keeps_unterminated_line() {
+async fn text_keeps_unterminated_line_until_asked() {
     let parser = StringTokenizer {};
     let source = BinaryByteSource::new(Cursor::new(b"{\"key\":\"value\"}".to_vec()));
 
     let mut producer = MessageProducer::new(parser, source);
     let mut collector = GeneralLogCollector::<StringMessage>::default();
 
+    // The input ends without a line break: the producer must hold those bytes instead of
+    // deciding on its own that the line is complete.
     let summary = producer.produce_next(&mut collector).await.unwrap();
-    match summary {
-        ProduceSummary::Processed {
-            bytes_consumed,
-            messages_count,
-            skipped_bytes,
-        } => {
-            assert_eq!(messages_count, 1);
-            assert_eq!(bytes_consumed, 15);
-            assert_eq!(skipped_bytes, 0);
-        }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
-            panic!("Summary should be Processed but got {summary:?}");
-        }
-    }
+    assert_matches!(
+        summary,
+        ProduceSummary::PendingRemainder { skipped_bytes: 0 }
+    );
+    assert!(collector.get_records().is_empty());
+
+    // Only the caller knows that no more bytes are coming, and then the line is delivered.
+    assert_eq!(producer.process_remaining(&mut collector).unwrap(), 1);
 
     let records = collector.get_records();
     assert_eq!(records.len(), 1);
@@ -114,7 +112,9 @@ async fn parse_item_then_skip() {
             assert_eq!(bytes_consumed, 5);
             assert_eq!(skipped_bytes, 0);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -139,7 +139,9 @@ async fn parse_item_then_skip() {
             assert_eq!(bytes_consumed, 5);
             assert_eq!(skipped_bytes, 5);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -149,7 +151,9 @@ async fn parse_item_then_skip() {
     // NoBytesAvailable message should be sent
     let summary = producer.produce_next(&mut collector).await.unwrap();
     match summary {
-        ProduceSummary::Processed { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::Processed { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
         ProduceSummary::NoBytesAvailable { skipped_bytes } => {
@@ -200,7 +204,9 @@ async fn parse_incomplete() {
             assert_eq!(bytes_consumed, 5);
             assert_eq!(skipped_bytes, 0);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -226,7 +232,9 @@ async fn parse_incomplete() {
             assert_eq!(bytes_consumed, 25);
             assert_eq!(skipped_bytes, 0);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -242,7 +250,9 @@ async fn parse_incomplete() {
     // NoBytesAvailable message should be sent
     let summary = producer.produce_next(&mut collector).await.unwrap();
     match summary {
-        ProduceSummary::Processed { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::Processed { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
         ProduceSummary::NoBytesAvailable { skipped_bytes } => {
@@ -295,7 +305,9 @@ async fn parse_err_eof() {
             assert_eq!(skipped_bytes, 0);
             assert_eq!(produced_messages, 0);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Processed { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::Processed { .. }
+        | ProduceSummary::PendingRemainder { .. } => {
             panic!("Summary should be Done but got {summary:?}");
         }
     }
@@ -335,7 +347,9 @@ async fn initial_parsing_error() {
     // Then the producer should be closed.
     let summary = producer.produce_next(&mut collector).await.unwrap();
     match summary {
-        ProduceSummary::Processed { .. } | ProduceSummary::NoBytesAvailable { .. } => {
+        ProduceSummary::Processed { .. }
+        | ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. } => {
             panic!("Summary should be Done but got {summary:?}");
         }
         ProduceSummary::Done { .. } => {}
@@ -385,7 +399,9 @@ async fn success_parse_err_success() {
             assert_eq!(bytes_consumed, 10);
             assert_eq!(skipped_bytes, 0);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -416,7 +432,9 @@ async fn success_parse_err_success() {
             assert_eq!(bytes_consumed, 10);
             assert_eq!(skipped_bytes, 0);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -439,7 +457,9 @@ async fn success_parse_err_success() {
     // NoBytesAvailable message should be sent
     let summary = producer.produce_next(&mut collector).await.unwrap();
     match summary {
-        ProduceSummary::Processed { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::Processed { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
         ProduceSummary::NoBytesAvailable { skipped_bytes } => {
@@ -487,7 +507,9 @@ async fn success_parse_err_done() {
             assert_eq!(bytes_consumed, 10);
             assert_eq!(skipped_bytes, 0);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -511,7 +533,9 @@ async fn success_parse_err_done() {
     // NoBytesAvailable message should be sent
     let summary = producer.produce_next(&mut collector).await.unwrap();
     match summary {
-        ProduceSummary::Processed { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::Processed { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
         ProduceSummary::NoBytesAvailable { skipped_bytes } => {
@@ -558,7 +582,9 @@ async fn success_parsing_error_then_fail_reload() {
             assert_eq!(bytes_consumed, 10);
             assert_eq!(skipped_bytes, 0);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -614,7 +640,9 @@ async fn parse_with_skipped_bytes() {
             assert_eq!(bytes_consumed, 3);
             assert_eq!(skipped_bytes, 4);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -639,7 +667,9 @@ async fn parse_with_skipped_bytes() {
             assert_eq!(bytes_consumed, 2);
             assert_eq!(skipped_bytes, 6);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -658,7 +688,9 @@ async fn parse_with_skipped_bytes() {
             assert_eq!(bytes_consumed, 15);
             assert_eq!(skipped_bytes, 15);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -668,7 +700,9 @@ async fn parse_with_skipped_bytes() {
     // NoBytesAvailable message should be sent
     let summary = producer.produce_next(&mut collector).await.unwrap();
     match summary {
-        ProduceSummary::Processed { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::Processed { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
         ProduceSummary::NoBytesAvailable { skipped_bytes } => {
@@ -722,7 +756,9 @@ async fn success_parsi_err_success_drain_bytes() {
             assert_eq!(bytes_consumed, 5);
             assert_eq!(skipped_bytes, 3);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -748,7 +784,9 @@ async fn success_parsi_err_success_drain_bytes() {
             assert_eq!(bytes_consumed, 5);
             assert_eq!(skipped_bytes, 4);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -774,7 +812,9 @@ async fn success_parsi_err_success_drain_bytes() {
             assert_eq!(bytes_consumed, 9);
             assert_eq!(skipped_bytes, 0);
         }
-        ProduceSummary::NoBytesAvailable { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::NoBytesAvailable { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
     }
@@ -791,7 +831,9 @@ async fn success_parsi_err_success_drain_bytes() {
     // NoBytesAvailable message should be sent
     let summary = producer.produce_next(&mut collector).await.unwrap();
     match summary {
-        ProduceSummary::Processed { .. } | ProduceSummary::Done { .. } => {
+        ProduceSummary::Processed { .. }
+        | ProduceSummary::PendingRemainder { .. }
+        | ProduceSummary::Done { .. } => {
             panic!("Summary should be Processed but got {summary:?}");
         }
         ProduceSummary::NoBytesAvailable { skipped_bytes } => {

--- a/crates/core/session/src/handlers/observing/logs_writer.rs
+++ b/crates/core/session/src/handlers/observing/logs_writer.rs
@@ -56,6 +56,9 @@ impl LogsWriter {
         }
         if !self.attachments.is_empty() {
             // Draining into a new vector preserves the capacity of the internal buffer.
+            // `mem::take` would hand the allocation away and force the buffer to regrow
+            // on each iteration.
+            #[allow(clippy::drain_collect)]
             let attachments = self.attachments.drain(..).collect();
             self.state.add_attachments(attachments)?;
         }

--- a/crates/core/session/src/handlers/observing/mod.rs
+++ b/crates/core/session/src/handlers/observing/mod.rs
@@ -13,7 +13,7 @@ use parsers::{
     text::StringTokenizer,
 };
 use plugins_host::PluginsParser;
-use processor::producer::{MessageProducer, ProduceError, ProduceSummary};
+use processor::producer::{FetchInfo, MessageProducer, ProcessError, ProcessOutcome};
 use sources::{
     ByteSource,
     sde::{SdeMsg, SdeReceiver},
@@ -21,7 +21,7 @@ use sources::{
 use tokio::{
     select,
     sync::mpsc::Receiver,
-    time::{Duration, timeout},
+    time::{Duration, Instant, sleep_until},
 };
 
 pub mod concat;
@@ -29,22 +29,80 @@ pub mod file;
 mod logs_writer;
 pub mod stream;
 
-pub const FLUSH_TIMEOUT_IN_MS: u128 = 500;
+/// Interval at which the items produced so far are flushed to the UI.
+pub const FLUSH_TIMEOUT_IN_MS: u64 = 500;
 
-/// Represents the possible steps while running the processing loop for a source.
+/// Schedules the flushes which deliver the produced items to the UI.
+///
+/// The next flush is kept as an absolute deadline so that the schedule survives any number of
+/// fetch and process rounds: a timeout wrapped around fetching alone would be renewed by every
+/// fetch, and a source dribbling bytes could starve flushing for an unbounded time.
+struct FlushSchedule {
+    interval: Duration,
+    deadline: Instant,
+}
+
+impl FlushSchedule {
+    fn new(interval: Duration) -> Self {
+        Self {
+            interval,
+            deadline: Instant::now() + interval,
+        }
+    }
+
+    /// The instant at which the next flush is due.
+    fn deadline(&self) -> Instant {
+        self.deadline
+    }
+
+    /// Advances the deadline to the next flush interval.
+    ///
+    /// Must be called whenever the current deadline is consumed, independent of whether an
+    /// actual flush happens: otherwise `sleep_until(deadline)` stays ready forever and the loop
+    /// busy-spins instead of waiting for the next interval.
+    fn reschedule(&mut self) {
+        self.deadline = Instant::now() + self.interval;
+    }
+
+    /// Flushes everything written to the session file so far and schedules the next flush.
+    async fn flush(&mut self, state: &SessionStateAPI) -> Result<(), stypes::NativeError> {
+        state.flush_session_file().await?;
+        self.reschedule();
+
+        Ok(())
+    }
+}
+
+/// The event which the processing loop of a source observed in the current iteration.
 /// This is for internal representation only.
-enum Next {
-    /// Items has been produced and needed to be sent.
-    ItemsProduced,
-    /// Producer is done. No loading or parsing is possible.
-    ProducerDone,
+enum LoopEvent {
+    /// Bytes have been fetched from the byte-source and still need to be processed
+    /// outside of the `select!` macro.
+    Fetched(FetchInfo),
     /// Flush timeout while waiting for next items has expired.
     Timeout,
-    /// Wait for source to have more bytes as it doesn't have more bytes currently.
-    /// (Enter tail mode for files)
-    Waiting,
     /// Source data exchange was sent and needed to be passed to byte-source.
     Sde(SdeMsg),
+}
+
+/// Represents the work the processing loop has to do once parsing has run.
+/// This is for internal representation only.
+enum LoopAction {
+    /// Write the items which have been produced to the session file.
+    WriteItems,
+    /// Finish the session as the producer can't load or parse anymore.
+    Finish,
+    /// Nothing to do currently. Go back to fetching more bytes.
+    Continue,
+    /// Flush the items which have been produced so far to the UI.
+    Flush,
+    /// Wait for the source to have more bytes as it doesn't have more bytes currently.
+    /// (Enter tail mode for files)
+    Wait,
+    /// Pass the sent source data exchange to the byte-source.
+    Sde(SdeMsg),
+    /// Terminate the session.
+    Stop,
 }
 
 pub async fn run_source<S: ByteSource>(
@@ -141,7 +199,6 @@ async fn run_producer<P: Parser, S: ByteSource>(
     mut rx_tail: Option<Receiver<Result<(), tail::Error>>>,
     mut rx_sde: Option<SdeReceiver>,
 ) -> OperationResult<()> {
-    use log::debug;
     state.set_session_file(None).await?;
     operation_api.processing();
     let mut logs_writer = LogsWriter::new(state.clone(), source_id);
@@ -150,96 +207,139 @@ async fn run_producer<P: Parser, S: ByteSource>(
 
     // We need to show the users some logs quick as possible by starting of the session.
     let mut first_run = true;
-    while let Some(next) = select! {
-        next_from_stream = async {
-            match timeout(Duration::from_millis(FLUSH_TIMEOUT_IN_MS as u64), producer.produce_next(&mut logs_writer)).await {
-                Ok(Ok(summary)) => {
-                match summary {
-                    ProduceSummary::Processed {
-                        bytes_consumed,
-                        messages_count,
-                        skipped_bytes,
-                    } => {
-                        log::trace!(
-                            "{bytes_consumed} Bytes consumed to produce {messages_count} items,\
+
+    let mut flush_schedule = FlushSchedule::new(Duration::from_millis(FLUSH_TIMEOUT_IN_MS));
+
+    loop {
+        // *** Cancel Safety ***:
+        // Every future here must be cancel safe. Parsing is done on `producer.process()`
+        // below, outside of this macro, because it isn't cancel safe.
+        let next_event = select! {
+            fetch_result = producer.fetch() => {
+                match fetch_result {
+                    Ok(fetch_info) => Some(LoopEvent::Fetched(fetch_info)),
+                    Err(source_err) => {
+                        //TODO: Deliver errors to UI.
+                        log::error!("Producer Error: {source_err}");
+                        // We need to print stopping errors for now as we don't have a solution
+                        // to show them to user.
+                        eprintln!("Unrecoverable error during producer session: {source_err}");
+
+                        None
+                    }
+                }
+            },
+
+            _ = sleep_until(flush_schedule.deadline()) => Some(LoopEvent::Timeout),
+
+            Some(sde_msg) = async {
+                if let Some(rx_sde) = rx_sde.as_mut() {
+                    rx_sde.recv().await
+                } else {
+                    None
+                }
+            } => Some(LoopEvent::Sde(sde_msg)),
+
+            _ = cancel.cancelled() => None,
+        };
+
+        let Some(next) = next_event else {
+            break;
+        };
+
+        let action = match next {
+            // Parsing happens here only: outside of the `select!` macro, where it can't be
+            // cancelled halfway through.
+            LoopEvent::Fetched(fetch_info) => {
+                match producer.process(fetch_info, &mut logs_writer) {
+                    Ok(outcome) => match outcome {
+                        ProcessOutcome::Parsed {
+                            bytes_consumed,
+                            messages_count,
+                            skipped_bytes,
+                        } => {
+                            log::trace!(
+                                "{bytes_consumed} Bytes consumed to produce {messages_count} items,\
                             with {skipped_bytes} bytes skipped."
-                        );
-                        Some(Next::ItemsProduced)
-                    }
-                    ProduceSummary::Done {
-                        loaded_bytes,
-                        skipped_bytes,
-                        produced_messages,
-                    } => {
-                        log::debug!(
-                            "Producer done: Total Messages: {produced_messages}. Total bytes:\
-                            {loaded_bytes}. Total skipped bytes {skipped_bytes}."
-                        );
+                            );
 
-                        Some(Next::ProducerDone)
-                    }
-                    ProduceSummary::NoBytesAvailable {skipped_bytes} => {
-                        log::trace!("No more bytes avaialbe with skipped {skipped_bytes} bytes. Going into tail");
+                            LoopAction::WriteItems
+                        }
+                        ProcessOutcome::NeedMoreBytes => LoopAction::Continue,
+                        ProcessOutcome::NoData => {
+                            log::trace!(
+                                "No more bytes available with {} bytes skipped in total. Going into tail",
+                                producer.total_skipped_bytes()
+                            );
 
-                        Some(Next::Waiting)
+                            LoopAction::Wait
+                        }
+                        ProcessOutcome::Done => {
+                            log::debug!(
+                                "Producer done: Total Messages: {}. Total bytes: {}. Total skipped bytes {}.",
+                                producer.total_produced_items(),
+                                producer.total_loaded_bytes(),
+                                producer.total_skipped_bytes()
+                            );
+
+                            LoopAction::Finish
+                        }
+                    },
+                    Err(process_err) => {
+                        //TODO: Deliver errors to UI.
+                        log::error!("Producer Error: {process_err}");
+                        match process_err {
+                            // Break directly on unrecoverable errors.
+                            ProcessError::Unrecoverable(_) => {
+                                // We need to print stopping errors for now as we don't have a
+                                // solution to show them to user.
+                                eprintln!(
+                                    "Unrecoverable error during producer session: {process_err}"
+                                );
+
+                                LoopAction::Stop
+                            }
+                            // Go into tailing mode on parse error since they are delivered only
+                            // where there is no more bytes in the source.
+                            ProcessError::Parse(_) => LoopAction::Wait,
+                        }
                     }
                 }
-                },
-                Ok(Err(producer_err)) => {
-                    //TODO: Deliver errors to UI.
-                    log::error!("Producer Error: {producer_err}");
-                    match producer_err {
-                        // Break directly on unrecoverable and byte source errors.
-                        ProduceError::Unrecoverable(_) | ProduceError::SourceError(_)  => {
-                            // We need to print stopping errors for now as we don't have a solution
-                            // to show them to user.
-                            eprintln!("Unrecoverable error during producer session: {producer_err}");
-                            None
-                        },
-                        // Go into tailing mode on parse error since they are delivered only
-                        // where there is no more bytes in the source.
-                        ProduceError::Parse(_) => Some(Next::Waiting),
-                    }
-                }
-                Err(_) => Some(Next::Timeout),
             }
-        } => next_from_stream,
+            LoopEvent::Timeout => {
+                flush_schedule.reschedule();
 
-        Some(sde_msg) = async {
-            if let Some(rx_sde) = rx_sde.as_mut() {
-                rx_sde.recv().await
-            } else {
-                None
+                LoopAction::Flush
             }
-        } => Some(Next::Sde(sde_msg)),
+            LoopEvent::Sde(sde_msg) => LoopAction::Sde(sde_msg),
+        };
 
-        _ = cancel.cancelled() => None,
-    } {
-        match next {
-            Next::ItemsProduced => {
+        match action {
+            LoopAction::WriteItems => {
                 logs_writer.write_to_session().await?;
                 if first_run {
                     first_run = false;
-                    state.flush_session_file().await?;
+                    flush_schedule.flush(&state).await?;
                 }
             }
-            Next::ProducerDone => {
+            LoopAction::Finish => {
                 logs_writer.write_to_session().await?;
 
-                state.flush_session_file().await?;
+                flush_schedule.flush(&state).await?;
                 state.file_read().await?;
                 break;
             }
-            Next::Timeout => {
+            LoopAction::Continue => {}
+            LoopAction::Flush => {
                 logs_writer.write_to_session().await?;
                 if !state.is_closing() {
-                    state.flush_session_file().await?;
+                    flush_schedule.flush(&state).await?;
                 }
             }
-            Next::Waiting => {
+            LoopAction::Wait => {
                 logs_writer.write_to_session().await?;
                 if !state.is_closing() {
-                    state.flush_session_file().await?;
+                    flush_schedule.flush(&state).await?;
                     state.file_read().await?;
                 }
                 if let Some(rx_tail) = rx_tail.as_mut() {
@@ -259,14 +359,15 @@ async fn run_producer<P: Parser, S: ByteSource>(
                     break;
                 }
             }
-            Next::Sde((msg, tx_response)) => {
+            LoopAction::Sde((msg, tx_response)) => {
                 let sde_res = producer.sde_income(msg).await.map_err(|e| e.to_string());
                 if tx_response.send(sde_res).is_err() {
                     log::warn!("Fail to send back message from source");
                 }
             }
+            LoopAction::Stop => break,
         }
     }
-    debug!("listen done");
+    log::debug!("listen done");
     Ok(None)
 }

--- a/crates/core/session/src/handlers/observing/mod.rs
+++ b/crates/core/session/src/handlers/observing/mod.rs
@@ -266,6 +266,19 @@ async fn run_producer<P: Parser, S: ByteSource>(
                             LoopAction::WriteItems
                         }
                         ProcessOutcome::NeedMoreBytes => LoopAction::Continue,
+                        ProcessOutcome::PendingRemainder => {
+                            // The parser holds a partial item and the source has stalled. A
+                            // source that stops delivering is usually finished rather than
+                            // paused mid-item, so give the parser the chance to close the item
+                            // now instead of holding it for the life of the session. Parsers
+                            // which can't complete a partial item keep their bytes, so a growing
+                            // file still completes them.
+                            if let Err(err) = producer.process_remaining(&mut logs_writer) {
+                                log::error!("Producer Error: {err}");
+                            }
+
+                            LoopAction::Wait
+                        }
                         ProcessOutcome::NoData => {
                             log::trace!(
                                 "No more bytes available with {} bytes skipped in total. Going into tail",

--- a/crates/core/session/tests/concat_files.rs
+++ b/crates/core/session/tests/concat_files.rs
@@ -1,0 +1,77 @@
+//! Contract tests for observing multiple concatenated files.
+
+use std::{fs::read_to_string, io::Write};
+
+use session::session::Session;
+use stypes::{CallbackEvent, FileFormat, ObserveOptions, ObserveOrigin, ParserType};
+use tempfile::NamedTempFile;
+use uuid::Uuid;
+
+/// The first file ends without a line break. Its last line must show up exactly once: a file
+/// source that stops delivering is finished, so the session loop asks the parser to close the
+/// item it is holding before it goes waiting.
+#[tokio::test(flavor = "multi_thread")]
+async fn line_without_trailing_break_survives_the_file_end() {
+    let mut first = NamedTempFile::new().unwrap();
+    write!(first, "first line\nsecond line").unwrap();
+    first.flush().unwrap();
+
+    let mut second = NamedTempFile::new().unwrap();
+    writeln!(second, "third line").unwrap();
+    second.flush().unwrap();
+
+    let uuid = Uuid::new_v4();
+    let (session, mut receiver) = Session::new(uuid).await.expect("Session should be created");
+
+    let files = vec![
+        (
+            Uuid::new_v4().to_string(),
+            FileFormat::Text,
+            first.path().to_path_buf(),
+        ),
+        (
+            Uuid::new_v4().to_string(),
+            FileFormat::Text,
+            second.path().to_path_buf(),
+        ),
+    ];
+
+    session
+        .observe(
+            uuid,
+            ObserveOptions {
+                origin: ObserveOrigin::Concat(files),
+                parser: ParserType::Text(()),
+            },
+        )
+        .unwrap();
+
+    // Each file reports `FileRead` on its own, so only the end of the operation means that all
+    // of them have been written to the session file.
+    while let Some(feedback) = receiver.recv().await {
+        match feedback {
+            CallbackEvent::OperationDone(_) => break,
+            CallbackEvent::OperationError { error, .. } => {
+                panic!("Received operation error: {error:#?}")
+            }
+            _ => {}
+        }
+    }
+
+    let session_file = session
+        .get_state()
+        .get_session_file()
+        .await
+        .expect("We must have a session file after the observe session is done");
+    let content = read_to_string(&session_file).expect("Session file can be read");
+
+    session
+        .stop(Uuid::new_v4())
+        .await
+        .expect("Session should stop after the session file is read");
+
+    assert_eq!(
+        content.lines().collect::<Vec<_>>(),
+        ["first line", "second line", "third line"]
+    );
+}

--- a/crates/core/sources/src/binary/pcap/legacy.rs
+++ b/crates/core/sources/src/binary/pcap/legacy.rs
@@ -146,6 +146,11 @@ impl<R: Read + Send + Sync> ByteSource for PcapLegacyByteSource<R> {
         res
     }
 
+    fn can_buffer_more(&self) -> bool {
+        // The buffer is never compacted, so only the space behind the buffered bytes is usable.
+        self.buffer.write_available() > 0
+    }
+
     fn current_slice(&self) -> &[u8] {
         self.buffer.read_slice()
     }

--- a/crates/core/sources/src/binary/pcap/ng.rs
+++ b/crates/core/sources/src/binary/pcap/ng.rs
@@ -146,6 +146,11 @@ impl<R: Read + Send + Sync> ByteSource for PcapngByteSource<R> {
         res
     }
 
+    fn can_buffer_more(&self) -> bool {
+        // The buffer is never compacted, so only the space behind the buffered bytes is usable.
+        self.buffer.write_available() > 0
+    }
+
     fn current_slice(&self) -> &[u8] {
         self.buffer.read_slice()
     }

--- a/crates/core/sources/src/binary/raw.rs
+++ b/crates/core/sources/src/binary/raw.rs
@@ -63,6 +63,12 @@ impl<R: Read + Send> ByteSource for BinaryByteSource<R> {
         )))
     }
 
+    fn can_buffer_more(&self) -> bool {
+        // `fill_buf` compacts only when the buffered bytes fall below its minimum, so free space
+        // in front of them is not reachable by the next read.
+        self.reader.write_available() > 0
+    }
+
     fn current_slice(&self) -> &[u8] {
         self.reader.buffer()
     }

--- a/crates/core/sources/src/command/process.rs
+++ b/crates/core/sources/src/command/process.rs
@@ -158,11 +158,19 @@ impl ByteSource for ProcessSource {
             }
         }
         if let Some(Ok(line)) = output {
-            let stored = line.len() + 1;
-            self.buffer.write_from(line.as_bytes());
-            self.buffer.write_from(b"\n");
+            // `write_from` truncates silently when the buffer is full, so its return value is the
+            // only honest `newly_loaded_bytes`: reporting the line length would tell the producer
+            // that bytes arrived which never did, and it would keep asking for more of them
+            // forever.
+            let written_line = self.buffer.write_from(line.as_bytes());
+            let written_break = self.buffer.write_from(b"\n");
             let available_bytes = self.buffer.read_available();
-            Ok(Some(ReloadInfo::new(stored, available_bytes, 0, None)))
+            Ok(Some(ReloadInfo::new(
+                written_line + written_break,
+                available_bytes,
+                0,
+                None,
+            )))
         } else if let Some(Err(err)) = output {
             Err(SourceError::Unrecoverable(format!("{err}")))
         } else {
@@ -247,5 +255,28 @@ mod tests {
                 .unwrap();
 
         general_source_reload_test(&mut process_source).await;
+    }
+
+    /// A line longer than the 8192-byte buffer cannot be stored in full. `ReloadInfo` must report
+    /// what was actually buffered: reporting the line length makes the producer believe it made
+    /// progress and ask for more bytes forever.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn long_line_reports_only_buffered_bytes() {
+        // POSIX `printf` width: 20000 spaces followed by a newline, so `LinesCodec` yields one
+        // line far larger than the 8192-byte buffer.
+        let mut source = ProcessSource::new(
+            "printf '%20000s\\n' ''".to_string(),
+            std::env::current_dir().unwrap(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let info = source.load(None).await.unwrap().unwrap();
+
+        assert_eq!(info.newly_loaded_bytes, info.available_bytes);
+        assert_eq!(info.newly_loaded_bytes, source.current_slice().len());
+        assert!(info.newly_loaded_bytes <= 8192);
     }
 }

--- a/crates/core/sources/src/command/process.rs
+++ b/crates/core/sources/src/command/process.rs
@@ -178,6 +178,11 @@ impl ByteSource for ProcessSource {
         }
     }
 
+    fn can_buffer_more(&self) -> bool {
+        // The buffer is never compacted, so only the space behind the buffered bytes is usable.
+        self.buffer.write_available() > 0
+    }
+
     fn current_slice(&self) -> &[u8] {
         self.buffer.read_slice()
     }

--- a/crates/core/sources/src/lib.rs
+++ b/crates/core/sources/src/lib.rs
@@ -129,6 +129,18 @@ pub trait ByteSource: Send {
     /// This function must be **Cancel-Safe**
     async fn load(&mut self, filter: Option<&SourceFilter>) -> Result<Option<ReloadInfo>, Error>;
 
+    /// Whether the next [`ByteSource::load()`] call could actually add bytes to the buffer
+    /// without the caller consuming any first.
+    ///
+    /// `false` means the parser will never see more than [`ByteSource::current_slice()`] until
+    /// something is consumed, so a caller that waits for more bytes would wait forever.
+    ///
+    /// # Note:
+    ///
+    /// Implementations must mirror their own `load()`: free space that `load()` can't reach
+    /// doesn't count. The two differ for every source which doesn't compact inside `load()`.
+    fn can_buffer_more(&self) -> bool;
+
     /// In case the ByteSource is some kind of connection that does not end,
     /// cancel can be implemented that will give the ByteSource the chance to perform some
     /// cleanup before the ByteSource is discarded

--- a/crates/core/sources/src/serial/serialport.rs
+++ b/crates/core/sources/src/serial/serialport.rs
@@ -77,7 +77,6 @@ pub struct SerialSource {
     write_stream: SplitSink<Framed<SerialStream, LineCodec>, Vec<u8>>,
     read_stream: SplitStream<Framed<SerialStream, LineCodec>>,
     buffer: DeqBuffer,
-    amount: usize,
     send_data_delay: u8,
 }
 
@@ -113,7 +112,6 @@ impl SerialSource {
                     write_stream,
                     read_stream,
                     buffer: DeqBuffer::new(8192),
-                    amount: 0,
                     send_data_delay: config.send_data_delay,
                 })
             }
@@ -131,28 +129,28 @@ impl ByteSource for SerialSource {
         _filter: Option<&SourceFilter>,
     ) -> Result<Option<ReloadInfo>, SourceError> {
         // Implementation is cancel-safe here because there is one await call on a stream only.
-        match self.read_stream.next().await {
-            Some(result) => match result {
-                Ok(received) => {
-                    self.amount = received.len();
-                    if self.amount == 0 {
-                        return Ok(None);
-                    }
-                    self.buffer.write_from(received.as_bytes());
+        let written = match self.read_stream.next().await {
+            Some(Ok(received)) => {
+                if received.is_empty() {
+                    return Ok(None);
                 }
-                Err(err) => {
-                    return Err(SourceError::Setup(format!("Failed to read stream: {err}")));
-                }
-            },
+                // Report what the buffer actually took: `write_from` truncates silently when the
+                // buffer is full, and a short write means a full buffer, not end of stream, so it
+                // must not turn into `Ok(None)`.
+                self.buffer.write_from(received.as_bytes())
+            }
+            Some(Err(err)) => {
+                return Err(SourceError::Setup(format!("Failed to read stream: {err}")));
+            }
             None => {
                 return Err(SourceError::Setup(
                     "Error awaiting future in reading (RX) stream".to_string(),
                 ));
             }
-        }
+        };
 
         let available_bytes = self.buffer.read_available();
-        Ok(Some(ReloadInfo::new(self.amount, available_bytes, 0, None)))
+        Ok(Some(ReloadInfo::new(written, available_bytes, 0, None)))
     }
 
     fn current_slice(&self) -> &[u8] {

--- a/crates/core/sources/src/serial/serialport.rs
+++ b/crates/core/sources/src/serial/serialport.rs
@@ -153,6 +153,11 @@ impl ByteSource for SerialSource {
         Ok(Some(ReloadInfo::new(written, available_bytes, 0, None)))
     }
 
+    fn can_buffer_more(&self) -> bool {
+        // The buffer is never compacted, so only the space behind the buffered bytes is usable.
+        self.buffer.write_available() > 0
+    }
+
     fn current_slice(&self) -> &[u8] {
         self.buffer.read_slice()
     }

--- a/crates/core/sources/src/socket/tcp.rs
+++ b/crates/core/sources/src/socket/tcp.rs
@@ -155,6 +155,12 @@ impl ByteSource for TcpSource {
         }
     }
 
+    fn can_buffer_more(&self) -> bool {
+        // `load()` compacts before reading, so the space in front of the buffered bytes counts
+        // too: this is the same question `handle_buff_capacity()` answers there.
+        self.buffer.spare_capacity() >= MAX_DATAGRAM_SIZE
+    }
+
     fn current_slice(&self) -> &[u8] {
         self.buffer.read_slice()
     }
@@ -226,6 +232,32 @@ mod tests {
 
         assert!(rec_res.is_ok());
         Ok(())
+    }
+
+    /// A line arriving in two segments must accumulate in the buffer: the source doesn't frame
+    /// lines, so both halves have to be exposed to the parser as one slice.
+    #[tokio::test]
+    async fn partial_line_accumulates_across_loads() {
+        static SERVER: &str = "127.0.0.1:4008";
+        let listener = TcpListener::bind(&SERVER).await.unwrap();
+        let accept_handle = tokio::spawn(async move { listener.accept().await.unwrap().0 });
+
+        let mut tcp_source = TcpSource::new(SERVER, None, None).await.unwrap();
+        let (_, mut send) = tokio::io::split(accept_handle.await.unwrap());
+
+        // Sending the second half only after the first load has returned puts the two halves in
+        // separate segments without relying on any timing.
+        send.write_all(b"hel").await.unwrap();
+        send.flush().await.unwrap();
+        let first = tcp_source.load(None).await.unwrap().unwrap();
+        assert_eq!(tcp_source.current_slice(), b"hel");
+
+        send.write_all(b"lo\n").await.unwrap();
+        send.flush().await.unwrap();
+        let second = tcp_source.load(None).await.unwrap().unwrap();
+
+        assert_eq!(tcp_source.current_slice(), b"hello\n");
+        assert_eq!(first.newly_loaded_bytes + second.newly_loaded_bytes, 6);
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/core/sources/src/socket/udp.rs
+++ b/crates/core/sources/src/socket/udp.rs
@@ -117,6 +117,12 @@ impl ByteSource for UdpSource {
         Ok(Some(ReloadInfo::new(len, available_bytes, 0, None)))
     }
 
+    fn can_buffer_more(&self) -> bool {
+        // `load()` compacts before reading, so the space in front of the buffered bytes counts
+        // too: this is the same question `handle_buff_capacity()` answers there.
+        self.buffer.spare_capacity() >= MAX_DATAGRAM_SIZE
+    }
+
     fn current_slice(&self) -> &[u8] {
         self.buffer.read_slice()
     }
@@ -168,6 +174,34 @@ mod tests {
 
         assert!(rec_res.is_ok());
         Ok(())
+    }
+
+    /// A line split over two datagrams must accumulate in the buffer: the source doesn't frame
+    /// lines, so both halves have to be exposed to the parser as one slice.
+    #[tokio::test]
+    async fn partial_line_accumulates_across_loads() {
+        static SENDER: &str = "127.0.0.1:4003";
+        static RECEIVER: &str = "127.0.0.1:5003";
+
+        // The receiver has to be bound before anything is sent: a datagram to a port nobody
+        // listens on is dropped, and `load()` would then wait forever.
+        let mut udp_source = UdpSource::new(RECEIVER, vec![]).await.unwrap();
+
+        let send_socket = UdpSocket::bind(SENDER).await.unwrap();
+        tokio::spawn(async move {
+            for part in ["hel", "lo\n"] {
+                send_socket
+                    .send_to(part.as_bytes(), RECEIVER)
+                    .await
+                    .expect("could not send on socket");
+            }
+        });
+
+        let first = udp_source.load(None).await.unwrap().unwrap();
+        let second = udp_source.load(None).await.unwrap().unwrap();
+
+        assert_eq!(udp_source.current_slice(), b"hello\n");
+        assert_eq!(first.newly_loaded_bytes + second.newly_loaded_bytes, 6);
     }
 
     #[tokio::test]

--- a/docs/development/core/producer.md
+++ b/docs/development/core/producer.md
@@ -23,3 +23,18 @@ And a variety of built-in byte-sources:
 
 For a visual representation of how the Message Producer connects Byte Sources and Parsers, please refer to the [diagram](./producer-plugins.svg).
 
+
+## Fetching and Processing
+
+The producer exposes its work in two halves, and the split is a contract rather than a convenience:
+
+- `fetch()` is **async** and does nothing but ask the `ByteSource` for more bytes. It is the only awaiting step of the producer and it is **cancel safe**, as long as the `ByteSource::load()` implementation is (the trait requires it). Dropping the future loses no data: everything loaded already lives in the source's internal buffer. This is the method that belongs on a `select!` arm.
+- `process()` is **synchronous**. It parses the bytes the source currently holds, appends the produced items to the given `LogRecordsCollector` and resyncs by dropping bytes when the parser can't make sense of them. It is deliberately not `async` so it *cannot* be cancelled halfway through: never call it inside a `select!` arm, call it on the result of `fetch()`, outside the macro.
+
+`process()` takes the `FetchInfo` returned by the preceding `fetch()` call by value. `FetchInfo` has no public constructor and is neither `Clone` nor `Copy`, so the only way to obtain one is to call `fetch()`, and passing it into `process()` consumes it: calling `fetch()`-then-`process()` in that order, once per fetch, is a fact the compiler checks rather than a convention documented on the two methods.
+
+`process()` never loads. When the parser needs more bytes it returns `ProcessOutcome::NeedMoreBytes`, and the caller has to run `fetch()` again to obtain a fresh `FetchInfo` before calling `process()` again. The other outcomes are `Parsed` (items were appended), `NoData` (the source is dry right now — the caller decides whether that means tailing or stopping) and `Done` (the parser reached the end of the data; the producer stays finished).
+
+`produce_next()` is a convenience wrapper that loops over both steps for callers which don't need to interleave other work between them, such as the exporters and the CLI. It is cancel safe by construction, since its only await points are `fetch()` calls.
+
+The session's processing loop in `crates/core/session/src/handlers/observing/mod.rs` uses the two-step form: `fetch()` races the flush deadline, the SDE receiver and the cancellation token inside the `select!`, and `process()` runs on the result outside of it.

--- a/docs/development/core/producer.md
+++ b/docs/development/core/producer.md
@@ -22,19 +22,3 @@ And a variety of built-in byte-sources:
 - PCap Legacy
 
 For a visual representation of how the Message Producer connects Byte Sources and Parsers, please refer to the [diagram](./producer-plugins.svg).
-
-
-## Fetching and Processing
-
-The producer exposes its work in two halves, and the split is a contract rather than a convenience:
-
-- `fetch()` is **async** and does nothing but ask the `ByteSource` for more bytes. It is the only awaiting step of the producer and it is **cancel safe**, as long as the `ByteSource::load()` implementation is (the trait requires it). Dropping the future loses no data: everything loaded already lives in the source's internal buffer. This is the method that belongs on a `select!` arm.
-- `process()` is **synchronous**. It parses the bytes the source currently holds, appends the produced items to the given `LogRecordsCollector` and resyncs by dropping bytes when the parser can't make sense of them. It is deliberately not `async` so it *cannot* be cancelled halfway through: never call it inside a `select!` arm, call it on the result of `fetch()`, outside the macro.
-
-`process()` takes the `FetchInfo` returned by the preceding `fetch()` call by value. `FetchInfo` has no public constructor and is neither `Clone` nor `Copy`, so the only way to obtain one is to call `fetch()`, and passing it into `process()` consumes it: calling `fetch()`-then-`process()` in that order, once per fetch, is a fact the compiler checks rather than a convention documented on the two methods.
-
-`process()` never loads. When the parser needs more bytes it returns `ProcessOutcome::NeedMoreBytes`, and the caller has to run `fetch()` again to obtain a fresh `FetchInfo` before calling `process()` again. The other outcomes are `Parsed` (items were appended), `NoData` (the source is dry right now — the caller decides whether that means tailing or stopping) and `Done` (the parser reached the end of the data; the producer stays finished).
-
-`produce_next()` is a convenience wrapper that loops over both steps for callers which don't need to interleave other work between them, such as the exporters and the CLI. It is cancel safe by construction, since its only await points are `fetch()` calls.
-
-The session's processing loop in `crates/core/session/src/handlers/observing/mod.rs` uses the two-step form: `fetch()` races the flush deadline, the SDE receiver and the cancellation token inside the `select!`, and `process()` runs on the result outside of it.


### PR DESCRIPTION
This PR closes #2413 
This PR closes #2635 


It splits `Producer::produce_next()` into a cancel-safe `fetch()` and a `process()` step, keeping the original method for
 existing call sites. 
And also it fixes silent data loss when a source (process/serial) receives a line longer than the internal buffer, which led to corruption of pending items and incorrect line splitting when a source stalls mid-read.

 - Process and serial sources reported the requested line length instead of the actually buffered bytes, so the
   producer believed more data had arrived than write_from()'s silent truncation allowed.
 - Parsers now hand back their held bytes via parse_remaining(), so a stalled source no longer erodes a pending
   item byte by byte and text lines no longer split at reader buffer boundaries.
 - can_buffer_more() now distinguishes a full buffer from a paused source, resolving remainders only when
   actually needed.

It also includes additional fixes for multiple issues found in the refactoring:
 - Fixes the CLI socket session sending duplicate, ever-growing message batches each round.
 - Fixes the export command producing incomplete or miscounted output.
 - Includes clippy fixes unrelated to the above, triggered by a newer Rust toolchain.