### PR TITLE
Add zoom functions to menu + commands palette

### DIFF
--- a/crates/app/src/host/ui/command_palette/commands.rs
+++ b/crates/app/src/host/ui/command_palette/commands.rs
@@ -100,6 +100,18 @@ const COMMANDS: &[CommandDefinition] = &[
         action: CommandAction::SetTheme(Theme::Light),
     },
     CommandDefinition {
+        title: "Zoom In",
+        action: CommandAction::ZoomIn,
+    },
+    CommandDefinition {
+        title: "Zoom Out",
+        action: CommandAction::ZoomOut,
+    },
+    CommandDefinition {
+        title: "Reset Zoom",
+        action: CommandAction::ResetZoom,
+    },
+    CommandDefinition {
         title: "Toggle Right Panel",
         action: CommandAction::ToggleRightPanel,
     },
@@ -221,6 +233,9 @@ pub enum CommandAction {
     ShowShortcuts,
     ShowAbout,
     SetTheme(Theme),
+    ZoomIn,
+    ZoomOut,
+    ResetZoom,
     ToggleRightPanel,
     ToggleBottomPanel,
     ToggleSdeBar,
@@ -256,6 +271,9 @@ impl CommandAction {
             | Self::ShowShortcuts
             | Self::ShowAbout
             | Self::SetTheme(_)
+            | Self::ZoomIn
+            | Self::ZoomOut
+            | Self::ResetZoom
             | Self::ToggleRightPanel
             | Self::ToggleBottomPanel
             | Self::ToggleSdeBar
@@ -372,6 +390,18 @@ pub fn execute_action(
         }
         CommandAction::SetTheme(theme) => {
             ui.ctx().set_theme(theme);
+            true
+        }
+        CommandAction::ZoomIn => {
+            egui::gui_zoom::zoom_in(ui.ctx());
+            true
+        }
+        CommandAction::ZoomOut => {
+            egui::gui_zoom::zoom_out(ui.ctx());
+            true
+        }
+        CommandAction::ResetZoom => {
+            ui.ctx().set_zoom_factor(1.0);
             true
         }
         CommandAction::ToggleRightPanel => {

--- a/crates/app/src/host/ui/command_palette/row.rs
+++ b/crates/app/src/host/ui/command_palette/row.rs
@@ -125,6 +125,9 @@ fn action_icon(action: CommandAction) -> &'static str {
         CommandAction::ShowAbout => icons::regular::INFO,
         CommandAction::SetTheme(Theme::Dark) => icons::regular::MOON,
         CommandAction::SetTheme(Theme::Light) => icons::regular::SUN,
+        CommandAction::ZoomIn => icons::regular::MAGNIFYING_GLASS_PLUS,
+        CommandAction::ZoomOut => icons::regular::MAGNIFYING_GLASS_MINUS,
+        CommandAction::ResetZoom => icons::regular::ARROW_COUNTER_CLOCKWISE,
         CommandAction::ToggleRightPanel | CommandAction::ToggleBottomPanel => {
             icons::regular::SIDEBAR
         }

--- a/crates/app/src/host/ui/menu.rs
+++ b/crates/app/src/host/ui/menu.rs
@@ -185,6 +185,10 @@ impl MainMenuBar {
             ui.menu_button("View", |ui| {
                 ui.set_min_size(MENU_MIN_SIZE);
 
+                egui::gui_zoom::zoom_menu_buttons(ui);
+
+                ui.separator();
+
                 if ui.button("Dark Theme").clicked() {
                     ui.set_theme(Theme::Dark);
                 }


### PR DESCRIPTION
This PR includes:

* Add standard zoom functions to the `view` menu
* Add zoom commands to command palette